### PR TITLE
fix: add cursor-based pagination to list_slack_list_items

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1182,14 +1182,21 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
           .max(100)
           .default(50)
           .describe("Maximum number of items to return"),
+        cursor: z
+          .string()
+          .optional()
+          .describe(
+            "Pagination cursor from a previous response's next_cursor field",
+          ),
       }),
-      execute: async ({ list_id, limit }) => {
+      execute: async ({ list_id, limit, cursor }) => {
         try {
           const result = await (client as any).apiCall(
             "slackLists.items.list",
             {
               list_id,
               limit,
+              ...(cursor ? { cursor } : {}),
             },
           );
 
@@ -1222,6 +1229,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
             list_id,
             items,
             count: items.length,
+            next_cursor: result.response_metadata?.next_cursor || null,
           };
         } catch (error: any) {
           logger.error("list_slack_list_items tool failed", {


### PR DESCRIPTION
Closes #98

## What

Adds cursor-based pagination to the `list_slack_list_items` tool so I can page through the full bug tracker (currently capped at 100 items).

## Changes

- Added optional `cursor` string parameter to the tool schema
- Pass cursor to the Slack `slackLists.items.list` API call when provided
- Return `next_cursor` in the response (null when no more pages, string token otherwise)

## How it works

First call: `list_slack_list_items(list_id, limit: 50)` → returns items + `next_cursor: "abc123"`
Next call: `list_slack_list_items(list_id, limit: 50, cursor: "abc123")` → returns next page

This is a 3-line change following existing patterns. TypeScript couldn't be verified due to OOM in sandbox, but the changes are straightforward and type-safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change limited to one Slack tool’s request/response shape; main risk is minor downstream breakage if callers assume the old response schema.
> 
> **Overview**
> Adds cursor-based pagination support to `list_slack_list_items` by accepting an optional `cursor`, passing it through to Slack’s `slackLists.items.list` API call, and returning `next_cursor` (or `null`) in the tool response so callers can fetch subsequent pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf635565cd447ff1cd9e265af8a7b988d8664bc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->