### PR TITLE
fix: multi-step responses lose text before final step

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -217,10 +217,12 @@ export async function generateResponse(
 
     // Get usage from the resolved promises
     const usage = await result.usage;
-    const text = await result.text;
 
-    // Use the full text from the result (not accumulated, in case of multi-step)
-    const finalText = text || accumulatedText;
+    // Always use accumulatedText as the source of truth.
+    // result.text only contains the LAST step's text in multi-step responses
+    // (e.g. text → tool call → text), which drops everything before the final step.
+    // accumulatedText captures every text-delta across all steps.
+    const finalText = accumulatedText;
 
     // Post-process: strip anti-patterns
     const { cleaned, flaggedWords, modifications } =


### PR DESCRIPTION
## Problem

When a response involves tool calls between text blocks (e.g. "Let me update the roadmap..." → tool call → "Now let me verify..."), the final message posted to Slack only contained the **last text block**, losing everything before it.

This is because the final update used `result.text` (from the Vercel AI SDK), which only resolves to the text from the **last step** in multi-step responses. The code had a fallback to `accumulatedText` but only when `result.text` was empty -- in multi-step cases, `result.text` is non-empty (it has the last step's text), so the fallback never triggered.

## Example of the bug

A response that should read:
> Here's what I found in the roadmap... [detailed analysis] ... Now let me update the note... [tool call] ... Done, here's the summary.

Would end up as just:
> Done, here's the summary.

## Fix

Use `accumulatedText` as the sole source of truth for the final text. It correctly captures every `text-delta` chunk across all steps and was already being used for the intermediate streaming updates during the response.

Removed the `result.text` call entirely since it's unreliable for multi-step responses.

## Impact

This is a significant UX bug -- any response involving tool calls (which is most of my responses) risked losing content. The streaming updates *during* generation looked correct because they used `accumulatedText`, but the final post-processed update would overwrite with truncated content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to final message assembly; main risk is minor behavioral differences if `accumulatedText` diverges from `result.text` in edge cases.
> 
> **Overview**
> Fixes a bug where the final Slack message could drop earlier text in multi-step LLM responses (text → tool call → text).
> 
> In `src/pipeline/respond.ts`, the final post-processed update now *always* uses the streamed `accumulatedText` as the canonical output and stops reading `result.text`, ensuring all text deltas across steps are preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22bca57da7dd6532b759f8065175eb57cdb843ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->