### PR TITLE
feat: add getSandboxEnvs function to manage environment variables

### DIFF
--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -18,6 +18,29 @@ async function loadE2B() {
 }
 
 /**
+ * Build the env vars map from the current Vercel process environment.
+ * Callers should pass this to every `commands.run({ envs })` call so
+ * env vars are always fresh — regardless of whether the sandbox was
+ * just created or resumed from a paused state.
+ *
+ * E2B's `Sandbox.connect()` does NOT restore the `envs` that were
+ * passed at creation time, and persistence across pause/resume is
+ * unreliable (see e2b-dev/E2B#884). Per-command `envs` is the only
+ * mechanism that works consistently.
+ */
+export function getSandboxEnvs(): Record<string, string> {
+  const envs: Record<string, string> = {};
+  if (process.env.GITHUB_TOKEN) {
+    envs.GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+    envs.GH_TOKEN = process.env.GITHUB_TOKEN;
+  }
+  if (process.env.ANTHROPIC_API_KEY) {
+    envs.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+  }
+  return envs;
+}
+
+/**
  * Get or create a sandbox. Tries to resume a previously paused sandbox,
  * creates a new one if none exists or resume fails.
  */
@@ -41,16 +64,7 @@ export async function getOrCreateSandbox(): Promise<any> {
   }
 
   const Sandbox = await loadE2B();
-
-  // Env vars to inject into the sandbox
-  const envs: Record<string, string> = {};
-  if (process.env.GITHUB_TOKEN) {
-    envs.GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-    envs.GH_TOKEN = process.env.GITHUB_TOKEN;
-  }
-  if (process.env.ANTHROPIC_API_KEY) {
-    envs.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-  }
+  const envs = getSandboxEnvs();
 
   // Try to resume a previously paused sandbox
   const savedId = await getSetting(SANDBOX_NOTE_KEY);
@@ -61,29 +75,8 @@ export async function getOrCreateSandbox(): Promise<any> {
         timeoutMs: DEFAULT_TIMEOUT_MS,
       });
 
-      // Inject env vars into resumed sandbox (connect() doesn't support envs)
-      if (Object.keys(envs).length > 0) {
-        const exports = Object.entries(envs)
-          .map(([k, v]) => `export ${k}="${v}"`)
-          .join(" && ");
-        await sandbox.commands.run(`${exports} && echo 'env set'`, {
-          cwd: "/home/user",
-          timeoutMs: 5000,
-        });
-
-        // Also write to .bashrc so env persists across commands
-        const bashrcLines = Object.entries(envs)
-          .map(([k, v]) => `export ${k}="${v}"`)
-          .join("\n");
-        await sandbox.files.write("/home/user/.env_injected", bashrcLines);
-        await sandbox.commands.run(
-          'grep -q env_injected /home/user/.bashrc || echo "source /home/user/.env_injected" >> /home/user/.bashrc',
-          { cwd: "/home/user", timeoutMs: 5000 },
-        );
-      }
-
       cachedSandbox = sandbox;
-      logger.info("E2B sandbox resumed with env vars", { sandboxId: savedId });
+      logger.info("E2B sandbox resumed", { sandboxId: savedId });
       return sandbox;
     } catch (error: any) {
       logger.warn("Failed to resume sandbox, creating new one", {
@@ -93,7 +86,7 @@ export async function getOrCreateSandbox(): Promise<any> {
     }
   }
 
-  // Create a new sandbox
+  // Create a new sandbox (pass envs as a convenience for manual processes)
   const templateId = process.env.E2B_TEMPLATE_ID || undefined;
   logger.info("Creating new E2B sandbox", { templateId: templateId || "default" });
 

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import {
   getOrCreateSandbox,
+  getSandboxEnvs,
   truncateOutput,
 } from "../lib/sandbox.js";
 import { isAdmin } from "../lib/permissions.js";
@@ -62,6 +63,7 @@ export function createSandboxTools(context?: ScheduleContext) {
 
         try {
           const sandbox = await getOrCreateSandbox();
+          const envs = getSandboxEnvs();
 
           logger.info("run_command tool: executing", {
             command: command.substring(0, 100),
@@ -71,6 +73,7 @@ export function createSandboxTools(context?: ScheduleContext) {
           const result = await sandbox.commands.run(command, {
             cwd: workdir || "/home/user",
             timeoutMs: timeout_seconds * 1000,
+            envs,
           });
 
           const stdout = truncateOutput(result.stdout || "", 4000);
@@ -225,10 +228,11 @@ export function createSandboxTools(context?: ScheduleContext) {
           logger.info("patch_own_code: executing agent runner", { branch: branch_name });
 
           const result = await sandbox.commands.run(
-            "source /home/user/.env_injected 2>/dev/null; NODE_PATH=/home/user/node_modules node /home/user/agent-runner.mjs",
+            "NODE_PATH=/home/user/node_modules node /home/user/agent-runner.mjs",
             {
               cwd: "/home/user",
               timeoutMs: 300_000,
+              envs: getSandboxEnvs(),
             },
           );
 


### PR DESCRIPTION
- Introduced a new function `getSandboxEnvs` to build a map of environment variables from the current Vercel process environment.
- Updated `getOrCreateSandbox` to utilize `getSandboxEnvs` for injecting environment variables into the sandbox, improving consistency and reliability.
- Removed redundant environment variable handling code from `getOrCreateSandbox` to streamline the function.
- Adjusted the `createSandboxTools` function to pass environment variables when executing commands in the sandbox.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how API tokens are propagated into the sandbox; mistakes could break sandbox tooling or inadvertently change credential availability across commands, though the change is scoped to env handling only.
> 
> **Overview**
> Improves sandbox env var reliability by introducing `getSandboxEnvs()` and using it to supply fresh `envs` on each `sandbox.commands.run()` call.
> 
> Removes the previous resume-time env injection (exporting/writing `.env_injected`/sourcing `.bashrc`) and updates `run_command` and `patch_own_code` executions to pass `envs` explicitly; sandbox creation still includes `envs` mainly as a convenience.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2138340032c29fac6e4d6a4e0dc50b8c7edba239. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->