### PR TITLE
feat: inject VERCEL_TOKEN into sandbox for self-diagnosis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ CRON_SECRET=your-cron-secret
 # GitHub (optional, for self-access and PRs)
 # GITHUB_TOKEN=github_pat_your-token
 
+# Vercel (optional, read-only — for self-diagnosing crashes via `vercel logs`)
+# VERCEL_TOKEN=your-vercel-token
+
 # Upstash Redis (shared rate limiting across serverless instances)
 # If using Vercel KV integration, these are set automatically:
 # KV_REST_API_URL=https://your-db.upstash.io

--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -40,6 +40,9 @@ export function getSandboxEnvs(): Record<string, string> {
   if (process.env.DATABASE_URL) {
     envs.DATABASE_URL = process.env.DATABASE_URL;
   }
+  if (process.env.VERCEL_TOKEN) {
+    envs.VERCEL_TOKEN = process.env.VERCEL_TOKEN;
+  }
   return envs;
 }
 


### PR DESCRIPTION
## Summary

- Injects `VERCEL_TOKEN` into the E2B sandbox env vars (same pattern as `GITHUB_TOKEN`, `DATABASE_URL`)
- Documents the new optional env var in `.env.example`
- Token already set in Vercel production via `vercel env add`

## What this unlocks

Aura can now run `vercel logs` and `vercel inspect` from the sandbox to self-diagnose crashes — no more Joan-as-a-log-relay. Currently every crash costs 10-30 min of manual log forwarding.

## Scope

- Token is **read-only** (logs, inspect, list deployments)
- No deploy permissions

## Test plan

- [ ] Merge and verify Aura can run `npx vercel logs aura-alpha-five.vercel.app --scope realadvisor` from the sandbox
- [ ] Trigger a test failure and confirm Aura can identify the error from logs


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive env-var plumbing and documentation only; risk is limited to ensuring the token is handled securely and not inadvertently logged/exfiltrated by sandbox commands.
> 
> **Overview**
> Allows the E2B sandbox to access Vercel in a read-only way by injecting `VERCEL_TOKEN` into the per-command sandbox environment (`getSandboxEnvs`).
> 
> Documents the new optional `VERCEL_TOKEN` in `.env.example` for local/dev configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4448a6bce2e87e8ff75052c7833ac897a571bee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->