### PR TITLE
Fix tool timeout, silent error swallowing, and rate limit FIFO queue

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -115,8 +115,12 @@ export async function generateResponse(
         ts: messageTs,
         text,
       });
-    } catch {
-      // Swallow update errors (rate limits, etc.)
+    } catch (err: any) {
+      // Log but don't throw — update failures shouldn't kill the stream
+      logger.warn("chat.update failed", {
+        error: err?.data?.error || err.message || "unknown",
+        retryAfter: err?.data?.headers?.["retry-after"],
+      });
     }
   };
 
@@ -132,6 +136,9 @@ export async function generateResponse(
     }, 180_000);
   };
   resetTimer(); // start the initial timer
+
+  // Keepalive interval during long tool calls (patch_own_code can take 3-10 min)
+  let toolKeepAlive: ReturnType<typeof setInterval> | null = null;
 
   // ── Build stream options ─────────────────────────────────────────────
   const streamOptions: any = {
@@ -188,12 +195,19 @@ export async function generateResponse(
 
           await updateMessage(statusText);
           lastUpdateMs = Date.now();
+
+          // Keep resetting inactivity timer during long tool execution
+          // (patch_own_code can take 3-10 minutes)
+          if (toolKeepAlive) clearInterval(toolKeepAlive);
+          toolKeepAlive = setInterval(() => resetTimer(), 60_000);
           break;
         }
 
         case "tool-result": {
-          // Clear the tool status after tool completes
+          // Clear the tool status and keepalive after tool completes
           currentToolStatus = "";
+          if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
+          resetTimer();
           break;
         }
 
@@ -213,6 +227,7 @@ export async function generateResponse(
 
     // ── Final update ─────────────────────────────────────────────────────
     clearTimeout(inactivityTimer);
+    if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
 
     const llmMs = Date.now() - start;
 
@@ -284,6 +299,7 @@ export async function generateResponse(
     };
   } catch (error: any) {
     clearTimeout(inactivityTimer);
+    if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
 
     // If we have a placeholder, update it with an error/interruption message
     if (messageTs) {

--- a/src/tools/rate-limit.ts
+++ b/src/tools/rate-limit.ts
@@ -3,28 +3,90 @@ import { logger } from "../lib/logger.js";
 // ── Rate Limiter ─────────────────────────────────────────────────────────────
 
 /**
- * Simple token-bucket rate limiter for Slack API calls.
- * Slack's Tier 2/3 methods allow ~20-50 requests per minute.
- * We limit to 15 req/min with a burst of 5 to stay well under.
+ * Sliding-window rate limiter with FIFO queue for Slack API calls.
+ * Slack Tier 2/3 methods allow ~20-50 req/min.
+ * We use 20 req/60s as a safe default.
+ *
+ * The queue ensures that when multiple callers are waiting,
+ * they execute in arrival order rather than racing.
  */
 const RATE_LIMIT_WINDOW_MS = 60_000;
-const MAX_REQUESTS_PER_WINDOW = 15;
+const MAX_REQUESTS_PER_WINDOW = 20;
 const requestTimestamps: number[] = [];
+
+// FIFO queue of resolvers waiting for a rate limit slot
+const waitQueue: Array<() => void> = [];
+let drainScheduled = false;
+
+function drainQueue() {
+  drainScheduled = false;
+
+  while (waitQueue.length > 0) {
+    const now = Date.now();
+
+    // Prune old timestamps
+    while (
+      requestTimestamps.length > 0 &&
+      requestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS
+    ) {
+      requestTimestamps.shift();
+    }
+
+    if (requestTimestamps.length < MAX_REQUESTS_PER_WINDOW) {
+      // Slot available — let the next waiter through
+      requestTimestamps.push(now);
+      const resolve = waitQueue.shift()!;
+      resolve();
+    } else {
+      // No slot — schedule retry when the oldest request expires
+      const waitMs = requestTimestamps[0] + RATE_LIMIT_WINDOW_MS - now + 50;
+      if (!drainScheduled) {
+        drainScheduled = true;
+        setTimeout(drainQueue, waitMs);
+        logger.info(
+          `Slack rate limit queue: ${waitQueue.length} waiting, next slot in ${waitMs}ms`,
+        );
+      }
+      break;
+    }
+  }
+}
 
 export async function throttle(): Promise<void> {
   const now = Date.now();
 
-  // Prune timestamps outside the window
-  while (requestTimestamps.length > 0 && requestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS) {
+  // Prune old timestamps
+  while (
+    requestTimestamps.length > 0 &&
+    requestTimestamps[0] < now - RATE_LIMIT_WINDOW_MS
+  ) {
     requestTimestamps.shift();
   }
 
-  if (requestTimestamps.length >= MAX_REQUESTS_PER_WINDOW) {
-    // Wait until the oldest request falls outside the window
-    const waitMs = requestTimestamps[0] + RATE_LIMIT_WINDOW_MS - now + 50;
-    logger.info(`Slack API throttle: waiting ${waitMs}ms`);
-    await new Promise((resolve) => setTimeout(resolve, waitMs));
+  // Fast path: slot available and no one queued ahead of us
+  if (
+    requestTimestamps.length < MAX_REQUESTS_PER_WINDOW &&
+    waitQueue.length === 0
+  ) {
+    requestTimestamps.push(now);
+    return;
   }
 
-  requestTimestamps.push(Date.now());
+  // Slow path: queue up and wait
+  return new Promise<void>((resolve) => {
+    waitQueue.push(resolve);
+    if (!drainScheduled) {
+      if (requestTimestamps.length >= MAX_REQUESTS_PER_WINDOW) {
+        const waitMs = requestTimestamps[0] + RATE_LIMIT_WINDOW_MS - now + 50;
+        drainScheduled = true;
+        setTimeout(drainQueue, waitMs);
+        logger.info(
+          `Slack rate limit queue: ${waitQueue.length} waiting, next slot in ${waitMs}ms`,
+        );
+      } else {
+        // There's capacity but someone is queued — drain immediately
+        drainQueue();
+      }
+    }
+  });
 }


### PR DESCRIPTION
Fixes three related issues that cause Aura to hang mid-response:

## 1. Inactivity timeout kills long tool calls
The 180s inactivity timeout resets on every stream chunk, but between `tool-call` and `tool-result` chunks there are zero chunks. Tools like `patch_own_code` (3-10 min) always get killed.

**Fix**: Keepalive interval during tool execution resets the timer every 60s. Cleared on tool-result, final update, and in the catch block.

## 2. Silent error swallowing on chat.update  
The `updateMessage` helper had a completely empty catch block -- rate limit errors, API failures, everything silently swallowed.

**Fix**: Log errors (error type + retry-after header) without throwing, so we can diagnose issues in Vercel logs.

## 3. Rate limiter has no FIFO guarantee
Multiple concurrent `throttle()` callers could race for the same slot when the limit was hit.

**Fix**: Proper FIFO queue -- callers wait in arrival order. Increased throughput from 15->20 req/min (Slack Tier 3 allows 50). Better logging of queue depth and wait times.

## Testing
- 170s sandbox sleep passes, 185s fails (confirms the 180s boundary)
- After this fix, long tool calls stay alive via the keepalive interval
- Rate limit queue guarantees eventual execution in FIFO order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core response streaming and shared Slack API throttling behavior; bugs could cause premature aborts or unexpected request pacing under concurrency, though changes are localized and defensive.
> 
> **Overview**
> Prevents streamed Slack replies from being aborted during long-running tool calls by adding a keepalive interval that periodically resets the inactivity timer between `tool-call` and `tool-result`, and ensures the interval is cleared on completion and error paths.
> 
> Stops silently swallowing `slackClient.chat.update` failures by logging warning details (including Slack error and `retry-after`).
> 
> Replaces the Slack API `throttle()` implementation with a sliding-window **FIFO** queue to avoid concurrent callers racing for rate-limit slots, and increases the default limit from 15 to 20 requests per minute with queue-depth/wait-time logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf3d5d4ed9366e3a7f64c9a26debb8018de5cb17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->