### PR TITLE
feat: implement streaming fallback for unsupported Slack channels

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -539,11 +539,13 @@ export async function generateResponse(
         blocks.push(pendingTableBlock);
       }
 
+      const toolMeta = buildToolMetadata(toolCallRecords);
       await slackClient.chat.postMessage({
         channel: channelId,
         text: finalText || "_I processed your request but had nothing to say._",
         thread_ts: threadTs,
         ...(blocks.length > 0 && { blocks }),
+        ...(toolMeta && { metadata: toolMeta }),
       });
 
       logger.info(`LLM completed in ${llmMs}ms (fallback postMessage)`, {


### PR DESCRIPTION
- Added a helper function to detect when streaming is unsupported due to channel type restrictions.
- Implemented a fallback mechanism in the `generateResponse` function to switch from streaming to posting messages directly when streaming fails.
- Enhanced logging to provide insights into the fallback process and response generation timing.

This change improves the robustness of the response generation in Slack, ensuring that messages are still sent even when certain channel types do not support streaming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Slack response delivery path and changes how messages are finalized (stream stop vs `postMessage`), which could affect message formatting/metadata in edge-case channels.
> 
> **Overview**
> Improves `generateResponse` robustness by detecting Slack `channel_type_not_supported` failures during `chatStream` appends and switching to a non-streaming mode that buffers output and posts the final result via `chat.postMessage`.
> 
> The fallback preserves **tool I/O metadata** and **table rendering** by attaching metadata to the posted message and, when a table block exists, emitting the LLM text as section blocks alongside the table; error handling is adjusted to avoid calling `streamer.stop()` when streaming never successfully started.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb216f683a695383a1ae0ddd36c2065bbe0e2832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->