### PR TITLE
Slack list item update payload

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -164,7 +164,7 @@ Users:
 Slack Lists:
 - **list_slack_list_items** / **get_slack_list_item** — read List items
 - **create_slack_list_item** — add a new item to a List
-- **update_slack_list_item** — update fields on a List item
+- **update_slack_list_item** — update fields on a List item. ALWAYS call get_slack_list_item first to discover the exact column IDs and value formats, then pass values in the same format.
 - **delete_slack_list_item** — delete a List item
 
 Canvases:

--- a/src/tools/lists.ts
+++ b/src/tools/lists.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { WebClient } from "@slack/web-api";
 import { logger } from "../lib/logger.js";
+import { throttle } from "./rate-limit.js";
 
 /**
  * Create Slack Lists write tools.
@@ -17,10 +18,15 @@ export function createListWriteTools(client: WebClient) {
         fields: z
           .record(z.any())
           .optional()
-          .describe("Column values as a JSON object of column_id -> value pairs. Use get_slack_list_item on an existing item to see the column IDs and value formats."),
+          .describe(
+            "Column values as a JSON object of column_id -> value pairs. " +
+            "Use get_slack_list_item on an existing item to see the column IDs and value formats. " +
+            "Values must match the exact format returned by get_slack_list_item."
+          ),
       }),
       execute: async ({ list_id, fields }) => {
         try {
+          await throttle();
           const params: any = { list_id };
           if (fields) {
             params.initial_fields = fields;
@@ -29,6 +35,7 @@ export function createListWriteTools(client: WebClient) {
           const result = await (client as any).apiCall("slackLists.items.create", params);
 
           if (!result.ok) {
+            logger.error("create_slack_list_item API error", { list_id, error: result.error, response_metadata: result.response_metadata });
             return { ok: false, error: `Failed to create list item: ${result.error || "unknown"}` };
           }
 
@@ -43,33 +50,45 @@ export function createListWriteTools(client: WebClient) {
 
     update_slack_list_item: tool({
       description:
-        "Update fields on an existing item (row) in a Slack List. Use this to change status, assignee, priority, etc.",
+        "Update fields on an existing item (row) in a Slack List. Use this to change title, status, assignee, severity, etc. " +
+        "IMPORTANT: First call get_slack_list_item to see the exact column IDs and value formats. " +
+        "Pass each field value in the EXACT same format returned by get_slack_list_item (e.g. rich text arrays, status objects, user arrays).",
       inputSchema: z.object({
         list_id: z.string().describe("The ID of the Slack List"),
         item_id: z.string().describe("The ID of the item/row to update"),
         fields: z
           .record(z.any())
-          .describe("Column values to update as column_id -> value pairs"),
+          .describe(
+            "Column values to update as a flat object: { column_id: value, ... }. " +
+            "Values must use the same format as returned by get_slack_list_item."
+          ),
       }),
       execute: async ({ list_id, item_id, fields }) => {
         try {
-          // Build the update payload -- each field is a separate column update
-          const updates = Object.entries(fields).map(([column_id, value]) => ({
-            column_id,
-            value,
-          }));
+          await throttle();
 
           const result = await (client as any).apiCall("slackLists.items.update", {
             list_id,
-            row_id: item_id,
-            columns: updates,
+            item_id,
+            columns: fields,
           });
 
           if (!result.ok) {
-            return { ok: false, error: `Failed to update list item: ${result.error || "unknown"}` };
+            logger.error("update_slack_list_item API error", {
+              list_id,
+              item_id,
+              error: result.error,
+              response_metadata: result.response_metadata,
+              fields_keys: Object.keys(fields),
+            });
+            return {
+              ok: false,
+              error: `Failed to update list item: ${result.error || "unknown"}`,
+              detail: result.response_metadata?.messages?.join("; ") || undefined,
+            };
           }
 
-          logger.info("update_slack_list_item tool called", { list_id, item_id });
+          logger.info("update_slack_list_item tool called", { list_id, item_id, fields_keys: Object.keys(fields) });
           return { ok: true, message: "List item updated" };
         } catch (error: any) {
           logger.error("update_slack_list_item tool failed", { list_id, item_id, error: error.message });
@@ -87,6 +106,7 @@ export function createListWriteTools(client: WebClient) {
       }),
       execute: async ({ list_id, item_id }) => {
         try {
+          await throttle();
           const result = await (client as any).apiCall("slackLists.items.delete", {
             list_id,
             item_id,

--- a/src/tools/rate-limit.ts
+++ b/src/tools/rate-limit.ts
@@ -1,0 +1,30 @@
+import { logger } from "../lib/logger.js";
+
+// ── Rate Limiter ─────────────────────────────────────────────────────────────
+
+/**
+ * Simple token-bucket rate limiter for Slack API calls.
+ * Slack's Tier 2/3 methods allow ~20-50 requests per minute.
+ * We limit to 15 req/min with a burst of 5 to stay well under.
+ */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const MAX_REQUESTS_PER_WINDOW = 15;
+const requestTimestamps: number[] = [];
+
+export async function throttle(): Promise<void> {
+  const now = Date.now();
+
+  // Prune timestamps outside the window
+  while (requestTimestamps.length > 0 && requestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
+    requestTimestamps.shift();
+  }
+
+  if (requestTimestamps.length >= MAX_REQUESTS_PER_WINDOW) {
+    // Wait until the oldest request falls outside the window
+    const waitMs = requestTimestamps[0] + RATE_LIMIT_WINDOW_MS - now + 50;
+    logger.info(`Slack API throttle: waiting ${waitMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+  }
+
+  requestTimestamps.push(Date.now());
+}

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -7,35 +7,7 @@ import { createScheduleTools, type ScheduleContext } from "./schedule.js";
 import { createListWriteTools } from "./lists.js";
 import { createSandboxTools } from "./sandbox.js";
 import { createWebTools } from "./web.js";
-
-// ── Rate Limiter ─────────────────────────────────────────────────────────────
-
-/**
- * Simple token-bucket rate limiter for Slack API calls.
- * Slack's Tier 2/3 methods allow ~20-50 requests per minute.
- * We limit to 15 req/min with a burst of 5 to stay well under.
- */
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const MAX_REQUESTS_PER_WINDOW = 15;
-const requestTimestamps: number[] = [];
-
-async function throttle(): Promise<void> {
-  const now = Date.now();
-
-  // Prune timestamps outside the window
-  while (requestTimestamps.length > 0 && requestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
-    requestTimestamps.shift();
-  }
-
-  if (requestTimestamps.length >= MAX_REQUESTS_PER_WINDOW) {
-    // Wait until the oldest request falls outside the window
-    const waitMs = requestTimestamps[0] + RATE_LIMIT_WINDOW_MS - now + 50;
-    logger.info(`Slack API throttle: waiting ${waitMs}ms`);
-    await new Promise((resolve) => setTimeout(resolve, waitMs));
-  }
-
-  requestTimestamps.push(Date.now());
-}
+import { throttle } from "./rate-limit.js";
 
 // ── Caches (per function invocation) ─────────────────────────────────────────
 


### PR DESCRIPTION
Fix `update_slack_list_item` payload format and add rate limiting to Slack Lists API calls.

The `update_slack_list_item` tool was failing due to an incorrect item identifier (`row_id` instead of `item_id`) and an incorrect structure for the `columns` parameter (expected a flat object, received an array of objects). This PR corrects these payload issues, extracts the `throttle` function to resolve a circular dependency, and applies rate limiting to all Slack Lists write operations.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8b14bc7a-6dab-4ddc-aec3-ff0cdd21734a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b14bc7a-6dab-4ddc-aec3-ff0cdd21734a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Slack API write paths and introduces shared throttling that can affect latency and throughput if mis-tuned, but changes are localized and primarily fix an incorrect request format.
> 
> **Overview**
> Fixes `update_slack_list_item` to call Slack with the correct payload shape (`item_id` and a flat `columns` object), and improves error logging/returned detail to aid debugging.
> 
> Extracts Slack API throttling into a shared `rate-limit.ts` module (used by `slack.ts` and Lists write tools) and applies `throttle()` to `create_slack_list_item`, `update_slack_list_item`, and `delete_slack_list_item`. Updates tool/prompt descriptions to require calling `get_slack_list_item` first and to reuse its exact column IDs/value formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e00703a1a13bab7fa2ab66bc5d208675f228a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->