### PR TITLE
Fix missing space between sentences across multi-step tool calls

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -198,6 +198,7 @@ export async function generateResponse(
   let accumulatedText = "";
   let lastUpdateMs = 0;
   let currentToolStatus = "";
+  let lastChunkWasToolResult = false;
 
   try {
     const result = streamText(streamOptions);
@@ -232,10 +233,21 @@ export async function generateResponse(
           currentToolStatus = "";
           if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           resetTimer();
+          lastChunkWasToolResult = true;
           break;
         }
 
         case "text-delta": {
+          // If text resumes after a tool result, ensure proper separation
+          if (lastChunkWasToolResult && accumulatedText.length > 0) {
+            const endsWithWhitespace = /\s$/.test(accumulatedText);
+            const startsWithWhitespace = /^\s/.test(chunk.text);
+            if (!endsWithWhitespace && !startsWithWhitespace) {
+              accumulatedText += "\n\n";
+            }
+          }
+          lastChunkWasToolResult = false;
+
           accumulatedText += chunk.text;
 
           // Debounced update: only update Slack every 1.5s


### PR DESCRIPTION
## Problem

When the LLM generates text, then executes a tool call, then continues generating text, the two text segments get concatenated without any separator. This produces output like:

> "conversation happened.Set for tomorrow morning."

...instead of properly separated paragraphs.

## Root cause

In `src/pipeline/respond.ts`, `accumulatedText` is built by concatenating all `text-delta` chunks across all steps via `accumulatedText += chunk.text`. There's no logic to detect step boundaries or ensure whitespace between pre-tool and post-tool text.

## Fix

Track when a `tool-result` event fires. When the next `text-delta` arrives after a tool result, check if the boundary lacks whitespace. If so, insert `\n\n` (paragraph break), since a tool call interruption naturally represents a paragraph boundary.

The fix is defensive — it only activates when:
1. Text resumes after a tool execution
2. The accumulated text is non-empty
3. Neither the end of existing text nor the start of new text has whitespace

**12 lines added, 0 removed. Single file change.**

Reported by @jakub-riziky.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to streaming text concatenation logic; only affects formatting of responses after tool execution.
> 
> **Overview**
> Prevents multi-step LLM streaming output from running sentences together when text generation resumes after a tool call.
> 
> `src/pipeline/respond.ts` now tracks when the last streamed chunk was a `tool-result` and, on the next `text-delta`, conditionally inserts a `\n\n` paragraph break when neither side already contains whitespace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83858c9605d31e726dbae4d83fd78ba999ef2f45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->