### PR TITLE
Message context processing

### DIFF
--- a/src/pipeline/context.ts
+++ b/src/pipeline/context.ts
@@ -9,6 +9,13 @@ import { resolveChannelById } from "../tools/slack.js";
 // Minimal local types — replaces the @slack/bolt dependency that was only used
 // for these type imports.
 
+export interface SlackAttachment {
+  text?: string;
+  fallback?: string;
+  pretext?: string;
+  [key: string]: unknown;
+}
+
 export interface SlackMessageEvent {
   type: "message";
   channel: string;
@@ -20,6 +27,7 @@ export interface SlackMessageEvent {
   channel_type?: string;
   subtype?: string;
   files?: Array<Record<string, unknown>>;
+  attachments?: SlackAttachment[];
 }
 
 export interface SlackAppMentionEvent {
@@ -64,13 +72,24 @@ export function buildMessageContext(
   event: SlackEvent,
   botUserId: string,
 ): MessageContext | null {
-  // Skip bot messages, message_changed, etc. -- but allow file_share (image uploads)
-  if ("subtype" in event && event.subtype) {
-    const allowedSubtypes = new Set(["file_share"]);
-    if (!allowedSubtypes.has(event.subtype as string)) {
-      logger.debug("Skipping message with subtype", { subtype: event.subtype });
-      return null;
-    }
+  // Skip system/meta subtypes but allow content-bearing ones (forwarded, shared, edited, file_share, etc.)
+  const ignoredSubtypes = new Set([
+    "channel_join",
+    "channel_leave",
+    "channel_topic",
+    "channel_purpose",
+    "channel_name",
+    "channel_archive",
+    "channel_unarchive",
+    "bot_add",
+    "bot_remove",
+    "pinned_item",
+    "unpinned_item",
+  ]);
+
+  if ("subtype" in event && event.subtype && ignoredSubtypes.has(event.subtype as string)) {
+    logger.debug("Skipping message with ignored subtype", { subtype: event.subtype });
+    return null;
   }
 
   // Skip messages from our own bot
@@ -78,9 +97,19 @@ export function buildMessageContext(
     return null;
   }
 
-  const text = "text" in event ? (event.text || "") : "";
+  let text = "text" in event ? (event.text || "") : "";
   const userId = "user" in event ? event.user! : "";
   const channelId = event.channel;
+
+  // If primary text is empty, try extracting from attachments (forwarded/shared messages)
+  if (!text.trim() && "attachments" in event && Array.isArray(event.attachments)) {
+    const attachmentTexts = event.attachments
+      .map((a) => a.text || a.fallback || "")
+      .filter((t) => t.trim());
+    if (attachmentTexts.length > 0) {
+      text = attachmentTexts.join("\n");
+    }
+  }
 
   // Allow empty text if the message has file attachments (image-only messages)
   const hasFiles = Array.isArray((event as any).files) && (event as any).files.length > 0;


### PR DESCRIPTION
Fixes #126 by switching `buildMessageContext` to a blocklist for message subtypes and extracting text from attachments, preventing silent drops of forwarded and shared messages.

The previous `buildMessageContext` implementation used an allowlist that only processed `file_share` messages, causing all other message types—including forwarded, shared, and edited messages—to be silently dropped from the pipeline. This PR reverses that logic to process all messages except explicitly ignored system/meta events, and also ensures content within attachments is captured when `event.text` is empty.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1383f752-76fc-4e0d-a778-6a926370498b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1383f752-76fc-4e0d-a778-6a926370498b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Slack event parsing that mainly broadens which messages enter the pipeline; risk is limited to potentially processing some additional message subtypes unexpectedly.
> 
> **Overview**
> Fixes message ingestion in `buildMessageContext` so forwarded/shared/edited Slack messages are no longer silently skipped. It replaces the previous subtype allowlist with an explicit blocklist of system/meta subtypes, and falls back to extracting text from `attachments` (using `text`/`fallback`) when the top-level `event.text` is empty.
> 
> Also extends the local Slack event typing with a `SlackAttachment` interface and optional `attachments` on `SlackMessageEvent` to support the new parsing logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3949c4c2571fd5ecb6f271917b201fd1071ffc0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->