### PR TITLE
fix: block SSRF via private IP range check in read_url

### DIFF
--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -70,12 +70,18 @@ async function isPrivateUrl(url: string): Promise<boolean> {
   }
 
   if (family === 6) {
-    // IPv6 private ranges
-    if (address === "::1") return true;                          // loopback
-    if (address.toLowerCase().startsWith("fe80:")) return true; // link-local (fe80::/10)
-    if (address.toLowerCase().startsWith("fc") ||
-        address.toLowerCase().startsWith("fd")) return true;    // ULA (fc00::/7)
-    return false;
+    // IPv4-mapped IPv6 (::ffff:x.x.x.x) — extract and validate as IPv4
+    const v4Mapped = address.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+    if (v4Mapped) {
+      address = v4Mapped[1];
+    } else {
+      if (address === "::1") return true;                          // loopback
+      const firstWord = parseInt(address.split(":")[0], 16);
+      if (firstWord >= 0xfe80 && firstWord <= 0xfebf) return true; // link-local (fe80::/10)
+      if (address.toLowerCase().startsWith("fc") ||
+          address.toLowerCase().startsWith("fd")) return true;     // ULA (fc00::/7)
+      return false;
+    }
   }
 
   // IPv4: parse octets and check private ranges
@@ -203,13 +209,33 @@ export function createWebTools() {
             }
           }
 
-          // Fallback: raw fetch + HTML stripping
-          const response = await fetch(url, {
-            headers: {
-              "User-Agent": "Mozilla/5.0 (compatible; AuraBot/1.0)",
-            },
-            signal: AbortSignal.timeout(10000),
-          });
+          // Fallback: raw fetch + HTML stripping (manual redirect to re-validate each hop)
+          let currentUrl = url;
+          let response!: Response;
+          for (let r = 0; r < 10; r++) {
+            response = await fetch(currentUrl, {
+              headers: {
+                "User-Agent": "Mozilla/5.0 (compatible; AuraBot/1.0)",
+              },
+              signal: AbortSignal.timeout(10000),
+              redirect: "manual",
+            });
+            if (response.status >= 300 && response.status < 400) {
+              const location = response.headers.get("location");
+              if (!location) break;
+              currentUrl = new URL(location, currentUrl).toString();
+              if (await isPrivateUrl(currentUrl)) {
+                logger.warn("read_url SSRF blocked (redirect)", { url, redirectTo: currentUrl });
+                return {
+                  ok: false,
+                  error: "Blocked: redirect resolves to a private/internal network address",
+                  url,
+                };
+              }
+              continue;
+            }
+            break;
+          }
 
           if (!response.ok) {
             return {


### PR DESCRIPTION
## What

Adds an `isPrivateUrl()` guard to the `read_url` tool that resolves hostnames via DNS and blocks requests to private/internal network addresses before any HTTP request is made.

## Why

**Security**: Without this check, the `read_url` tool could be used to probe internal network resources (RFC-1918 addresses, loopback, cloud metadata endpoints, etc.).

Closes #91

## How

1. New `isPrivateUrl(url)` async helper in `src/tools/web.ts`
2. Parses URL hostname, immediately blocks known-private names (`localhost`, `.local`, `.internal`)  
3. Resolves hostname via `dns.promises.lookup()` and checks resolved IP against:
   - `127.0.0.0/8` (loopback)
   - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC-1918)
   - `169.254.0.0/16` (link-local)
   - `0.0.0.0/8`
   - IPv6: `::1`, `fe80::/10`, `fc00::/7`
4. Fails closed: DNS failure → request blocked
5. Guard runs **before** both the Tavily extract path and the raw fetch fallback

## Testing

- `read_url('http://127.0.0.1:8080/admin')` → blocked
- `read_url('http://192.168.1.1')` → blocked
- `read_url('http://metadata.google.internal')` → blocked
- `read_url('https://example.com')` → works as before

## Impact

One file changed: `src/tools/web.ts` (+74 lines). No behavioral change for public URLs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive change to outbound URL fetching; risk is mainly false positives/behavior changes for some hostnames and redirect chains, but scope is limited to `read_url`.
> 
> **Overview**
> Prevents SSRF via the `read_url` tool by adding an `isPrivateUrl()` guard that DNS-resolves hostnames and blocks loopback, RFC1918, link-local, ULA, and other internal targets (failing closed on parse/DNS errors).
> 
> Also changes the raw `fetch` fallback to handle redirects manually (up to 10 hops) and re-run the private-network check on each redirect target, returning a clear blocked error and warning logs when tripped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab3d223d9ff1bdf8ea6e5058f9a36cc7b844fa83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->