### PR TITLE
Tables

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -270,7 +270,10 @@ Sandbox (Linux VM):
 - For complex workflows, check your skill notes first — you may have a playbook.
 
 Tables:
-- **draw_table** — render a native Slack table in your reply. Use this instead of markdown tables whenever you have tabular data (comparisons, query results, multi-column lists). Provide rows as an array of string arrays — the first row is the header. The table renders at the bottom of your message. Only one table per message, max 100 rows × 20 columns. Continue writing normal text around the table — add context/commentary before calling the tool, and the table attaches automatically.
+- **draw_table** — render a native Slack table. Use this instead of markdown tables for any tabular data (comparisons, query results, multi-column lists). Provide rows as an array of string arrays — the first row is the header. Max 100 rows × 20 columns.
+  - **Inline** (default): table attaches to the bottom of your current reply. Best for a single table. Write your commentary as normal text, then call draw_table.
+  - **Reply** (\`send_as_reply: true\`): posts the table as a separate thread reply in the current conversation. Use this when you need multiple tables in one answer — each one appears in the thread as you work. Include \`message\` for a short label above each table.
+  - **Targeted** (\`target_channel\` or \`target_user\`): posts the table to a different channel or DM. Include \`message\` for context above the table.
 
 Data warehouse (BigQuery):
 - **list_datasets** — list all datasets in the data warehouse.

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -143,7 +143,7 @@ async function searchPublicChannelByName(
  * falls back to searching all public channels via the user token.
  * This is needed for join_channel — the bot can't see channels it hasn't joined.
  */
-async function resolveChannelByName(
+export async function resolveChannelByName(
   client: WebClient,
   name: string,
   options?: { fallbackToUserToken?: boolean },
@@ -192,7 +192,7 @@ async function resolveChannelByName(
  * Resolve a user display name, username, or ID to a user object.
  * Accepts: "jonas", "@jonas", "U066V1AN6", "jonas (U066V1AN6)"
  */
-async function resolveUserByName(
+export async function resolveUserByName(
   client: WebClient,
   name: string,
 ): Promise<{ id: string; name: string } | null> {
@@ -1920,6 +1920,6 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     ...createBigQueryTools(),
 
     // ── Table Tools (native Slack table blocks) ──────────────────────────
-    ...createTableTools(),
+    ...createTableTools(client, context),
   };
 }

--- a/src/tools/table.ts
+++ b/src/tools/table.ts
@@ -1,58 +1,135 @@
 import { tool } from "ai";
 import { z } from "zod";
+import type { WebClient } from "@slack/web-api";
 import { logger } from "../lib/logger.js";
+import { resolveChannelByName, resolveUserByName } from "./slack.js";
+import type { ScheduleContext } from "../db/schema.js";
 
 /**
  * Sentinel key used by the pipeline to detect table blocks in tool results.
- * When the LLM calls draw_table, the execute function returns the built
- * Slack TableBlock under this key. The streaming loop in respond.ts captures
- * it and injects it into `streamer.stop({ blocks: [tableBlock] })` so the
- * table renders natively as part of the same message.
+ * When draw_table is called in inline mode, the execute function returns the
+ * built Slack TableBlock under this key. The streaming loop in respond.ts
+ * captures it and injects it into `streamer.stop({ blocks: [tableBlock] })` so
+ * the table renders natively as part of the same message.
  */
 export const TABLE_BLOCK_KEY = "__table_block";
 
-export function createTableTools() {
+function buildTableBlock(
+  rows: string[][],
+  columnAlignments?: ("left" | "center" | "right")[],
+) {
+  const colCount = rows[0].length;
+  return {
+    type: "table" as const,
+    rows: rows.map((row) =>
+      row.map((cell) => ({ type: "raw_text" as const, text: cell })),
+    ),
+    column_settings: columnAlignments
+      ? columnAlignments.map((align) => ({ align, is_wrapped: true }))
+      : Array.from({ length: colCount }, () => ({ is_wrapped: true })),
+  };
+}
+
+function validateRows(rows: string[][]) {
+  if (rows.length < 2) {
+    return "Need at least a header row and one data row.";
+  }
+  const colCount = rows[0].length;
+  if (colCount > 20) {
+    return "Max 20 columns allowed.";
+  }
+  for (let i = 0; i < rows.length; i++) {
+    if (rows[i].length !== colCount) {
+      return `Row ${i} has ${rows[i].length} columns but header has ${colCount}. All rows must match.`;
+    }
+  }
+  return null;
+}
+
+async function postTable(
+  client: WebClient,
+  channelId: string,
+  tableBlock: Record<string, any>,
+  message?: string,
+  threadTs?: string,
+) {
+  return client.chat.postMessage({
+    channel: channelId,
+    text: message || "Here's a table:",
+    blocks: [tableBlock as any],
+    ...(threadTs ? { thread_ts: threadTs } : {}),
+  });
+}
+
+export function createTableTools(client: WebClient, context?: ScheduleContext) {
   return {
     draw_table: tool({
       description:
-        "Render structured data as a native Slack table at the bottom of your reply. " +
+        "Render structured data as a native Slack table. " +
         "Use this instead of markdown tables whenever you have tabular data " +
         "(comparisons, query results, lists with multiple columns, etc.). " +
-        "Only one table per message. Max 100 rows, 20 columns. " +
-        "The first row you provide in `rows` becomes the header row.",
+        "The first row in `rows` becomes the header row.\n\n" +
+        "Three modes:\n" +
+        "- **Inline** (default): table attaches to the bottom of your current reply. " +
+        "Limited to one table per reply. Best for a single table.\n" +
+        "- **Reply** (`send_as_reply: true`): posts the table as a separate thread " +
+        "reply in the current conversation. Use this when you need multiple tables " +
+        "— they appear in the thread as you work. Include `message` for context.\n" +
+        "- **Targeted** (`target_channel` or `target_user`): posts the table to " +
+        "a different channel or DM. Include `message` for context.",
       inputSchema: z.object({
         rows: z
           .array(z.array(z.string().describe("Cell text")))
           .min(2, "Need at least a header row and one data row")
           .max(100, "Max 100 rows including header")
           .describe(
-            "Array of rows. The FIRST row is the header row. Each row is an array of cell strings. All rows must have the same number of columns (max 20).",
+            "Array of rows. The FIRST row is the header. Each row is an array of cell strings. All rows must have the same column count (max 20).",
           ),
         column_alignments: z
           .array(z.enum(["left", "center", "right"]))
           .optional()
+          .describe("Optional per-column alignment. Defaults to left."),
+        send_as_reply: z
+          .boolean()
+          .optional()
           .describe(
-            "Optional per-column alignment. Array length should match column count. Defaults to left.",
+            "Post the table as a thread reply in the current conversation instead of inline. " +
+            "Use when sending multiple tables.",
           ),
+        target_channel: z
+          .string()
+          .optional()
+          .describe(
+            "Channel name or ID to post the table to. Mutually exclusive with target_user and send_as_reply.",
+          ),
+        target_user: z
+          .string()
+          .optional()
+          .describe(
+            "User display name or ID to DM the table to. Mutually exclusive with target_channel and send_as_reply.",
+          ),
+        thread_ts: z
+          .string()
+          .optional()
+          .describe("Thread timestamp for targeted posts — post the table as a thread reply."),
+        message: z
+          .string()
+          .optional()
+          .describe("Text above the table. Recommended for reply and targeted modes."),
       }),
-      execute: async ({ rows, column_alignments }) => {
-        if (rows.length < 2) {
-          return { ok: false, error: "Need at least a header row and one data row." };
-        }
+      execute: async ({
+        rows,
+        column_alignments,
+        send_as_reply,
+        target_channel,
+        target_user,
+        thread_ts,
+        message,
+      }) => {
+        const error = validateRows(rows);
+        if (error) return { ok: false, error };
 
         const colCount = rows[0].length;
-        if (colCount > 20) {
-          return { ok: false, error: "Max 20 columns allowed." };
-        }
-
-        for (let i = 0; i < rows.length; i++) {
-          if (rows[i].length !== colCount) {
-            return {
-              ok: false,
-              error: `Row ${i} has ${rows[i].length} columns but header has ${colCount}. All rows must have the same number of columns.`,
-            };
-          }
-        }
 
         if (column_alignments && column_alignments.length !== colCount) {
           return {
@@ -61,31 +138,98 @@ export function createTableTools() {
           };
         }
 
-        const tableBlock = {
-          type: "table" as const,
-          rows: rows.map((row) =>
-            row.map((cell) => ({ type: "raw_text" as const, text: cell })),
-          ),
-          ...(column_alignments
-            ? {
-                column_settings: column_alignments.map((align) => ({
-                  align,
-                  is_wrapped: true,
-                })),
-              }
-            : {
-                column_settings: Array.from({ length: colCount }, () => ({
-                  is_wrapped: true,
-                })),
-              }),
-        };
+        if ((target_channel || target_user) && send_as_reply) {
+          return { ok: false, error: "Use send_as_reply OR target_channel/target_user, not both." };
+        }
+        if (target_channel && target_user) {
+          return { ok: false, error: "Set target_channel or target_user, not both." };
+        }
 
-        logger.info("draw_table tool called", {
-          columns: colCount,
-          rows: rows.length - 1, // exclude header
-        });
+        const tableBlock = buildTableBlock(rows, column_alignments);
 
-        return { ok: true, [TABLE_BLOCK_KEY]: tableBlock };
+        // ── Inline mode: return block for pipeline injection ──────────
+        if (!target_channel && !target_user && !send_as_reply) {
+          logger.info("draw_table tool called (inline)", {
+            columns: colCount,
+            rows: rows.length - 1,
+          });
+          return { ok: true, [TABLE_BLOCK_KEY]: tableBlock };
+        }
+
+        // ── Reply mode: post in the current conversation thread ──────
+        if (send_as_reply) {
+          if (!context?.channelId || !context?.threadTs) {
+            return {
+              ok: false,
+              error: "No current conversation context available for send_as_reply.",
+            };
+          }
+
+          try {
+            const result = await postTable(
+              client, context.channelId, tableBlock, message, context.threadTs,
+            );
+            logger.info("draw_table tool called (reply)", {
+              channelId: context.channelId,
+              threadTs: context.threadTs,
+              columns: colCount,
+              rows: rows.length - 1,
+              messageTs: result.ts,
+            });
+            return {
+              ok: true,
+              message: "Table posted as a thread reply.",
+              timestamp: result.ts,
+            };
+          } catch (err: any) {
+            logger.error("draw_table (reply) failed", { error: err.message });
+            return { ok: false, error: `Failed to post table reply: ${err.message}` };
+          }
+        }
+
+        // ── Targeted mode: post to a specific channel or DM ──────────
+        try {
+          let channelId: string;
+
+          if (target_user) {
+            const user = await resolveUserByName(client, target_user);
+            if (!user) {
+              return { ok: false, error: `Could not find user "${target_user}".` };
+            }
+            const dm = await client.conversations.open({ users: user.id });
+            if (!dm.channel?.id) {
+              return { ok: false, error: `Failed to open DM with ${user.name}.` };
+            }
+            channelId = dm.channel.id;
+          } else {
+            const channel = await resolveChannelByName(client, target_channel!);
+            if (!channel) {
+              return { ok: false, error: `Could not find channel "${target_channel}".` };
+            }
+            channelId = channel.id;
+          }
+
+          const result = await postTable(
+            client, channelId, tableBlock, message, thread_ts,
+          );
+
+          const targetLabel = target_user || target_channel;
+          logger.info("draw_table tool called (targeted)", {
+            target: targetLabel,
+            columns: colCount,
+            rows: rows.length - 1,
+            messageTs: result.ts,
+          });
+
+          return {
+            ok: true,
+            message: `Table sent to ${target_user ? target_user : `#${target_channel}`}`,
+            timestamp: result.ts,
+          };
+        } catch (err: any) {
+          logger.error("draw_table (targeted) failed", { error: err.message });
+          return { ok: false, error: `Failed to send table: ${err.message}` };
+        }
       },
     }),
   };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Slack API write paths (`chat.postMessage`, `conversations.open`) and routing logic (thread/DM/channel resolution), which could misdirect messages or fail due to missing context/scopes if not carefully tested.
> 
> **Overview**
> Improves the `draw_table` Slack tool from *inline-only rendering* to also support **posting tables as thread replies** and **sending tables to a specified channel or user DM**, including optional `message` text and `thread_ts` for targeted thread posts.
> 
> Exports `resolveChannelByName`/`resolveUserByName` for reuse, wires `createTableTools(client, context)` through `createSlackTools`, and updates table tool validation/logging plus the system prompt documentation to reflect the new modes and constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d54329c602b9f22880c6070cb27ac6baa761e697. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->