### PR TITLE
feat: inject self-directive note into system prompt

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -1,6 +1,10 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db/client.js";
 import type { Memory, UserProfile } from "../db/schema.js";
+import { notes } from "../db/schema.js";
 import { getCurrentTimeContext, relativeTime } from "../lib/temporal.js";
 import { buildSkillIndex } from "../lib/skill-index.js";
+import { logger } from "../lib/logger.js";
 
 interface SystemPromptContext {
   /** Retrieved memories relevant to this conversation */
@@ -339,6 +343,22 @@ export async function buildSystemPrompt(
 
   // Core personality (always present)
   parts.push(PERSONALITY);
+
+  // Self-directive: agent's own editable context (identity, company, priorities)
+  try {
+    const selfDirective = await db
+      .select({ content: notes.content })
+      .from(notes)
+      .where(eq(notes.topic, "self-directive"))
+      .limit(1);
+    if (selfDirective[0]?.content) {
+      parts.push(
+        `\n## Self-directive\n\nThis is your own living context document. You wrote this and maintain it yourself.\n\n${selfDirective[0].content}`,
+      );
+    }
+  } catch (error) {
+    logger.warn("Failed to load self-directive note", { error });
+  }
 
   // Temporal awareness
   parts.push(


### PR DESCRIPTION
Reads the 'self-directive' note from the DB and injects it into every LLM invocation, right after the base personality. This is a living context document that Aura maintains herself -- company info, leadership team, OKRs, strategic priorities, current focus, and hard-won lessons.

The base system prompt stays generic (productizable). The self-directive is what makes each instance specific to the company it's deployed in.

Fail-safe: wrapped in try/catch so a missing or broken note doesn't crash prompt assembly. If the note doesn't exist, nothing is injected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes every LLM invocation’s system prompt by adding dynamic DB-loaded content, which can affect behavior and token usage; failure is guarded but prompt content correctness becomes operationally important.
> 
> **Overview**
> Adds a new **dynamic “Self-directive” section** to `buildSystemPrompt`, loaded from the `notes` table (`topic = "self-directive"`) and injected immediately after the base `PERSONALITY` prompt.
> 
> The DB read is wrapped in `try/catch` and logs a warning via `logger` on failure; if the note is missing/empty, nothing is added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3f3a641bc24f33803fe11f7c21b0ac9ca436106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->