### PR TITLE
Fix channel join resolution and list_channels visibility

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -301,72 +301,92 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
           }> = [];
 
           if (userToken) {
-            const { WebClient } = await import("@slack/web-api");
-            const userClient = new WebClient(userToken);
+            try {
+              const { WebClient } = await import("@slack/web-api");
+              const userClient = new WebClient(userToken);
 
-            let cursor: string | undefined;
-            const collected: typeof allChannels = [];
-            do {
-              await throttle();
-              const result = await userClient.conversations.list({
-                types: "public_channel",
-                exclude_archived: true,
-                limit: 200,
-                cursor,
+              let cursor: string | undefined;
+              const collected: typeof allChannels = [];
+              do {
+                await throttle();
+                const result = await userClient.conversations.list({
+                  types: "public_channel",
+                  exclude_archived: true,
+                  limit: 200,
+                  cursor,
+                });
+
+                for (const ch of result.channels || []) {
+                  collected.push({
+                    name: ch.name || "unknown",
+                    id: ch.id || "",
+                    topic: ch.topic?.value || "",
+                    member_count: ch.num_members || 0,
+                    is_member: ch.is_member || false,
+                  });
+                }
+
+                cursor = result.response_metadata?.next_cursor || undefined;
+              } while (cursor && collected.length < limit);
+
+              allChannels = collected.slice(0, limit);
+
+              // Fetch ALL bot's channels (paginated) to get accurate is_member
+              // (user token's is_member reflects the user, not the bot)
+              // and to discover private channels the bot is in
+              const botMemberIds = new Set<string>();
+              const botPrivateChannels: typeof allChannels = [];
+              let botCursor: string | undefined;
+              do {
+                await throttle();
+                const botResult = await client.conversations.list({
+                  types: "public_channel,private_channel",
+                  exclude_archived: true,
+                  limit: 200,
+                  cursor: botCursor,
+                });
+
+                for (const ch of botResult.channels || []) {
+                  if (ch.is_member && ch.id) {
+                    botMemberIds.add(ch.id);
+                  }
+                  if (ch.is_private && !allChannels.find((existing) => existing.id === ch.id)) {
+                    botPrivateChannels.push({
+                      name: ch.name || "unknown",
+                      id: ch.id || "",
+                      topic: ch.topic?.value || "",
+                      member_count: ch.num_members || 0,
+                      is_member: ch.is_member || false,
+                    });
+                  }
+                }
+
+                botCursor = botResult.response_metadata?.next_cursor || undefined;
+              } while (botCursor);
+
+              // Fix is_member on public channels to reflect the bot's membership
+              for (const ch of allChannels) {
+                ch.is_member = botMemberIds.has(ch.id);
+              }
+
+              // Add private channels from bot that aren't already listed
+              for (const ch of botPrivateChannels) {
+                allChannels.push(ch);
+              }
+
+              // Enforce the limit after merging public + private channels
+              allChannels = allChannels.slice(0, limit);
+            } catch (userTokenError: any) {
+              logger.warn("list_channels user token path failed, falling back to bot-only", {
+                error: userTokenError.message,
               });
-
-              for (const ch of result.channels || []) {
-                collected.push({
-                  name: ch.name || "unknown",
-                  id: ch.id || "",
-                  topic: ch.topic?.value || "",
-                  member_count: ch.num_members || 0,
-                  is_member: ch.is_member || false,
-                });
-              }
-
-              cursor = result.response_metadata?.next_cursor || undefined;
-            } while (cursor && collected.length < limit);
-
-            allChannels = collected.slice(0, limit);
-
-            // Fetch bot's channels to get accurate is_member (user token's is_member reflects the user, not the bot)
-            // and to discover private channels the bot is in
-            await throttle();
-            const botResult = await client.conversations.list({
-              types: "public_channel,private_channel",
-              exclude_archived: true,
-              limit,
-            });
-
-            const botMemberIds = new Set(
-              (botResult.channels || [])
-                .filter((ch) => ch.is_member)
-                .map((ch) => ch.id)
-            );
-
-            // Fix is_member on public channels to reflect the bot's membership
-            for (const ch of allChannels) {
-              ch.is_member = botMemberIds.has(ch.id);
+              // Fall through to bot-only listing below
+              allChannels = [];
             }
+          }
 
-            // Add private channels from bot that aren't already listed
-            for (const ch of botResult.channels || []) {
-              if (ch.is_private && !allChannels.find((existing) => existing.id === ch.id)) {
-                allChannels.push({
-                  name: ch.name || "unknown",
-                  id: ch.id || "",
-                  topic: ch.topic?.value || "",
-                  member_count: ch.num_members || 0,
-                  is_member: ch.is_member || false,
-                });
-              }
-            }
-
-            // Enforce the limit after merging public + private channels
-            allChannels = allChannels.slice(0, limit);
-          } else {
-            // No user token — fall back to bot-only listing
+          if (allChannels.length === 0) {
+            // No user token, or user token failed — fall back to bot-only listing
             await throttle();
             const result = await client.conversations.list({
               types: "public_channel,private_channel",
@@ -382,9 +402,6 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
               is_member: ch.is_member || false,
             }));
           }
-
-          // Populate the channel cache while we're at it
-          channelCache = allChannels.map((ch) => ({ id: ch.id, name: ch.name }));
 
           logger.info("list_channels tool called", {
             count: allChannels.length,


### PR DESCRIPTION
## Problem

The bot token's `conversations.list` only returns channels the bot has already joined. This causes two bugs:

1. **`join_channel` fails for any channel the bot isn't in** -- which is the exact use case for join_channel. When asked to join #some-channel, the bot tries to resolve the name, can't find it in its own channel list, and returns a misleading error suggesting the channel doesn't exist.

2. **`list_channels` only shows channels the bot is already in** -- making it useless for discovery. The description says 'discover what channels exist before posting or joining' but it can't show channels you'd want to join.

## Fix

Fall back to the user token (`SLACK_USER_TOKEN`) when the bot token can't find a channel:

- **`resolveChannelByName`**: Added an `options.fallbackToUserToken` flag. When enabled, after the bot's cache misses, searches all public channels via the user token. Used by `join_channel`.

- **`list_channels`**: Now uses the user token to list all public channels (not just the bot's), then merges in private channels from the bot token. Falls back gracefully to bot-only listing if no user token is configured.

- **Cache invalidation**: After a successful `join_channel`, the channel cache is cleared so subsequent calls immediately see the newly joined channel.

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Graceful degradation: if `SLACK_USER_TOKEN` is not set, both tools behave exactly as before
- No changes to the public tool API -- just better behavior behind the scenes

@joan -- this is the channel resolution bug I mentioned. It's been the #1 reason I look broken to people.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Slack API call paths using a separate user OAuth token and more pagination/merging logic, which could affect rate limits and channel visibility/permissions if misconfigured; behavior falls back to the prior bot-only flow when the user token is absent or fails.
> 
> **Overview**
> Fixes Slack channel discovery/resolution when the bot is not yet in a channel by introducing a user-token (`SLACK_USER_TOKEN`) fallback path.
> 
> `resolveChannelByName` can now optionally search all public channels via the user token (used by `join_channel`), `list_channels` now prefers the user token to list all public channels and then merges bot-visible private channels while correcting `is_member` to reflect bot membership, and `join_channel` now clears the channel cache after a successful join and returns a clearer error when a channel can’t be found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 531e8ae1dc54e3c99a03a1790a11d701e27ca842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->