### PR TITLE
Fix update_slack_list_item: auto-detect cell value types for Slack Lists API

### DIFF
--- a/src/tools/lists.ts
+++ b/src/tools/lists.ts
@@ -144,11 +144,8 @@ export function createListWriteTools(client: WebClient) {
                 if (value.every((v: string) => /^[UW][A-Z0-9]{8,}$/.test(v))) {
                   return { ...base, user: value };
                 }
-                // ISO date strings (YYYY-MM-DD) → date
-                if (value.every((v: string) => /^\d{4}-\d{2}-\d{2}$/.test(v))) {
-                  return { ...base, date: value };
-                }
                 // Default: treat string arrays as select values
+                // (Date fields are handled via typed objects above, per tool description)
                 return { ...base, select: value };
               }
             }


### PR DESCRIPTION
## Problem

`update_slack_list_item` fails with `invalid_arguments` for every field type because the Slack `slackLists.items.update` API requires type-specific keys (`select`, `rich_text`, `user`, `date`, `timestamp`) but the code was sending a generic `value` key.

Fixes #29.

## Root cause

When the LLM passes `{"Col088U32KQQL": ["medium"]}`, the value is an array, so the old code produced `{ value: ["medium"], row_id, column_id }`. Slack rejects this — it expects `{ select: ["medium"], row_id, column_id }`.

## Fix

Smart type detection in cell construction:
- **String** → wraps as `rich_text`
- **String array** → detects as `select` (or `user` if values match user ID pattern)
- **Rich text array** → passes as `rich_text`
- **Number** → wraps as `timestamp`
- **Typed object** (already has `select`/`rich_text`/etc keys) → passes through as-is

Also updates tool and field descriptions to document accepted formats clearly.

## Tested manually

Before this fix: `update_slack_list_item` with `["medium"]` → `invalid_arguments`
The explicit typed format `{"select": ["medium"]}` works (spread path), confirming the API itself is fine — just the payload formatting was wrong.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `update_slack_list_item` serializes user-provided field values into Slack API `cells`, which can affect all list updates if the type inference is wrong for certain columns or edge-case values.
> 
> **Overview**
> Fixes `update_slack_list_item` to build Slack Lists `cells` with the correct type-specific keys instead of sending a generic `value`, preventing `invalid_arguments` errors for common field types.
> 
> The tool now auto-detects and converts inputs (strings → `rich_text`, string arrays → `select` or `user` by ID pattern, rich_text arrays passthrough, numbers → `number`, typed objects passthrough) and updates the tool/schema descriptions to document the accepted formats (including requiring typed objects for dates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ebd68a8b81cfc9d84b89ae1bfa7432949d1857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->