### PR TITLE
DM history thread replies

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1245,17 +1245,59 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
           const result = await client.conversations.history(historyParams as any);
 
-          // Resolve user IDs to display names
+          // Resolve user IDs to display names, and fetch thread replies for threaded messages
           const messages = await Promise.all(
             (result.messages || []).map(async (msg) => {
               const userName = msg.user
                 ? await resolveUserById(client, msg.user)
                 : "unknown";
+
+              const replyCount = (msg as any).reply_count as number | undefined;
+              const threadTs = msg.ts || "";
+              const latestReply = (msg as any).latest_reply as string | undefined;
+
+              let replies: Array<{ user: string; user_id: string; text: string; timestamp: string }> | undefined;
+
+              if (replyCount && replyCount > 0 && threadTs) {
+                try {
+                  const threadResult = await client.conversations.replies({
+                    channel: dmChannelId!,
+                    ts: threadTs,
+                    limit: 200,
+                  });
+                  // First message in replies is the parent — skip it
+                  const threadMessages = (threadResult.messages || []).slice(1);
+                  replies = await Promise.all(
+                    threadMessages.map(async (reply) => {
+                      const replyUserName = reply.user
+                        ? await resolveUserById(client, reply.user)
+                        : "unknown";
+                      return {
+                        user: replyUserName,
+                        user_id: reply.user || "",
+                        text: reply.text || "",
+                        timestamp: reply.ts || "",
+                      };
+                    }),
+                  );
+                } catch (threadError: any) {
+                  logger.error("Failed to fetch thread replies", {
+                    channel: dmChannelId,
+                    thread_ts: threadTs,
+                    error: threadError.message,
+                  });
+                }
+              }
+
               return {
                 user: userName,
                 user_id: msg.user || "",
                 text: msg.text || "",
                 timestamp: msg.ts || "",
+                ...(replyCount != null && replyCount > 0
+                  ? { reply_count: replyCount, thread_ts: threadTs, latest_reply: latestReply }
+                  : {}),
+                ...(replies && replies.length > 0 ? { replies } : {}),
                 reactions:
                   (msg as any).reactions?.map((r: any) => ({
                     name: r.name,


### PR DESCRIPTION
Enhance `read_dm_history` to fetch and include thread replies, resolving GitHub issue #124 where critical responses were missed.

Previously, `read_dm_history` only returned top-level messages, making thread replies invisible and leading to a critical incident where a user's response was entirely missed. This change ensures that all relevant conversation context, including threaded discussions, is retrieved.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-3e5a8ac9-67a6-4e27-a316-0c250f178c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e5a8ac9-67a6-4e27-a316-0c250f178c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds additional Slack API calls per message, which can impact latency and hit rate limits; response shape also changes by optionally including thread fields and `replies`.
> 
> **Overview**
> Enhances `read_dm_history` to include *threaded DM replies* by detecting messages with `reply_count` and fetching their threads via `conversations.replies`.
> 
> Thread metadata (`reply_count`, `thread_ts`, `latest_reply`) and a resolved `replies` array (with per-reply user display names) are appended to each message when present, with error logging on thread fetch failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1152af8156bd91a39cebe3b80b7268d266f45ec8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->