### PR TITLE
Add self-patching capability to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Slack bot with persistent memory, personality, cross-user awareness, and auton
 - **Respects privacy** -- DM content stays private unless explicitly shared
 - **Forgets on request** -- users can ask "what do you know about me?" or say "forget X"
 - **Configurable** -- admins change models via the Slack App Home tab, no redeploy needed
+- 🔧 **Self-patching** -- Can diagnose issues in its own codebase and dispatch coding agents to open PRs with fixes
 
 ## Stack
 


### PR DESCRIPTION
## Automated patch by Aura

Dispatched via `patch_own_code` using the Claude Agent SDK.

### Changes
README.md | 1 +
 1 file changed, 1 insertion(+)

### Agent summary
Now I can see the README content. I need to find the "Key Capabilities" section and add the new bullet point. Looking at the file, I don't see a section specifically titled "Key Capabilities". However, I see a "What it does" section (lines 5-20) that lists the capabilities. Let me add the new bullet point there after the existing ones, maintaining the same formatting style.

Perfect! I've successfully added the new bullet point to the README.md file. The update adds:

- 🔧 **Self-patching** -- Can diagnose issues in its own codebase and dispatch coding agents to open PRs with fixes

The new bullet point has been added after the existing capabilities in the "What it does" section, maintaining the same formatting style with the emoji, bold capability name, and descriptive text separated by double dashes.

Cost: $0.1351

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates `README.md` to document a new capability: *self-patching* (Aura can diagnose issues in its own codebase and dispatch coding agents to open fix PRs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9b9ddc0cc6f913f27b2c73239910b630bcc7940. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->