### PR TITLE
fix: wrap markdown tables in code blocks for Slack rendering

### DIFF
--- a/src/slack/formatter.ts
+++ b/src/slack/formatter.ts
@@ -30,8 +30,9 @@ function wrapTablesInCodeBlocks(text: string): string {
   let inCodeBlock = false;
 
   while (i < lines.length) {
-    // Track code block boundaries
-    if (lines[i].trimStart().startsWith("```")) {
+    // Track code block boundaries (backtick and tilde fences)
+    const trimmedLine = lines[i].trimStart();
+    if (trimmedLine.startsWith("```") || trimmedLine.startsWith("~~~")) {
       inCodeBlock = !inCodeBlock;
       result.push(lines[i]);
       i++;
@@ -150,13 +151,14 @@ export function markdownToSlackMrkdwn(markdown: string): string {
 
   // Split into code-block and non-code-block segments so markdown
   // conversions don't modify content inside code fences.
-  const segments = text.split(/(```[\s\S]*?```)/g);
+  // Handles both backtick (```) and tilde (~~~) fences, with optional leading indentation.
+  const segments = text.split(/([ \t]*(?:```|~~~)[\s\S]*?(?:```|~~~))/g);
 
   return segments
     .map((segment) => {
-      if (segment.startsWith("```")) {
+      if (/^\s*(?:```|~~~)/.test(segment)) {
         // Only strip language tags from code blocks
-        return segment.replace(/```[a-zA-Z]*\n/, "```\n");
+        return segment.replace(/(```|~~~)[a-zA-Z]*\n/, "$1\n");
       }
       return convertMarkdownSegment(segment);
     })


### PR DESCRIPTION
## Problem

Slack mrkdwn doesn't support tables. When I output markdown tables (which I do frequently for job lists, data summaries, etc.), they render as broken pipe-character text with no alignment.

**Before:** Raw pipes and dashes, unreadable mess.
**After:** Clean monospace table inside a code block with aligned columns.

## Solution

Added `wrapTablesInCodeBlocks()` as a pre-processing step in `markdownToSlackMrkdwn()`. It detects markdown tables by looking for:
1. A header row (line with `|` and word content)
2. A separator row (line matching `|---|---|---|` pattern)
3. Subsequent data rows

Then wraps the entire table in triple backticks.

**Edge cases handled:**
- Tables with and without leading pipe characters
- Multiple tables in one message
- Tables already inside code blocks (skipped — no double-wrapping)
- Inline formatting inside tables (stays raw in code block, which is fine)

## Tradeoff

You lose inline formatting (bold, code) inside table cells since they're now in a code block. But alignment and readability matter far more for tables than cell-level formatting.

Closes #58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized text-formatting changes in Slack output; main risk is edge-case mis-detection of tables or code fences causing unexpected formatting.
> 
> **Overview**
> Improves `markdownToSlackMrkdwn` so Markdown tables render legibly in Slack by **detecting pipe-delimited tables and wrapping them in ``` code blocks** before other conversions run.
> 
> Refactors formatting to **avoid touching content inside code fences** by splitting the message into code vs non-code segments, applying header/link/bold/italic/strikethrough conversions only outside fences, and stripping language tags from both backtick and tilde fenced code blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5ffe516ce6f3f038a24f2eb47d3d55e3fa4d0a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->