### PR TITLE
Fix: Resolve thread_channel_id and thread_ts for Slack List items

### DIFF
--- a/.cursor/skills/aura-deployment/SKILL.md
+++ b/.cursor/skills/aura-deployment/SKILL.md
@@ -92,6 +92,28 @@ Production URLs:
 
 After adding new scopes or events, reinstall the app at api.slack.com/apps.
 
+## Direct API Investigation (POWERFUL)
+
+When debugging Slack/GitHub integration issues, **call APIs directly with curl** using tokens from `.env` to see raw responses. This bypasses Aura's code and reveals undocumented fields, hidden metadata, and the true API response shape.
+
+**Slack API** (source `.env` first for tokens):
+```bash
+source .env && curl -s -X POST 'https://slack.com/api/<METHOD>' \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"channel":"C...","limit":5}' | python3 -m json.tool
+```
+
+Use `$SLACK_USER_TOKEN` (xoxp-) for user-scoped methods (e.g. `search.messages`). Use `$SLACK_BOT_TOKEN` (xoxb-) for most other methods.
+
+**GitHub API**:
+```bash
+source .env && curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  'https://api.github.com/repos/realadvisor/aura/pulls' | python3 -m json.tool
+```
+
+**Key lesson**: Slack's typed SDK and Aura's wrapper code can hide fields from the raw response. For example, `conversations.history` on a list channel returns `msg.slack_list.list_record_id` -- a direct record-to-thread mapping that the SDK types don't expose. Always check the raw JSON when something "doesn't exist" in the API.
+
 ## Quick Health Check
 
 ```bash

--- a/.cursor/skills/aura-self-modification/SKILL.md
+++ b/.cursor/skills/aura-self-modification/SKILL.md
@@ -55,6 +55,21 @@ run_command("git clone https://x-access-token:$GITHUB_TOKEN@github.com/realadvis
 - `src/app.ts` -- Hono routes, events, interactions
 - `src/db/schema.ts` -- database schema
 
+## Debugging API Integrations
+
+When Aura's tools return unexpected results (e.g. null fields, missing data), **don't trust the typed SDK or Aura's wrapper code** -- call the API directly with curl using tokens from `.env`:
+
+```bash
+source .env && curl -s -X POST 'https://slack.com/api/conversations.history' \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"channel":"C088REN54FM","limit":5}' | python3 -m json.tool
+```
+
+This technique revealed that Slack list channel messages contain `slack_list.list_record_id` -- a field invisible to the typed SDK that provides a deterministic record-to-thread mapping. The raw JSON is the source of truth; SDK types and existing code can both be wrong about what's available.
+
+Pipe through `python3 -m json.tool` for pretty printing, or use `python3 -c "import json,sys; ..."` for custom field extraction.
+
 ## Rules
 
 - Never push to main -- always branches + PRs

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -267,6 +267,49 @@ async function resolveUserById(
  * Each tool receives the WebClient via closure.
  */
 export function createSlackTools(client: WebClient, context?: ScheduleContext) {
+  // Resolve thread coordinates for Slack List items.
+  // List channels use the list ID with a C prefix (F088... → C088...).
+  // Each root message in the channel has a slack_list.list_record_id field
+  // that maps directly to a record ID — no fuzzy timestamp matching needed.
+  async function resolveListItemThreads(
+    listId: string,
+    items: Array<{ id: string; date_created?: number | string }>,
+  ): Promise<Map<string, { channelId: string; threadTs: string }>> {
+    const result = new Map<string, { channelId: string; threadTs: string }>();
+    const listChannelId = listId.startsWith('F') ? 'C' + listId.slice(1) : null;
+    if (!listChannelId || items.length === 0) return result;
+
+    try {
+      let minCreated = Infinity;
+      let maxCreated = -Infinity;
+      for (const item of items) {
+        if (item.date_created != null) {
+          const created = typeof item.date_created === 'number' ? item.date_created : parseInt(item.date_created);
+          if (created < minCreated) minCreated = created;
+          if (created > maxCreated) maxCreated = created;
+        }
+      }
+      if (minCreated === Infinity) return result;
+
+      await throttle();
+      const historyResult = await client.conversations.history({
+        channel: listChannelId,
+        oldest: String(minCreated - 5),
+        latest: String(maxCreated + 5),
+        limit: Math.max(items.length * 2, 10),
+      });
+      for (const msg of (historyResult.messages || []) as any[]) {
+        const recordId = msg.slack_list?.list_record_id;
+        if (recordId && msg.ts && !result.has(recordId)) {
+          result.set(recordId, { channelId: listChannelId, threadTs: msg.ts });
+        }
+      }
+    } catch (e) {
+      logger.warn("Could not resolve list item threads", { listId, error: e });
+    }
+    return result;
+  }
+
   return {
     list_channels: tool({
       description:
@@ -1187,53 +1230,15 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
             itemCount: result.items?.length || 0,
           });
 
-          // Derive the list's conversation channel ID (F prefix → C prefix)
-          const listChannelId = list_id.startsWith('F') ? 'C' + list_id.slice(1) : null;
           const itemsRaw = result.items || [];
+          const threadMap = await resolveListItemThreads(list_id, itemsRaw);
 
-          // Build record_id → thread_ts map from the list channel's root messages.
-          // Each Slackbot "list_record_comment" message has a slack_list.list_record_id
-          // field that directly identifies which record it belongs to.
-          const recordThreadMap = new Map<string, string>();
-          if (listChannelId && itemsRaw.length > 0) {
-            try {
-              // Compute time range for bounded history query
-              let minCreated = Infinity;
-              let maxCreated = -Infinity;
-              for (const item of itemsRaw) {
-                if (item.date_created) {
-                  const created = typeof item.date_created === 'number' ? item.date_created : parseInt(item.date_created);
-                  if (created < minCreated) minCreated = created;
-                  if (created > maxCreated) maxCreated = created;
-                }
-              }
-              if (minCreated !== Infinity) {
-                await throttle();
-                const historyResult = await client.conversations.history({
-                  channel: listChannelId,
-                  oldest: String(minCreated - 5),
-                  latest: String(maxCreated + 5),
-                  limit: 200,
-                });
-                for (const msg of (historyResult.messages || []) as any[]) {
-                  const recordId = msg.slack_list?.list_record_id;
-                  if (recordId && msg.ts) {
-                    recordThreadMap.set(recordId, msg.ts);
-                  }
-                }
-              }
-            } catch (e) {
-              logger.warn("Could not read list channel history for thread resolution", { listChannelId, error: e });
-            }
-          }
-
-          // Attach thread info to each item using the deterministic record_id mapping
           const items = itemsRaw.map((item: any) => {
-            const threadTs = recordThreadMap.get(item.id) || null;
+            const thread = threadMap.get(item.id);
             return {
               ...item,
-              thread_channel_id: threadTs ? listChannelId : null,
-              thread_ts: threadTs,
+              thread_channel_id: thread?.channelId ?? null,
+              thread_ts: thread?.threadTs ?? null,
             };
           });
 
@@ -1290,33 +1295,14 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
           const raw = result.record || result.item;
 
-          // Resolve thread info using the list channel's slack_list.list_record_id field
           let threadChannelId: string | null = null;
           let threadTs: string | null = null;
           if (raw?.id) {
-            const listChannelId = list_id.startsWith('F') ? 'C' + list_id.slice(1) : null;
-            if (listChannelId) {
-              try {
-                await throttle();
-                const created = raw.date_created
-                  ? (typeof raw.date_created === 'number' ? raw.date_created : parseInt(raw.date_created))
-                  : undefined;
-                // Fetch a small window of history around the item's creation time
-                const historyResult = await client.conversations.history({
-                  channel: listChannelId,
-                  ...(created ? { oldest: String(created - 5), latest: String(created + 5) } : {}),
-                  limit: 10,
-                });
-                for (const msg of (historyResult.messages || []) as any[]) {
-                  if (msg.slack_list?.list_record_id === raw.id && msg.ts) {
-                    threadChannelId = listChannelId;
-                    threadTs = msg.ts;
-                    break;
-                  }
-                }
-              } catch (e) {
-                logger.warn("Could not resolve thread for list item", { list_id, item_id, error: e });
-              }
+            const threadMap = await resolveListItemThreads(list_id, [raw]);
+            const thread = threadMap.get(raw.id);
+            if (thread) {
+              threadChannelId = thread.channelId;
+              threadTs = thread.threadTs;
             }
           }
 


### PR DESCRIPTION
## Problem

Slack List items always return `thread_channel_id: null` and `thread_ts: null` because the code tried to read from `item.message?.channel_id` — a field that doesn't exist at the item level.

This prevented Aura from commenting on list item discussion threads, which is the #1 blocker for useful bug triage.

## Root Cause

The Slack Lists API doesn't expose thread info directly on items. However:
- Each Slack List has an associated channel (list ID `F088REN54FM` → channel `C088REN54FM`)
- Each item has a root Slackbot message in that channel, created within ~1-2 seconds of `date_created`
- Comments on list items are thread replies to that root message

## Fix

For both `list_slack_list_items` and `get_slack_list_item`:
1. Derive the list's channel ID by replacing the `F` prefix with `C`
2. Read the channel history to find root messages
3. Match items to their root messages by timestamp (within ±2 seconds of `date_created`)
4. Populate `thread_channel_id` and `thread_ts` with the matched values

Gracefully degrades to null if the channel isn't accessible or no match is found.

## Testing

Manually verified:
- List `F088REN54FM` → channel `C088REN54FM` ✓
- Item `Rec0AFALXGCQ5` (date_created: 1771318827) → root message at 1771318828.755419 ✓
- `send_thread_reply(channel: "C088REN54FM", thread_ts: "1771318828.755419")` successfully posted ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds extra `conversations.history` calls and new mapping logic when reading Slack List items, which could impact rate limits/perf and fail in edge cases, though it degrades to nulls on errors.
> 
> **Overview**
> Fixes Slack List item thread resolution so `list_slack_list_items` and `get_slack_list_item` return usable `thread_channel_id`/`thread_ts` for commenting.
> 
> Introduces `resolveListItemThreads`, which derives the List’s backing channel ID from the List ID and scans `conversations.history` to map each item’s record ID (`msg.slack_list.list_record_id`) to the root message `ts`, replacing the previous (non-working) `item.message?.*` fields.
> 
> Updates internal skill docs to recommend direct `curl` API inspection for Slack/GitHub integrations and to highlight the hidden `slack_list.list_record_id` field in raw Slack responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4f1e4b1bee00a317112b8a6895311cdcc84cbdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->