### PR TITLE
Voice input transcription

### DIFF
--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,0 +1,48 @@
+import { logger } from "./logger.js";
+
+/**
+ * Transcribe an audio file using OpenAI's Whisper API.
+ * Uses direct fetch to avoid adding the openai package as a dependency.
+ */
+export async function transcribeAudio(
+  data: Uint8Array,
+  mimeType: string,
+  filename: string,
+): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+
+  const formData = new FormData();
+  formData.append("file", new Blob([data], { type: mimeType }), filename);
+  formData.append("model", "whisper-1");
+
+  const response = await fetch(
+    "https://api.openai.com/v1/audio/transcriptions",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: formData,
+      signal: AbortSignal.timeout(60_000),
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "unknown");
+    throw new Error(
+      `Whisper API error: HTTP ${response.status} — ${errorBody}`,
+    );
+  }
+
+  const result = (await response.json()) as { text: string };
+
+  logger.info("Whisper transcription complete", {
+    filename,
+    mimeType,
+    textLength: result.text.length,
+    textPreview: result.text.substring(0, 100),
+  });
+
+  return result.text;
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,4 +1,5 @@
 import { logger } from "./logger.js";
+import { transcribeAudio } from "./audio.js";
 
 /** Max file size to download (20MB) */
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
@@ -8,6 +9,16 @@ const IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/gif",
   "image/webp",
+]);
+
+const AUDIO_MIME_TYPES = new Set([
+  "audio/webm",
+  "audio/ogg",
+  "audio/mp4",
+  "audio/mpeg",
+  "audio/mp4a-latm",
+  "audio/wav",
+  "audio/x-m4a",
 ]);
 
 const TEXT_MIME_TYPES = new Set([
@@ -87,13 +98,33 @@ async function downloadSlackFile(
 }
 
 /** Convert raw file data + metadata into an AI SDK content part. */
-function toContentPart(
+async function toContentPart(
   data: Uint8Array,
   mimeType: string,
   name: string,
-): FileContentPart {
+): Promise<FileContentPart> {
   if (IMAGE_MIME_TYPES.has(mimeType)) {
     return { type: "image", image: data, mediaType: mimeType };
+  }
+
+  if (AUDIO_MIME_TYPES.has(mimeType)) {
+    try {
+      const transcription = await transcribeAudio(data, mimeType, name);
+      return {
+        type: "text",
+        text: `[Voice message transcription]: ${transcription}`,
+      };
+    } catch (error: any) {
+      logger.error("Audio transcription failed", {
+        name,
+        mimeType,
+        error: error.message,
+      });
+      return {
+        type: "text",
+        text: `[Voice message]: Audio transcription failed — ${error.message}`,
+      };
+    }
   }
 
   if (isTextMimeType(mimeType)) {
@@ -119,7 +150,7 @@ export async function downloadEventFiles(
   for (const file of files) {
     try {
       const data = await downloadSlackFile(file.url, botToken);
-      const part = toContentPart(data, file.mimetype, file.name);
+      const part = await toContentPart(data, file.mimetype, file.name);
       parts.push(part);
       logger.info("Downloaded Slack file", {
         name: file.name,


### PR DESCRIPTION
feat: Transcribe audio messages via Whisper to enable LLM processing of voice inputs.

Aura previously ignored audio file attachments; this PR integrates OpenAI's Whisper API to transcribe audio into text, allowing the LLM to understand and respond to voice messages.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d56b4090-0e8c-4c6b-82f5-e9b19c17f6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d56b4090-0e8c-4c6b-82f5-e9b19c17f6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external API call path using `OPENAI_API_KEY`, which can impact latency/cost and may surface transcription text in logs; failure handling is present but behavior changes for audio attachments.
> 
> **Overview**
> Adds voice-attachment support by introducing `transcribeAudio` (new `audio.ts`) which calls OpenAI Whisper via `fetch`/`FormData` (60s timeout) and logs transcription metadata.
> 
> Updates Slack file handling to recognize common audio MIME types and asynchronously convert audio attachments into `text` parts containing a transcription (or an explicit failure message), so the LLM receives voice content instead of an opaque file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593a9f946aff9d0280c3f90285431ac52a5cea81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->