### PR TITLE
Slack file type support

### DIFF
--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,105 +1,140 @@
 import { logger } from "./logger.js";
 
-/** Supported image MIME types for multimodal LLM input */
-const SUPPORTED_IMAGE_TYPES = new Set([
+/** Max file size to download (20MB) */
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+
+const IMAGE_MIME_TYPES = new Set([
   "image/jpeg",
   "image/png",
   "image/gif",
   "image/webp",
 ]);
 
-/** Max file size to download (10MB) */
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const TEXT_MIME_TYPES = new Set([
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/x-javascript",
+  "application/typescript",
+  "application/csv",
+  "application/x-yaml",
+  "application/yaml",
+  "application/sql",
+  "application/graphql",
+  "application/x-sh",
+  "application/xhtml+xml",
+]);
 
-export interface SlackImage {
-  data: Uint8Array;
-  mimeType: string;
-  name: string;
+function isTextMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("text/") || TEXT_MIME_TYPES.has(mimeType);
 }
 
+/** AI SDK content part for a user message file attachment. */
+export type FileContentPart =
+  | { type: "image"; image: Uint8Array; mediaType: string }
+  | { type: "file"; data: Uint8Array; mediaType: string; filename: string }
+  | { type: "text"; text: string };
+
 /**
- * Extract downloadable image files from a Slack event.
- * Filters for supported image types and reasonable sizes.
+ * Extract downloadable files from a Slack event.
+ * Accepts all file types, filtering only by size and presence of a download URL.
  */
-export function getImageFiles(
+export function getEventFiles(
   event: any,
-): { url_private_download: string; mimetype: string; name: string; size: number }[] {
+): { url: string; mimetype: string; name: string; size: number }[] {
   const files = event.files;
   if (!Array.isArray(files) || files.length === 0) return [];
 
-  return files.filter((f: any) => {
-    // Slack uses url_private_download or url_private
-    if (!f.url_private_download && !f.url_private) return false;
-    if (!f.url_private_download) f.url_private_download = f.url_private;
-    if (!f.mimetype || !SUPPORTED_IMAGE_TYPES.has(f.mimetype)) return false;
-    if (f.size && f.size > MAX_FILE_SIZE) {
-      logger.warn("Skipping large image file", {
-        name: f.name,
-        size: f.size,
-      });
-      return false;
-    }
-    return true;
-  });
+  return files
+    .filter((f: any) => {
+      const url = f.url_private_download || f.url_private;
+      if (!url) return false;
+      if (f.size && f.size > MAX_FILE_SIZE) {
+        logger.warn("Skipping large file (exceeds 20MB limit)", {
+          name: f.name,
+          size: f.size,
+          mimetype: f.mimetype,
+        });
+        return false;
+      }
+      return true;
+    })
+    .map((f: any) => ({
+      url: f.url_private_download || f.url_private,
+      mimetype: f.mimetype || "application/octet-stream",
+      name: f.name || "file",
+      size: f.size || 0,
+    }));
 }
 
 /**
- * Download an image from Slack's private URL using the bot token.
- * Returns raw bytes as Uint8Array (no base64 needed for AI SDK v6).
+ * Download a file from Slack's private URL using the bot token.
  */
-export async function downloadSlackImage(
+async function downloadSlackFile(
   url: string,
   botToken: string,
 ): Promise<Uint8Array> {
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${botToken}` },
-    signal: AbortSignal.timeout(15000),
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to download image: HTTP ${response.status}`);
+    throw new Error(`Failed to download file: HTTP ${response.status}`);
   }
 
   return new Uint8Array(await response.arrayBuffer());
 }
 
+/** Convert raw file data + metadata into an AI SDK content part. */
+function toContentPart(
+  data: Uint8Array,
+  mimeType: string,
+  name: string,
+): FileContentPart {
+  if (IMAGE_MIME_TYPES.has(mimeType)) {
+    return { type: "image", image: data, mediaType: mimeType };
+  }
+
+  if (isTextMimeType(mimeType)) {
+    const text = new TextDecoder().decode(data);
+    return { type: "text", text: `[File: ${name}]\n${text}` };
+  }
+
+  return { type: "file", data, mediaType: mimeType, filename: name };
+}
+
 /**
- * Download all image files from a Slack event.
- * Returns an array of SlackImage objects ready for multimodal input.
+ * Download all files from a Slack event and convert to AI SDK content parts.
  */
-export async function downloadEventImages(
+export async function downloadEventFiles(
   event: any,
   botToken: string,
-): Promise<SlackImage[]> {
-  const imageFiles = getImageFiles(event);
-  if (imageFiles.length === 0) return [];
+): Promise<FileContentPart[]> {
+  const files = getEventFiles(event);
+  if (files.length === 0) return [];
 
-  const images: SlackImage[] = [];
+  const parts: FileContentPart[] = [];
 
-  for (const file of imageFiles) {
+  for (const file of files) {
     try {
-      const data = await downloadSlackImage(
-        file.url_private_download,
-        botToken,
-      );
-      images.push({
-        data,
-        mimeType: file.mimetype,
-        name: file.name || "image",
-      });
-      logger.info("Downloaded Slack image", {
+      const data = await downloadSlackFile(file.url, botToken);
+      const part = toContentPart(data, file.mimetype, file.name);
+      parts.push(part);
+      logger.info("Downloaded Slack file", {
         name: file.name,
         size: data.length,
         mimeType: file.mimetype,
+        partType: part.type,
       });
     } catch (error: any) {
-      logger.error("Failed to download Slack image", {
+      logger.error("Failed to download Slack file", {
         name: file.name,
-        url: file.url_private_download,
+        url: file.url,
         error: error.message,
       });
     }
   }
 
-  return images;
+  return parts;
 }

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -24,7 +24,7 @@ import {
   recordInteraction,
   updateProfileFromConversation,
 } from "../users/profiles.js";
-import { downloadEventImages, type SlackImage } from "../lib/files.js";
+import { downloadEventFiles } from "../lib/files.js";
 import { pauseSandbox } from "../lib/sandbox.js";
 import { logger } from "../lib/logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
@@ -172,7 +172,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     }
 
     // ── Edge case: extremely long message ────────────────────────────────
-    let messageText = context.text || (hasFiles ? "What do you see in this image?" : "");
+    let messageText = context.text || (hasFiles ? "What can you tell me about this file?" : "");
     if (messageText.length > MAX_MESSAGE_LENGTH) {
       messageText = messageText.substring(0, MAX_MESSAGE_LENGTH);
       logger.warn("Truncated long message", {
@@ -220,13 +220,13 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     );
     const retrievalMs = Date.now() - retrievalStart;
 
-    // 4b. Download images if the message has file attachments
+    // 4b. Download files if the message has attachments
     const botToken = process.env.SLACK_BOT_TOKEN || "";
-    const images = await downloadEventImages(event, botToken);
-    if (images.length > 0) {
-      logger.info("Images ready for LLM", {
-        count: images.length,
-        names: images.map((i) => i.name),
+    const fileParts = await downloadEventFiles(event, botToken);
+    if (fileParts.length > 0) {
+      logger.info("Files ready for LLM", {
+        count: fileParts.length,
+        types: fileParts.map((p) => p.type),
       });
     }
 
@@ -237,7 +237,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       userMessage: messageText,
       slackClient: client,
       context: { userId: context.userId, channelId: context.channelId, threadTs: replyThreadTs },
-      images,
+      files: fileParts,
       channelId: context.channelId,
       threadTs: replyThreadTs,
       teamId,

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -2,7 +2,7 @@ import { streamText, stepCountIs } from "ai";
 import type { WebClient } from "@slack/web-api";
 import { getMainModel } from "../lib/ai.js";
 import { createSlackTools } from "../tools/slack.js";
-import type { SlackImage } from "../lib/files.js";
+import type { FileContentPart } from "../lib/files.js";
 import { logger } from "../lib/logger.js";
 import { TABLE_BLOCK_KEY } from "../tools/table.js";
 
@@ -241,7 +241,7 @@ interface RespondOptions {
   userMessage: string;
   slackClient: WebClient;
   context?: { userId?: string; channelId?: string; threadTs?: string };
-  images?: SlackImage[];
+  files?: FileContentPart[];
   channelId: string;
   threadTs?: string;
   /** Slack team ID — required for chatStream in channels */
@@ -306,7 +306,7 @@ export async function generateResponse(
   const { slackClient, channelId, threadTs } = options;
 
   const model = await getMainModel();
-  const hasImages = options.images && options.images.length > 0;
+  const hasFiles = options.files && options.files.length > 0;
 
   // ── Start native Slack stream ───────────────────────────────────────
   // thread_ts is required by chat.startStream — the caller must always
@@ -382,14 +382,10 @@ export async function generateResponse(
     abortSignal: abortController.signal,
   };
 
-  if (hasImages) {
+  if (hasFiles) {
     const content: any[] = [
       { type: "text", text: options.userMessage },
-      ...options.images!.map((img) => ({
-        type: "image",
-        image: img.data,
-        mediaType: img.mimeType,
-      })),
+      ...options.files!,
     ];
     streamOptions.messages = [{ role: "user", content }];
   } else {
@@ -398,7 +394,7 @@ export async function generateResponse(
 
   logger.info("Starting LLM stream", {
     model: model.modelId || "unknown",
-    hasImages,
+    hasFiles,
     toolCount: Object.keys(streamOptions.tools || {}).length,
     promptLength: options.systemPrompt.length,
   });


### PR DESCRIPTION
Enable processing of all Slack file types (not just images) to forward them to the LLM as-is.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-08807253-166e-473e-ae35-5d5bca775e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08807253-166e-473e-ae35-5d5bca775e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens the set of user-supplied inputs (arbitrary file bytes/text) sent to the LLM and increases download limits/timeouts, which can affect latency, token usage, and content-handling edge cases.
> 
> **Overview**
> Slack message attachments are now processed as **general files**, not just images, and are forwarded to the LLM as AI SDK multi-part user content.
> 
> `src/lib/files.ts` now extracts any downloadable Slack file under **20MB** (up from 10MB), downloads with a longer timeout, and converts attachments into `FileContentPart` variants: images remain `type: "image"`, known text types are decoded and inlined as `type: "text"`, and everything else is passed through as `type: "file"` bytes.
> 
> The pipeline and response layer are updated to use `downloadEventFiles()` and pass `files` into `generateResponse()`, including updated logging and a new default prompt for file-only messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c099be123e09ab593dd337a73014f79083572c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->