### PR TITLE
Message rich content

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -123,8 +123,11 @@ function extractFullMessageText(msg: any): string {
     }
   }
 
-  // Rich-text blocks: iterate into nested element tree
-  if (Array.isArray(msg.blocks)) {
+  // Rich-text blocks: only extract when msg.text is absent, since msg.text
+  // already contains the full mrkdwn fallback and partial extraction of
+  // rich_text elements (which drops links, mentions, emoji) creates noisy
+  // near-duplicate lines that fail dedup.
+  if (!msg.text && Array.isArray(msg.blocks)) {
     for (const block of msg.blocks) {
       if (block.type === "rich_text" && Array.isArray(block.elements)) {
         for (const section of block.elements) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Extract rich content from Slack messages to fix blank forwarded messages in `read_dm_history` and `read_channel_history`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, `msg.text` was often empty for messages containing forwards, attachments, or rich blocks, leading to incomplete message history. This PR introduces `extractFullMessageText` to aggregate text from all relevant fields and `generateAttachmentsSummary` to indicate the presence of rich content.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-12ef036f-ff49-4ca2-9a9a-8748e6b9a299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12ef036f-ff49-4ca2-9a9a-8748e6b9a299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Slack history response formatting; main risk is slight output shape/text changes (including new optional `attachments_summary`) that could affect downstream consumers expecting only `msg.text`.
> 
> **Overview**
> Fixes blank/partial Slack history results by aggregating message content beyond `msg.text`.
> 
> Adds `extractFullMessageText` to pull text from attachments (including forwarded/unfurled messages), rich-text blocks (when `msg.text` is absent), and file shares with basic deduping, and updates `read_channel_history` and `read_dm_history` to use it.
> 
> Adds `generateAttachmentsSummary` and includes an optional `attachments_summary` field in history responses to indicate forwarded messages/attachments/files when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3751eab876be5ea398c3de39fc4c0aab5567dd9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->