### PR TITLE
Sandbox pause timing

### DIFF
--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -20,6 +20,7 @@ import {
   updateProfileFromConversation,
 } from "../users/profiles.js";
 import { downloadEventImages, type SlackImage } from "../lib/files.js";
+import { pauseSandbox } from "../lib/sandbox.js";
 import { logger } from "../lib/logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
 import type { KnownEventFromType } from "@slack/bolt";
@@ -171,6 +172,15 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     });
     const llmMs = Date.now() - llmStart;
 
+    // Pause sandbox once after all tool calls are complete for this turn.
+    // This avoids the e2b multi-resume bug (e2b-dev/E2B#884) that causes
+    // filesystem state loss when pause/resume is called between every tool.
+    await pauseSandbox().catch((err: any) => {
+      logger.warn("Failed to pause sandbox after response", {
+        error: err.message,
+      });
+    });
+
     // Response is already posted to Slack via streaming updates
 
     const totalMs = Date.now() - pipelineStart;
@@ -212,6 +222,9 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       await backgroundTasks;
     }
   } catch (error: any) {
+    // Ensure sandbox is paused even on pipeline errors
+    await pauseSandbox().catch(() => {});
+
     const errorMessage = error?.message || String(error);
     const errorName = error?.name || "UnknownError";
 

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -2,7 +2,6 @@ import { tool } from "ai";
 import { z } from "zod";
 import {
   getOrCreateSandbox,
-  pauseSandbox,
   truncateOutput,
 } from "../lib/sandbox.js";
 import { logger } from "../lib/logger.js";
@@ -67,9 +66,6 @@ export function createSandboxTools() {
             stderrLength: (result.stderr || "").length,
           });
 
-          // Pause sandbox after execution to save credits
-          await pauseSandbox();
-
           return {
             ok: true,
             exit_code: result.exitCode,
@@ -81,9 +77,6 @@ export function createSandboxTools() {
             command: command.substring(0, 100),
             error: error.message,
           });
-
-          // Try to pause even on error
-          await pauseSandbox().catch(() => {});
 
           if (error.message?.includes("timed out")) {
             return {
@@ -127,8 +120,6 @@ export function createSandboxTools() {
             length: content.length,
           });
 
-          await pauseSandbox();
-
           return {
             ok: true,
             path,
@@ -141,7 +132,6 @@ export function createSandboxTools() {
             path,
             error: error.message,
           });
-          await pauseSandbox().catch(() => {});
 
           return {
             ok: false,
@@ -180,8 +170,6 @@ export function createSandboxTools() {
             length: content.length,
           });
 
-          await pauseSandbox();
-
           return {
             ok: true,
             message: `File written to ${path} (${content.length} bytes)`,
@@ -191,7 +179,6 @@ export function createSandboxTools() {
             path,
             error: error.message,
           });
-          await pauseSandbox().catch(() => {});
 
           return {
             ok: false,


### PR DESCRIPTION
Refactor sandbox pausing to fix the e2b multi-resume bug (e2b-dev/E2B#884).

This change removes all `pauseSandbox()` calls from individual tool functions in `src/tools/sandbox.ts` and instead adds a single `pauseSandbox()` call in `src/pipeline/index.ts` after `generateResponse()` completes and in the error path. This ensures the sandbox remains active throughout an LLM turn, allowing multiple tool calls, and is paused only once at the end to save credits.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f83bd647-7bd5-4a19-82f5-9043980baa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f83bd647-7bd5-4a19-82f5-9043980baa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle timing for pausing the E2B sandbox, which can affect tool execution reliability and credit usage if mis-timed. Scoped to pipeline/tool integration with straightforward error-handling fallbacks.
> 
> **Overview**
> Moves `pauseSandbox()` responsibility from individual sandbox tool executions to the main pipeline loop.
> 
> `src/tools/sandbox.ts` no longer pauses the sandbox after each `run_command`/file read/write (or on their errors), keeping the sandbox active across multiple tool calls in a single LLM turn. `src/pipeline/index.ts` now pauses the sandbox once after `generateResponse()` completes and also in the pipeline error path, with warning-only logging on pause failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c7b2d17989caecda8f50ab27e896466a159f645. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->