### PR TITLE
feat: Extract rich content from messages (attachments, blocks, forwards, files)

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -96,6 +96,64 @@ const channelIdNameCache = new Map<string, { id: string; name: string; is_privat
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
+ * Extract text from all rich-content locations in a Slack message.
+ * Slack messages can carry content in msg.text, attachments (forwarded/shared
+ * messages), rich_text blocks, and file shares.
+ */
+function extractFullMessageText(msg: any): string {
+  const parts: string[] = [];
+  if (msg.text) parts.push(msg.text);
+  if (Array.isArray(msg.attachments)) {
+    for (const att of msg.attachments) {
+      const attParts: string[] = [];
+      if (att.pretext) attParts.push(att.pretext);
+      if (att.title) attParts.push(att.title);
+      if (att.text) attParts.push(att.text);
+      else if (att.fallback) attParts.push(att.fallback);
+      if (attParts.length > 0) {
+        const label = att.is_msg_unfurl ? "[forwarded message]" : "[attachment]";
+        parts.push(`${label} ${attParts.join(" — ")}`);
+      }
+    }
+  }
+  if (Array.isArray(msg.blocks)) {
+    for (const block of msg.blocks) {
+      if (block.type === "rich_text" && Array.isArray(block.elements)) {
+        for (const section of block.elements) {
+          if (Array.isArray(section.elements)) {
+            const sectionText = section.elements
+              .filter((el: any) => el.type === "text" && el.text)
+              .map((el: any) => el.text)
+              .join("");
+            if (sectionText) parts.push(sectionText);
+          }
+        }
+      }
+    }
+  }
+  if (Array.isArray(msg.files)) {
+    for (const file of msg.files) {
+      const fileName = file.title || file.name || "unnamed file";
+      const fileType = file.filetype || "unknown";
+      parts.push(`[file: ${fileName} (${fileType})]`);
+    }
+  }
+  return parts.filter(Boolean).join("\n") || "";
+}
+
+function generateAttachmentsSummary(msg: any): string | null {
+  if (!Array.isArray(msg.attachments) || msg.attachments.length === 0) return null;
+  const summaries = msg.attachments.map((att: any) => {
+    const parts: string[] = [];
+    if (att.author_name) parts.push(`from: ${att.author_name}`);
+    if (att.title) parts.push(att.title);
+    if (att.text) parts.push(att.text.substring(0, 200));
+    return parts.join(" — ") || att.fallback || "attachment";
+  });
+  return summaries.join("; ");
+}
+
+/**
  * Search for a public channel by name using the user token.
  * The bot token's conversations.list only returns channels the bot is in,
  * so we need the user token to find channels the bot hasn't joined yet.
@@ -750,10 +808,12 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
               const userName = msg.user
                 ? await resolveUserById(client, msg.user)
                 : "unknown";
+              const attachmentsSummary = generateAttachmentsSummary(msg);
               return {
                 user: userName,
-                text: msg.text || "",
+                text: extractFullMessageText(msg),
                 timestamp: msg.ts || "",
+                ...(attachmentsSummary ? { attachments_summary: attachmentsSummary } : {}),
                 reactions:
                   (msg as any).reactions?.map((r: any) => ({
                     name: r.name,
@@ -1275,7 +1335,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
                       return {
                         user: replyUserName,
                         user_id: reply.user || "",
-                        text: reply.text || "",
+                        text: extractFullMessageText(reply),
                         timestamp: reply.ts || "",
                       };
                     }),
@@ -1289,11 +1349,13 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
                 }
               }
 
+              const attachmentsSummary = generateAttachmentsSummary(msg);
               return {
                 user: userName,
                 user_id: msg.user || "",
-                text: msg.text || "",
+                text: extractFullMessageText(msg),
                 timestamp: msg.ts || "",
+                ...(attachmentsSummary ? { attachments_summary: attachmentsSummary } : {}),
                 ...(replyCount != null && replyCount > 0
                   ? { reply_count: replyCount, thread_ts: threadTs, latest_reply: latestReply }
                   : {}),


### PR DESCRIPTION
## What
Adds `extractFullMessageText()` and `generateAttachmentsSummary()` helpers to `src/tools/slack.ts`.

Applied to both `read_channel_history` and `read_dm_history` tools.

**Forwarded messages**, **attachments**, **rich text blocks**, and **files** are now properly extracted instead of showing as empty text.

## Why
This was the root cause of the Jakub incident — forwarded messages appeared as empty `text` because content lived in `attachments[]` or `blocks[]` and we only read `msg.text`.

## Changes
- `extractFullMessageText(msg)`: extracts text from `msg.text`, `attachments[].text`, `blocks[].elements`, and `files[]`
- `generateAttachmentsSummary(msg)`: creates a brief summary of attachments for metadata
- Both helpers used in `read_channel_history` and `read_dm_history` message mapping

Rebased cleanly on top of #130 and #132.

Fixes #125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Slack message formatting/serialization for history reads; the main risk is minor output-shape/content changes for consumers of these tool responses.
> 
> **Overview**
> Slack history reads now return *complete message text* by extracting content not only from `msg.text` but also from `attachments` (including forwarded/unfurled messages), `rich_text` blocks, and shared `files`.
> 
> `read_channel_history` and `read_dm_history` (including threaded DM replies) switch from `msg.text` to `extractFullMessageText()` and optionally include an `attachments_summary` field derived from `generateAttachmentsSummary()` to surface attachment context in responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3d7dcbd4786c5ddd9944c7833ab1ae9b61989da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->