### PR TITLE
test: verify patch_own_code works without manual env var tricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Slack bot with persistent memory, personality, cross-user awareness, and auton
 - **Respects privacy** -- DM content stays private unless explicitly shared
 - **Forgets on request** -- users can ask "what do you know about me?" or say "forget X"
 - **Configurable** -- admins change models via the Slack App Home tab, no redeploy needed
-- 🔧 **Self-patching** -- Can diagnose issues in its own codebase and dispatch coding agents to open PRs with fixes
+- 🔧 **Self-patching** -- Aura can autonomously diagnose bugs and dispatch fixes via Claude Code (verified working)
 
 ## Stack
 


### PR DESCRIPTION
## Automated patch by Aura

Dispatched via `patch_own_code` using the Claude Agent SDK.

### Changes
README.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

### Agent summary
Perfect! I can see the README.md file. I notice there's already a self-patching bullet point on line 21:

"🔧 **Self-patching** -- Can diagnose issues in its own codebase and dispatch coding agents to open PRs with fixes"

According to your instructions, I should update this to the "verified working" version. Let me make that change:

Perfect! I've successfully updated the README.md file. The self-patching bullet point has been changed from:

❌ "Can diagnose issues in its own codebase and dispatch coding agents to open PRs with fixes"

To:

✅ "Aura can autonomously diagnose bugs and dispatch fixes via Claude Code (verified working)"

This confirms the patch_own_code tool pipeline is working end-to-end. The change has been made to line 21 in the "What it does" section of the README.

Cost: $0.1172

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the README’s *What it does* list to reword the 🔧 **Self-patching** capability, explicitly stating Aura can autonomously diagnose bugs and dispatch fixes via Claude Code (marked as verified working).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b710dd4e3ed58707b9829c7e57b1df980b125c63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->