### PR TITLE
Add Claude Sonnet 4.6 to model dropdown

### DIFF
--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -12,6 +12,7 @@ interface ModelOption {
 
 const MAIN_MODELS: ModelOption[] = [
   { value: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6" },
+  { value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
   { value: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
   { value: "anthropic/claude-sonnet-4-20250514", label: "Claude Sonnet 4" },
   { value: "openai/gpt-5.2", label: "GPT-5.2" },


### PR DESCRIPTION
Sonnet 4.6 was released today (Feb 17, 2026). Adds it to the App Home model dropdown so it can be selected as the main model.

Model ID: `anthropic/claude-sonnet-4-6` (via Vercel AI Gateway)

One-line insertion, no other changes.

Requested by Joan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-option UI/config dropdown update with no changes to model selection logic or data handling.
> 
> **Overview**
> Adds **Claude Sonnet 4.6** (model id `anthropic/claude-sonnet-4-6`) to the `MAIN_MODELS` list in `src/slack/home.ts`, making it selectable in the Slack App Home “Main Model” dropdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862dfabb8294cdc54a49cc8e5f047787246b51df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->