### PR TITLE
Gateway file type allowlist

### DIFF
--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -24,6 +24,7 @@ const AUDIO_MIME_TYPES = new Set([
 const GATEWAY_SUPPORTED_FILE_TYPES = new Set([
   "application/pdf",
   "text/csv",
+  "application/csv",
   "application/msword",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/vnd.ms-excel",
@@ -39,7 +40,6 @@ const TEXT_MIME_TYPES = new Set([
   "application/javascript",
   "application/x-javascript",
   "application/typescript",
-  "application/csv",
   "application/x-yaml",
   "application/yaml",
   "application/sql",

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -682,8 +682,6 @@ export async function generateResponse(
       const retryOptions: any = {
         model,
         system: options.systemPrompt,
-        tools: streamOptions.tools,
-        stopWhen: stepCountIs(25),
         prompt: retryPrompt,
         abortSignal: retryAbortController.signal,
       };


### PR DESCRIPTION
Gate file mime types to Vercel AI Gateway's allowlist and add defensive error handling to prevent silent LLM call failures for unsupported file types.

The current system silently crashes LLM calls when users send files with mime types not supported by the Vercel AI Gateway, leading to a poor user experience. This PR ensures that only supported file types are sent as `file` parts, and for unsupported types, it provides a graceful text acknowledgment or retries the LLM call without the problematic files, preventing complete silence.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ab8d51df-7af6-439f-acc4-977006c45146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab8d51df-7af6-439f-acc4-977006c45146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core response streaming/error path and changes how attachments are represented to the model; mistakes could cause missing context or unexpected retry/stream behavior, but scope is limited and gated to unsupported-file failure cases.
> 
> **Overview**
> Prevents unsupported Slack attachments from being sent to the Vercel AI Gateway as `file` parts by introducing a **gateway file-type allowlist**; non-allowlisted binaries now become a user-visible text acknowledgment, while allowlisted docs/spreadsheets/PDFs remain `file` parts.
> 
> Adds defensive handling in `generateResponse` to detect unsupported-file errors from the AI SDK and **retry the LLM call without file parts**, streaming the retry response back to Slack and annotating the prompt with which attachments were skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df6728027882cc5e2697c5cb857aacfbf867580a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->