### PR TITLE
Streaming message continuation

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -507,6 +507,13 @@ export async function generateResponse(
               await tryStreamAppend({ markdown_text: before });
             }
 
+            if (streamingFailed) {
+              fallbackStartIdx = accumulatedText.length - remaining.length - before.length;
+              break;
+            }
+
+            if (!remaining) break;
+
             logger.info("Splitting stream for continuation message", {
               currentStreamLength,
               totalAccumulated: accumulatedText.length,
@@ -649,6 +656,9 @@ export async function generateResponse(
     const totalTokens = inputTokens + outputTokens;
 
     if (streamingFailed) {
+      // Stop the current streamer to avoid leaving an orphaned stream on Slack
+      try { await streamer.stop(); } catch { /* stream may already be broken */ }
+
       // Fallback: post the unsent portion via chat.postMessage.
       // If a continuation split partially succeeded, only post text that
       // wasn't already streamed (fallbackStartIdx marks the boundary).


### PR DESCRIPTION
Adds graceful stream continuation to prevent `msg_too_long` crashes in Slack streaming responses for long LLM outputs.

The Slack API's `chatStream` rejects `append()` calls when total content exceeds ~40K characters, leading to unrecoverable mid-stream crashes. This PR implements a cascading boundary detection strategy (newline, sentence, word, hard stop) to automatically split long responses into multiple messages within the same thread, ensuring seamless delivery without truncation.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6fd6328c-2328-4431-b38a-fada095ce696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fd6328c-2328-4431-b38a-fada095ce696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Slack streaming logic and introduces stream stop/restart behavior; bugs could cause duplicated/missing output or stuck/orphaned streams in long responses.
> 
> **Overview**
> Prevents Slack `chatStream.append()` failures on long LLM outputs by adding **stream continuation**: as the stream nears Slack’s ~40k character limit, the code now splits outgoing deltas at newline/sentence/whitespace (or a hard cutoff), stops the current stream, and starts a new one to continue in the same thread.
> 
> Improves fallback behavior by tracking the boundary of what was already streamed and, if streaming later fails, posting only the *unsent* remainder via `chat.postMessage` (and attempting to stop any partially-open stream to avoid orphaned streams).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45c7d554806a1dd92b9fd41ba05c1c6a20b75198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->