### PR TITLE
feat: Google Workspace Directory integration

### DIFF
--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -46,6 +46,7 @@ const SCOPES = [
   "https://www.googleapis.com/auth/gmail.send",
   "https://www.googleapis.com/auth/gmail.readonly",
   "https://www.googleapis.com/auth/gmail.modify",
+  "https://www.googleapis.com/auth/admin.directory.user.readonly",
 ];
 
 // ── Email Signature ─────────────────────────────────────────────────────────

--- a/src/lib/workspace-directory.ts
+++ b/src/lib/workspace-directory.ts
@@ -1,0 +1,246 @@
+import { logger } from "./logger.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface DirectoryUser {
+  email: string;
+  name: string;
+  title?: string;
+  department?: string;
+  phone?: string;
+  orgUnitPath?: string;
+  isAdmin: boolean;
+  suspended: boolean;
+  lastLoginTime?: string;
+  thumbnailPhotoUrl?: string;
+}
+
+// ── Auth ────────────────────────────────────────────────────────────────────
+
+function getCredentials() {
+  const clientId = process.env.GOOGLE_EMAIL_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_EMAIL_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_EMAIL_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    return null;
+  }
+  return { clientId, clientSecret, refreshToken };
+}
+
+let cachedAccessToken: { token: string; expiresAt: number } | null = null;
+
+async function getAccessToken(): Promise<string | null> {
+  if (cachedAccessToken && Date.now() < cachedAccessToken.expiresAt - 60_000) {
+    return cachedAccessToken.token;
+  }
+
+  const creds = getCredentials();
+  if (!creds) return null;
+
+  const resp = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: creds.clientId,
+      client_secret: creds.clientSecret,
+      refresh_token: creds.refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+
+  if (!resp.ok) {
+    logger.error("Failed to refresh access token for directory", {
+      status: resp.status,
+      body: await resp.text(),
+    });
+    return null;
+  }
+
+  const data = (await resp.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+  cachedAccessToken = {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+  return data.access_token;
+}
+
+// ── Directory API ───────────────────────────────────────────────────────────
+
+function parseUser(user: Record<string, unknown>): DirectoryUser {
+  const primaryEmail = (user.primaryEmail as string) || "";
+  const name = user.name as Record<string, string> | undefined;
+  const fullName = name?.fullName || `${name?.givenName || ""} ${name?.familyName || ""}`.trim();
+
+  return {
+    email: primaryEmail,
+    name: fullName,
+    title: (user.organizations as Array<Record<string, string>>)?.[0]?.title,
+    department: (user.organizations as Array<Record<string, string>>)?.[0]?.department,
+    phone: (user.phones as Array<Record<string, string>>)?.[0]?.value,
+    orgUnitPath: user.orgUnitPath as string | undefined,
+    isAdmin: (user.isAdmin as boolean) || false,
+    suspended: (user.suspended as boolean) || false,
+    lastLoginTime: user.lastLoginTime as string | undefined,
+    thumbnailPhotoUrl: user.thumbnailPhotoUrl as string | undefined,
+  };
+}
+
+/**
+ * List all users in the Google Workspace directory.
+ */
+export async function listDirectoryUsers(
+  options: { maxResults?: number; query?: string; orderBy?: string } = {}
+): Promise<DirectoryUser[] | null> {
+  const token = await getAccessToken();
+  if (!token) return null;
+
+  const params = new URLSearchParams({
+    customer: "my_customer",
+    maxResults: String(options.maxResults || 100),
+    projection: "full",
+    orderBy: options.orderBy || "email",
+  });
+
+  if (options.query) {
+    params.set("query", options.query);
+  }
+
+  const allUsers: DirectoryUser[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    if (pageToken) params.set("pageToken", pageToken);
+
+    const resp = await fetch(
+      `https://admin.googleapis.com/admin/directory/v1/users?${params}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      logger.error("Directory API list users failed", {
+        status: resp.status,
+        body,
+      });
+      return null;
+    }
+
+    const data = (await resp.json()) as {
+      users?: Record<string, unknown>[];
+      nextPageToken?: string;
+    };
+
+    if (data.users) {
+      allUsers.push(...data.users.map(parseUser));
+    }
+    pageToken = data.nextPageToken;
+  } while (pageToken && allUsers.length < (options.maxResults || 100));
+
+  return allUsers;
+}
+
+/**
+ * Search for a user by name or email in the directory.
+ */
+export async function searchDirectoryUser(
+  query: string
+): Promise<DirectoryUser[] | null> {
+  const token = await getAccessToken();
+  if (!token) return null;
+
+  // Try exact email lookup first
+  if (query.includes("@")) {
+    const resp = await fetch(
+      `https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(query)}?projection=full`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (resp.ok) {
+      const user = (await resp.json()) as Record<string, unknown>;
+      return [parseUser(user)];
+    }
+    // Fall through to search if exact lookup fails
+  }
+
+  // Search by name or email prefix
+  // The Directory API supports queries like: name:'John' email:'john@'
+  const params = new URLSearchParams({
+    customer: "my_customer",
+    maxResults: "10",
+    projection: "full",
+    query: `name:'${query}' email:'${query}'`,
+  });
+
+  const resp = await fetch(
+    `https://admin.googleapis.com/admin/directory/v1/users?${params}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!resp.ok) {
+    // Try with just name query (OR doesn't work, need separate call)
+    const nameParams = new URLSearchParams({
+      customer: "my_customer",
+      maxResults: "10",
+      projection: "full",
+      query: `name:'${query}'`,
+    });
+
+    const nameResp = await fetch(
+      `https://admin.googleapis.com/admin/directory/v1/users?${nameParams}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (!nameResp.ok) {
+      const body = await nameResp.text();
+      logger.error("Directory API search failed", {
+        status: nameResp.status,
+        body,
+        query,
+      });
+      return null;
+    }
+
+    const nameData = (await nameResp.json()) as {
+      users?: Record<string, unknown>[];
+    };
+    return nameData.users?.map(parseUser) || [];
+  }
+
+  const data = (await resp.json()) as {
+    users?: Record<string, unknown>[];
+  };
+  return data.users?.map(parseUser) || [];
+}
+
+/**
+ * Get a specific user by email.
+ */
+export async function getDirectoryUser(
+  email: string
+): Promise<DirectoryUser | null> {
+  const token = await getAccessToken();
+  if (!token) return null;
+
+  const resp = await fetch(
+    `https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(email)}?projection=full`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    const body = await resp.text();
+    logger.error("Directory API get user failed", {
+      status: resp.status,
+      body,
+      email,
+    });
+    return null;
+  }
+
+  const user = (await resp.json()) as Record<string, unknown>;
+  return parseUser(user);
+}

--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -257,5 +257,122 @@ export function createEmailTools() {
         }
       },
     }),
+
+    // ── Workspace Directory Tools ───────────────────────────────────────────
+
+    lookup_workspace_user: tool({
+      description:
+        "Look up a person in the Google Workspace directory by name or email. Returns their email, title, department, and other org info. Use this to find someone's email address before sending them an email.",
+      inputSchema: z.object({
+        query: z
+          .string()
+          .describe(
+            "Name or email to search for, e.g. 'Joan Rodriguez' or 'joan@realadvisor.com'"
+          ),
+      }),
+      execute: async ({ query }) => {
+        try {
+          const { searchDirectoryUser } = await import(
+            "../lib/workspace-directory.js"
+          );
+          const users = await searchDirectoryUser(query);
+          if (!users) {
+            return {
+              ok: false,
+              error:
+                "Workspace Directory is not configured or the API returned an error. The OAuth token may need the admin.directory.user.readonly scope.",
+            };
+          }
+
+          if (users.length === 0) {
+            return {
+              ok: true,
+              message: `No users found matching "${query}"`,
+              users: [],
+            };
+          }
+
+          logger.info("lookup_workspace_user tool called", {
+            query,
+            resultCount: users.length,
+          });
+
+          return {
+            ok: true,
+            users: users.map((u) => ({
+              email: u.email,
+              name: u.name,
+              title: u.title || undefined,
+              department: u.department || undefined,
+              isAdmin: u.isAdmin,
+            })),
+          };
+        } catch (error: any) {
+          logger.error("lookup_workspace_user failed", {
+            query,
+            error: error.message,
+          });
+          return {
+            ok: false,
+            error: `Failed to search directory: ${error.message}`,
+          };
+        }
+      },
+    }),
+
+    list_workspace_users: tool({
+      description:
+        "List all users in the Google Workspace directory. Returns emails, names, titles, and departments for everyone in the organization.",
+      inputSchema: z.object({
+        max_results: z
+          .number()
+          .optional()
+          .default(100)
+          .describe("Maximum number of users to return (default 100)"),
+      }),
+      execute: async ({ max_results }) => {
+        try {
+          const { listDirectoryUsers } = await import(
+            "../lib/workspace-directory.js"
+          );
+          const users = await listDirectoryUsers({
+            maxResults: max_results,
+          });
+          if (!users) {
+            return {
+              ok: false,
+              error:
+                "Workspace Directory is not configured or the API returned an error.",
+            };
+          }
+
+          logger.info("list_workspace_users tool called", {
+            resultCount: users.length,
+          });
+
+          return {
+            ok: true,
+            count: users.length,
+            users: users
+              .filter((u) => !u.suspended)
+              .map((u) => ({
+                email: u.email,
+                name: u.name,
+                title: u.title || undefined,
+                department: u.department || undefined,
+                isAdmin: u.isAdmin,
+              })),
+          };
+        } catch (error: any) {
+          logger.error("list_workspace_users failed", {
+            error: error.message,
+          });
+          return {
+            ok: false,
+            error: `Failed to list directory users: ${error.message}`,
+          };
+        }
+      },
+    }),
   };
 }


### PR DESCRIPTION
## What
Adds two new tools: `lookup_workspace_user` and `list_workspace_users` that query the Google Admin Directory API. This lets me resolve any team member's email, title, and department without asking.

## Changes
- **`src/lib/workspace-directory.ts`** (new) — Directory API client with search, list, and get user functions. Uses raw REST calls (no heavy SDK).
- **`src/tools/email.ts`** — Two new tools added to the email tools set:
  - `lookup_workspace_user` — search by name or email
  - `list_workspace_users` — list all org members
- **`src/lib/gmail.ts`** — Added `admin.directory.user.readonly` OAuth scope

## Note
After deploying, the OAuth flow needs to be re-run once to grant the new directory scope. The existing refresh token only covers Gmail scopes.

Closes #169

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new calls to the Google Admin Directory API and expands OAuth scopes, which can impact permissioning and runtime behavior if tokens/scopes are misconfigured.
> 
> **Overview**
> Adds Google Workspace Directory integration so the AI email toolset can **search or list org users** and return basic profile/org info (email, name, title, department, admin flag).
> 
> Introduces a new `workspace-directory` client that refreshes/caches an access token from the existing Google OAuth refresh token and calls the Admin Directory REST API for `searchDirectoryUser`, `listDirectoryUsers`, and `getDirectoryUser`. Updates Gmail OAuth scopes to include `admin.directory.user.readonly`, which requires re-consenting to grant the new permission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb1f5b350463b8132e65422db2f1a2850135c9f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->