### PR TITLE
feat: store OAuth refresh token in database (not env vars)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -330,95 +330,28 @@ app.get("/api/oauth/google/auth-url", async (c) => {
 app.get("/api/oauth/google/callback", async (c) => {
   const code = c.req.query("code");
   if (!code) return c.json({ error: "No auth code received" }, 400);
-  const { exchangeCodeForTokens } = await import("./lib/gmail.js");
+  const { exchangeCodeForTokens, saveRefreshToken } = await import("./lib/gmail.js");
   const result = await exchangeCodeForTokens(code);
   if (!result.refreshToken) return c.json({ error: "Token exchange failed", detail: result.error || "No refresh token returned" }, 500);
 
-  // Auto-save refresh token to Vercel env vars
-  const vercelToken = process.env.VERCEL_TOKEN;
-  const teamId = process.env.VERCEL_TEAM_ID;
-  if (vercelToken && teamId) {
-    try {
-      const envName = "GOOGLE_EMAIL_REFRESH_TOKEN";
-      const baseUrl = `https://api.vercel.com/v9/projects/aura/env?teamId=${teamId}`;
-
-      // Check if env var already exists
-      const listRes = await fetch(baseUrl, {
-        headers: { Authorization: `Bearer ${vercelToken}` },
-      });
-      const listData = (await listRes.json()) as { envs?: Array<{ id: string; key: string }> };
-      const existing = listData.envs?.find((e: { key: string }) => e.key === envName);
-
-      if (existing) {
-        // Update existing
-        await fetch(
-          `https://api.vercel.com/v9/projects/aura/env/${existing.id}?teamId=${teamId}`,
-          {
-            method: "PATCH",
-            headers: {
-              Authorization: `Bearer ${vercelToken}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ value: result.refreshToken }),
-          },
-        );
-      } else {
-        // Create new
-        await fetch(`https://api.vercel.com/v10/projects/aura/env?teamId=${teamId}`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${vercelToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            key: envName,
-            value: result.refreshToken,
-            target: ["production"],
-            type: "encrypted",
-          }),
-        });
-      }
-
-      // Trigger production redeploy
-      const deploysRes = await fetch(
-        `https://api.vercel.com/v6/deployments?teamId=${teamId}&projectId=aura&limit=1&target=production&state=READY`,
-        { headers: { Authorization: `Bearer ${vercelToken}` } },
-      );
-      const deploysData = (await deploysRes.json()) as { deployments?: Array<{ uid: string }> };
-      const latestDeploy = deploysData.deployments?.[0];
-      if (latestDeploy) {
-        await fetch(`https://api.vercel.com/v13/deployments?teamId=${teamId}`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${vercelToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            name: "aura",
-            deploymentId: latestDeploy.uid,
-            target: "production",
-          }),
-        });
-      }
-
-      logger.info("OAuth refresh token auto-saved to Vercel and redeploy triggered");
-      return c.json({
-        success: true,
-        message: "Gmail connected! Refresh token saved to Vercel and redeploy triggered. Email will be active in ~3 minutes.",
-      });
-    } catch (saveError: any) {
-      logger.error("Failed to auto-save refresh token to Vercel", { error: saveError.message });
-      // Fall through to manual instructions
-    }
+  // Save refresh token to database — no env var or redeploy needed
+  try {
+    await saveRefreshToken(result.refreshToken);
+    logger.info("OAuth refresh token saved to database");
+    return c.json({
+      success: true,
+      message: "Gmail connected! Refresh token saved to database. Email is active immediately — no redeploy needed.",
+    });
+  } catch (saveError: any) {
+    logger.error("Failed to save refresh token to database", { error: saveError.message });
+    // Fallback: show token for manual setup
+    return c.json({
+      success: true,
+      refresh_token: result.refreshToken,
+      instructions:
+        "Auto-save to database failed. Add this refresh token as GOOGLE_EMAIL_REFRESH_TOKEN in Vercel env vars, then redeploy.",
+    });
   }
-
-  // Fallback: show token for manual setup
-  return c.json({
-    success: true,
-    refresh_token: result.refreshToken,
-    instructions:
-      "Auto-save failed. Add this refresh token as GOOGLE_EMAIL_REFRESH_TOKEN in Vercel env vars, then redeploy.",
-  });
 });
 
 // ── Cursor Agent Webhook ───────────────────────────────────────────────────

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -76,14 +76,39 @@ function getRedirectUri(): string {
   return `${protocol}://${host}/api/oauth/google/callback`;
 }
 
