### PR TITLE
feat: auto-save OAuth token + HTML emails with signature

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -333,11 +333,91 @@ app.get("/api/oauth/google/callback", async (c) => {
   const { exchangeCodeForTokens } = await import("./lib/gmail.js");
   const result = await exchangeCodeForTokens(code);
   if (!result.refreshToken) return c.json({ error: "Token exchange failed", detail: result.error || "No refresh token returned" }, 500);
+
+  // Auto-save refresh token to Vercel env vars
+  const vercelToken = process.env.VERCEL_TOKEN;
+  const teamId = process.env.VERCEL_TEAM_ID;
+  if (vercelToken && teamId) {
+    try {
+      const envName = "GOOGLE_EMAIL_REFRESH_TOKEN";
+      const baseUrl = `https://api.vercel.com/v9/projects/aura/env?teamId=${teamId}`;
+
+      // Check if env var already exists
+      const listRes = await fetch(baseUrl, {
+        headers: { Authorization: `Bearer ${vercelToken}` },
+      });
+      const listData = (await listRes.json()) as { envs?: Array<{ id: string; key: string }> };
+      const existing = listData.envs?.find((e: { key: string }) => e.key === envName);
+
+      if (existing) {
+        // Update existing
+        await fetch(
+          `https://api.vercel.com/v9/projects/aura/env/${existing.id}?teamId=${teamId}`,
+          {
+            method: "PATCH",
+            headers: {
+              Authorization: `Bearer ${vercelToken}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ value: result.refreshToken }),
+          },
+        );
+      } else {
+        // Create new
+        await fetch(`https://api.vercel.com/v10/projects/aura/env?teamId=${teamId}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${vercelToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            key: envName,
+            value: result.refreshToken,
+            target: ["production"],
+            type: "encrypted",
+          }),
+        });
+      }
+
+      // Trigger production redeploy
+      const deploysRes = await fetch(
+        `https://api.vercel.com/v6/deployments?teamId=${teamId}&projectId=aura&limit=1&target=production&state=READY`,
+        { headers: { Authorization: `Bearer ${vercelToken}` } },
+      );
+      const deploysData = (await deploysRes.json()) as { deployments?: Array<{ uid: string }> };
+      const latestDeploy = deploysData.deployments?.[0];
+      if (latestDeploy) {
+        await fetch(`https://api.vercel.com/v13/deployments?teamId=${teamId}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${vercelToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: "aura",
+            deploymentId: latestDeploy.uid,
+            target: "production",
+          }),
+        });
+      }
+
+      logger.info("OAuth refresh token auto-saved to Vercel and redeploy triggered");
+      return c.json({
+        success: true,
+        message: "Gmail connected! Refresh token saved to Vercel and redeploy triggered. Email will be active in ~3 minutes.",
+      });
+    } catch (saveError: any) {
+      logger.error("Failed to auto-save refresh token to Vercel", { error: saveError.message });
+      // Fall through to manual instructions
+    }
+  }
+
+  // Fallback: show token for manual setup
   return c.json({
     success: true,
     refresh_token: result.refreshToken,
     instructions:
-      "Add this refresh token as GOOGLE_EMAIL_REFRESH_TOKEN in Vercel env vars, then redeploy.",
+      "Auto-save failed. Add this refresh token as GOOGLE_EMAIL_REFRESH_TOKEN in Vercel env vars, then redeploy.",
   });
 });
 

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -48,6 +48,24 @@ const SCOPES = [
   "https://www.googleapis.com/auth/gmail.modify",
 ];
 
+// ── Email Signature ─────────────────────────────────────────────────────────
+
+const EMAIL_SIGNATURE_HTML = `
+<div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid #e0e0e0; font-family: Arial, sans-serif; font-size: 13px; color: #666;">
+  <strong style="color: #333;">Aura</strong> &middot; AI Team Member<br/>
+  <a href="https://www.realadvisor.com" style="color: #0066cc; text-decoration: none;">RealAdvisor</a>
+</div>`.trim();
+
+const EMAIL_SIGNATURE_TEXT = `\n--\nAura · AI Team Member\nRealAdvisor · https://www.realadvisor.com`;
+
+function textToHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\n/g, "<br/>");
+}
+
 function getRedirectUri(): string {
   const host =
     process.env.VERCEL_PROJECT_PRODUCTION_URL ||
@@ -115,23 +133,42 @@ function buildMimeMessage(
 ): string {
   const auraEmail =
     process.env.AURA_EMAIL_ADDRESS || "aura@realadvisor.com";
-  const lines: string[] = [
+  const boundary = `boundary_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const htmlBody = `<div style="font-family: Arial, sans-serif; font-size: 14px; color: #333; line-height: 1.6;">${textToHtml(body)}</div>\n${EMAIL_SIGNATURE_HTML}`;
+  const textBody = `${body}${EMAIL_SIGNATURE_TEXT}`;
+
+  const headers: string[] = [
     `From: Aura <${auraEmail}>`,
     `To: ${to}`,
     `Subject: ${subject}`,
     "MIME-Version: 1.0",
-    'Content-Type: text/plain; charset="UTF-8"',
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
   ];
 
-  if (options?.cc) lines.push(`Cc: ${options.cc}`);
-  if (options?.bcc) lines.push(`Bcc: ${options.bcc}`);
+  if (options?.cc) headers.push(`Cc: ${options.cc}`);
+  if (options?.bcc) headers.push(`Bcc: ${options.bcc}`);
   if (options?.replyToMessageId) {
-    lines.push(`In-Reply-To: ${options.replyToMessageId}`);
-    lines.push(`References: ${options.replyToMessageId}`);
+    headers.push(`In-Reply-To: ${options.replyToMessageId}`);
+    headers.push(`References: ${options.replyToMessageId}`);
   }
 
-  lines.push("", body);
-  return lines.join("\r\n");
+  const parts = [
+    headers.join("\r\n"),
+    "",
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    "",
+    textBody,
+    "",
+    `--${boundary}`,
+    'Content-Type: text/html; charset="UTF-8"',
+    "",
+    htmlBody,
+    "",
+    `--${boundary}--`,
+  ];
+
+  return parts.join("\r\n");
 }
 
 function getHeader(


### PR DESCRIPTION
## Changes

### 1. OAuth callback auto-saves refresh token (closes #174)
The callback endpoint now automatically saves the refresh token to Vercel env vars via the Vercel API and triggers a production redeploy. No more manual copy-paste.

Flow: Google consent → callback → exchange code → save token → redeploy → done.

Falls back to displaying the token if auto-save fails (missing VERCEL_TOKEN or VERCEL_TEAM_ID).

### 2. HTML emails with signature (closes #172)
Emails now send as `multipart/alternative` with both HTML and plain text parts.

**HTML part:** Clean, professional styling with signature block:
> **Aura** · AI Team Member
> [RealAdvisor](https://www.realadvisor.com)

**Plain text part:** Same content with text signature for clients that don't render HTML.

### Files changed
- `src/app.ts` — OAuth callback with Vercel API integration
- `src/lib/gmail.ts` — HTML email builder with signature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deployment configuration by programmatically writing env vars and triggering redeploys; incorrect Vercel API behavior or credentials could break email auth setup. Email MIME format changes may affect how some clients render messages or handle threading/headers.
> 
> **Overview**
> Adds automation to the Gmail OAuth callback to **persist the returned refresh token into Vercel project env vars** (create-or-update `GOOGLE_EMAIL_REFRESH_TOKEN`) and **trigger a production redeploy** via the Vercel API, with a fallback response that returns the token for manual setup if auto-save fails.
> 
> Updates outbound Gmail message construction to send `multipart/alternative` emails (plain-text + HTML) and appends a standardized Aura/RealAdvisor signature to both formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba62e2039e719ccbc500d05fedb431575bc6fbb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->