### PR TITLE
Stderr in sandbox errors

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -202,8 +202,20 @@ function getToolOutput(toolName: string, output: any): string | undefined {
     case "execute_query": return `${output.total_rows ?? 0} rows`;
     case "web_search": return `${output.count ?? 0} results`;
     case "search_messages": return `${output.count ?? 0} messages`;
-    case "run_command":
-      return output.exit_code === 0 ? undefined : `Exit code ${output.exit_code}`;
+    case "run_command": {
+      if (output.exit_code === 0) return undefined;
+      const stderr = typeof output.stderr === "string" ? output.stderr.trim() : "";
+      const stdout = typeof output.stdout === "string" ? output.stdout.trim() : "";
+      if (stderr) {
+        const detail = truncate(stderr, 180);
+        return `Exit code ${output.exit_code}: ${detail}`;
+      }
+      if (stdout) {
+        const detail = truncate(stdout, 180);
+        return `Exit code ${output.exit_code}: ${detail}`;
+      }
+      return `Exit code ${output.exit_code}`;
+    }
     case "read_channel_history": return `${output.count ?? 0} messages`;
     case "inspect_table":
       return `${output.row_count ?? "?"} rows, ${(output.schema ?? []).length} columns`;


### PR DESCRIPTION
Include stderr in sandbox error output for `run_command` failures to provide better diagnostic information.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-09fcc36d-93b9-4d62-9714-b24c1bf27f31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09fcc36d-93b9-4d62-9714-b24c1bf27f31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to user-facing error summarization for `run_command` results with minimal behavioral impact beyond improved diagnostics.
> 
> **Overview**
> Improves Slack task card diagnostics for `run_command` failures by expanding `getToolOutput` to include a truncated snippet of `stderr` (falling back to `stdout`) alongside the non-zero exit code.
> 
> Successful commands remain unchanged (no output summary), and failures with no captured output still show just `Exit code N`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 481a2c1edb9108606d5b94acece216cddb5d7652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->