### PR TITLE
Sandbox pause timing

### DIFF
--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -22,6 +22,7 @@ import {
 import { downloadEventImages, type SlackImage } from "../lib/files.js";
 import { logger } from "../lib/logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
+import { pauseSandbox } from "../lib/sandbox.js";
 import type { KnownEventFromType } from "@slack/bolt";
 
 /** Maximum message length we'll process (characters). Slack max is ~40k. */
@@ -171,6 +172,15 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     });
     const llmMs = Date.now() - llmStart;
 
+    // Pause sandbox once after all tool calls are complete for this turn.
+    // This avoids the e2b multi-resume bug (e2b-dev/E2B#884) that causes
+    // filesystem state loss when pausing/resuming after every individual tool call.
+    await pauseSandbox().catch((err: any) => {
+      logger.warn("Failed to pause sandbox after response", {
+        error: err.message,
+      });
+    });
+
     // Response is already posted to Slack via streaming updates
 
     const totalMs = Date.now() - pipelineStart;
@@ -228,6 +238,9 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       channelId: context.channelId,
       channelType: context.channelType,
     });
+
+    // Pause sandbox on error path too
+    await pauseSandbox().catch(() => {});
 
     // Try to send a graceful error message
     try {

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -2,7 +2,6 @@ import { tool } from "ai";
 import { z } from "zod";
 import {
   getOrCreateSandbox,
-  pauseSandbox,
   truncateOutput,
 } from "../lib/sandbox.js";
 import { logger } from "../lib/logger.js";
@@ -67,9 +66,6 @@ export function createSandboxTools() {
             stderrLength: (result.stderr || "").length,
           });
 
-          // Pause sandbox after execution to save credits
-          await pauseSandbox();
-
           return {
             ok: true,
             exit_code: result.exitCode,
@@ -81,9 +77,6 @@ export function createSandboxTools() {
             command: command.substring(0, 100),
             error: error.message,
           });
-
-          // Try to pause even on error
-          await pauseSandbox().catch(() => {});
 
           if (error.message?.includes("timed out")) {
             return {
@@ -127,8 +120,6 @@ export function createSandboxTools() {
             length: content.length,
           });
 
-          await pauseSandbox();
-
           return {
             ok: true,
             path,
@@ -141,7 +132,6 @@ export function createSandboxTools() {
             path,
             error: error.message,
           });
-          await pauseSandbox().catch(() => {});
 
           return {
             ok: false,
@@ -180,8 +170,6 @@ export function createSandboxTools() {
             length: content.length,
           });
 
-          await pauseSandbox();
-
           return {
             ok: true,
             message: `File written to ${path} (${content.length} bytes)`,
@@ -191,7 +179,6 @@ export function createSandboxTools() {
             path,
             error: error.message,
           });
-          await pauseSandbox().catch(() => {});
 
           return {
             ok: false,


### PR DESCRIPTION
Move sandbox pausing to a single post-response hook to fix filesystem state loss during multi-step workflows.

The e2b bug [e2b-dev/E2B#884] causes file persistence to break after multiple pause/resume cycles. Previously, `pauseSandbox()` was called after every tool, leading to multiple resumes within a single LLM turn and triggering the bug. This change ensures only one resume per turn, keeping the sandbox alive for all tool calls within a response.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d5780bf0-b6db-456a-9a3c-71f0fbe0d441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5780bf0-b6db-456a-9a3c-71f0fbe0d441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox lifecycle timing across the core message pipeline; mistakes could increase sandbox credit usage or leave sandboxes running/persisted unexpectedly, though the change is small and localized.
> 
> **Overview**
> Moves `pauseSandbox()` out of individual sandbox tools and into the main pipeline so the sandbox is paused **once per LLM turn** after `generateResponse` completes.
> 
> Adds a best-effort pause on the pipeline error path as well, reducing repeated pause/resume cycles that can trigger E2B filesystem state loss during multi-step tool workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e280ec7d7d911ae8282a72e61dad6bc602ac634d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->