+const SETTINGS_KEY = "google_refresh_token";
+
+async function getRefreshToken(): Promise<string | null> {
+  // DB is source of truth; env var is fallback for migration
+  try {
+    const { getSetting } = await import("./settings.js");
+    const dbToken = await getSetting(SETTINGS_KEY);
+    if (dbToken) return dbToken;
+  } catch {
+    // DB unavailable — fall back to env
+  }
+  return process.env.GOOGLE_EMAIL_REFRESH_TOKEN || null;
+}
+
+/**
+ * Save a refresh token to the database.
+ * Called by the OAuth callback after exchanging an auth code.
+ */
+export async function saveRefreshToken(token: string): Promise<void> {
+  const { setSetting } = await import("./settings.js");
+  await setSetting(SETTINGS_KEY, token, "oauth-callback");
+  logger.info("Refresh token saved to database");
+}
+
 async function getOAuth2Client() {
   const clientId = process.env.GOOGLE_EMAIL_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_EMAIL_CLIENT_SECRET;
-  const refreshToken = process.env.GOOGLE_EMAIL_REFRESH_TOKEN;
 
   if (!clientId || !clientSecret) {
     return null;
   }
+
+  const refreshToken = await getRefreshToken();
 
   const { OAuth2Client } = await import("google-auth-library");
   const oauth2Client = new OAuth2Client(
@@ -106,9 +131,10 @@ export async function getGmailClient() {
   const auth = await getOAuth2Client();
   if (!auth) return null;
 
-  // Verify we have a refresh token
-  if (!process.env.GOOGLE_EMAIL_REFRESH_TOKEN) {
-    logger.warn("Gmail: No refresh token configured");
+  // Verify we have a refresh token (check DB + env)
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) {
+    logger.warn("Gmail: No refresh token configured (checked DB and env)");
     return null;
   }
 


### PR DESCRIPTION
## What
Moves the Google OAuth refresh token from Vercel env vars to the PostgreSQL settings table.

## Why
Jonas correctly pointed out that storing tokens in env vars is wrong:
- Every token rotation requires a redeploy (~3 min downtime)
- The Vercel API dance (list envs → upsert → trigger redeploy) is 60 lines of fragile code
- DB storage means instant activation, no redeploy, no Vercel API dependency

## Changes
**`src/lib/gmail.ts`**
- New `getRefreshToken()` — reads from `settings` table first, falls back to env var for migration
- New `saveRefreshToken(token)` — exported for the callback to use
- `getOAuth2Client()` and `getGmailClient()` now use `getRefreshToken()` instead of raw env var

**`src/app.ts`**
- OAuth callback simplified: exchanges code → saves to DB → done
- Removed all Vercel API calls (list envs, upsert, trigger redeploy)
- Net -41 lines

## Migration
The env var fallback means existing deployments with `GOOGLE_EMAIL_REFRESH_TOKEN` set will continue to work. Once the token is in the DB (via the next OAuth flow), the env var can be removed.

Closes #174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth credentials are stored and loaded for Gmail; misconfiguration or DB outages could break email until fallback/env is used, but scope is limited and includes a fallback path.
> 
> **Overview**
> Moves Gmail OAuth refresh-token persistence from Vercel env vars to the database.
> 
> The `/api/oauth/google/callback` flow now calls `saveRefreshToken()` and returns success immediately, removing the Vercel env upsert + redeploy logic; on DB write failure it falls back to returning the token with manual env-var instructions. `src/lib/gmail.ts` adds DB-backed token read/write via the `settings` table (with env-var fallback for migration) and updates `getOAuth2Client()`/`getGmailClient()` to use this shared lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e020a49d1b0b08d0e336f2c957787028830fd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->