### PR TITLE
Enhance README and pipeline to support `assistant:write` scope for lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Go to **OAuth & Permissions** in the sidebar. Under **Bot Token Scopes**, add:
 | `canvases:read` | Read Canvas content |
 | `canvases:write` | Create/edit Canvases |
 | `users.profile:write` | Set bot's own status |
+| `assistant:write` | Loading shimmer & status indicators (auto-added by Agents & AI Apps toggle) |
+
+> **Agents & AI Apps**: In the Slack app sidebar, find **Agents & AI Apps** and toggle it **on**. This auto-adds the `assistant:write` scope and enables the loading shimmer on Aura's name while she's thinking.
 
 Optional (for message search):
 

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -152,6 +152,20 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       return;
     }
 
+    // Set assistant thread status — triggers the shimmer animation on
+    // Aura's name and shows a loading indicator while processing.
+    // Requires the `assistant:write` scope (enabled via Agents & AI Apps
+    // toggle in Slack app settings). Status auto-clears on reply.
+    try {
+      await client.assistant.threads.setStatus({
+        channel_id: context.channelId,
+        thread_ts: replyThreadTs,
+        status: "Thinking...",
+      });
+    } catch {
+      // Non-fatal: scope may not be configured or channel type unsupported
+    }
+
     // ── Edge case: extremely long message ────────────────────────────────
     let messageText = context.text || (hasFiles ? "What do you see in this image?" : "");
     if (messageText.length > MAX_MESSAGE_LENGTH) {


### PR DESCRIPTION
…ading indicators

- Updated README.md to include the new `assistant:write` scope, which enables loading shimmer and status indicators for the bot.
- Modified index.ts in the pipeline to implement the assistant thread status feature, allowing for a "Thinking..." status during processing, which enhances user experience by providing visual feedback while the bot is working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, optional UX enhancement that adds a non-fatal Slack API call; failures are caught and don’t affect message handling.
> 
> **Overview**
> Adds the `assistant:write` Slack scope to the setup docs and explains enabling it via the **Agents & AI Apps** toggle to get Aura’s loading shimmer/status indicators.
> 
> Updates the message pipeline to best-effort call `client.assistant.threads.setStatus` with `"Thinking..."` at the start of processing (swallowing errors when the scope/channel isn’t supported), providing in-thread visual feedback while the bot works.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1ae58bd9e0d0330055a4b57bd319a51f6b563a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->