### PR TITLE
feat: Enhance error handling and logging for Slack message posting

### DIFF
--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -302,6 +302,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     logger.error("Pipeline error", {
       errorName,
       errorMessage,
+      slackErrorCode: error?.data?.error,
       userId: context.userId,
       channelId: context.channelId,
       channelType: context.channelType,

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -279,6 +279,12 @@ function isStreamingUnsupported(error: any): boolean {
   );
 }
 
+function isInvalidBlocks(error: any): boolean {
+  const msg = error?.message || "";
+  const code = error?.data?.error || "";
+  return msg.includes("invalid_blocks") || code === "invalid_blocks";
+}
+
 // ── Main Function ────────────────────────────────────────────────────────────
 
 /**
@@ -338,6 +344,13 @@ export async function generateResponse(
           "chatStream not supported for this channel, falling back to postMessage",
           { channelId },
         );
+      } else if (isInvalidBlocks(err)) {
+        streamingFailed = true;
+        logger.warn("chatStream append returned invalid_blocks, falling back to postMessage", {
+          channelId,
+          slackError: err?.data?.error,
+          payloadKeys: Object.keys(payload),
+        });
       } else {
         throw err;
       }
@@ -551,13 +564,32 @@ export async function generateResponse(
       });
 
       const toolMeta = buildToolMetadata(toolCallRecords);
-      await slackClient.chat.postMessage({
-        channel: channelId,
-        text: finalText || "_I processed your request but had nothing to say._",
-        thread_ts: threadTs,
-        blocks,
-        ...(toolMeta && { metadata: toolMeta }),
-      });
+      const fallbackText = finalText || "_I processed your request but had nothing to say._";
+
+      try {
+        await slackClient.chat.postMessage({
+          channel: channelId,
+          text: fallbackText,
+          thread_ts: threadTs,
+          blocks,
+          ...(toolMeta && { metadata: toolMeta }),
+        });
+      } catch (postErr: any) {
+        if (isInvalidBlocks(postErr)) {
+          logger.warn("Fallback postMessage rejected blocks, retrying as plain text", {
+            channelId,
+            slackError: postErr?.data?.error,
+            blockTypes: blocks.map((b: any) => b.type),
+          });
+          await slackClient.chat.postMessage({
+            channel: channelId,
+            text: fallbackText,
+            thread_ts: threadTs,
+          });
+        } else {
+          throw postErr;
+        }
+      }
 
       logger.info(`LLM completed in ${llmMs}ms (fallback postMessage)`, {
         rawLength: finalText.length,
@@ -584,7 +616,25 @@ export async function generateResponse(
       stopBlocks.push(feedbackBlock);
       const stopArgs: Record<string, any> = { blocks: stopBlocks };
       if (toolMeta) stopArgs.metadata = toolMeta;
-      await streamer.stop(stopArgs);
+
+      try {
+        await streamer.stop(stopArgs);
+      } catch (stopErr: any) {
+        if (isInvalidBlocks(stopErr)) {
+          logger.warn("streamer.stop() rejected blocks, retrying without them", {
+            channelId,
+            slackError: stopErr?.data?.error,
+            blockTypes: stopBlocks.map((b: any) => b.type),
+          });
+          try {
+            await streamer.stop();
+          } catch {
+            // Stream may already be finalized — nothing we can do
+          }
+        } else {
+          throw stopErr;
+        }
+      }
 
       logger.info(`LLM stream completed in ${llmMs}ms`, {
         rawLength: finalText.length,


### PR DESCRIPTION
- Added a new function to check for invalid block errors and log relevant details.
- Updated the response generation logic to handle invalid block errors during message posting, falling back to plain text if necessary.
- Improved logging to capture additional error context, including Slack error codes and block types, enhancing debugging capabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive error handling and logging around Slack API failures, with limited behavior change to fallback/retry paths when Slack rejects blocks.
> 
> **Overview**
> Hardens Slack response posting by detecting Slack `invalid_blocks` failures and automatically falling back to safer behavior.
> 
> `generateResponse` now treats `invalid_blocks` from `chatStream.append` as a signal to abandon streaming and use `chat.postMessage`; if `postMessage` (or `streamer.stop`) rejects blocks, it retries without blocks (plain text / stop without blocks) and logs Slack error codes plus payload/block details for debugging. The pipeline-level error log also now captures the Slack error code (`error.data.error`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd8e6bca142a2cc2239af55452f333d698e00e9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->