### PR TITLE
fix: workspace directory reads refresh token from DB

### DIFF
--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -80,7 +80,7 @@ function getRedirectUri(): string {
 
 const SETTINGS_KEY = "google_refresh_token";
 
-async function getRefreshToken(): Promise<string | null> {
+export async function getRefreshToken(): Promise<string | null> {
   // DB is source of truth; env var is fallback for migration
   try {
     const { getSetting } = await import("./settings.js");

--- a/src/lib/workspace-directory.ts
+++ b/src/lib/workspace-directory.ts
@@ -1,4 +1,5 @@
 import { logger } from "./logger.js";
+import { getRefreshToken } from "./gmail.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -17,10 +18,10 @@ export interface DirectoryUser {
 
 // ── Auth ────────────────────────────────────────────────────────────────────
 
-function getCredentials() {
+async function getCredentials() {
   const clientId = process.env.GOOGLE_EMAIL_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_EMAIL_CLIENT_SECRET;
-  const refreshToken = process.env.GOOGLE_EMAIL_REFRESH_TOKEN;
+  const refreshToken = await getRefreshToken();
 
   if (!clientId || !clientSecret || !refreshToken) {
     return null;
@@ -35,7 +36,7 @@ async function getAccessToken(): Promise<string | null> {
     return cachedAccessToken.token;
   }
 
-  const creds = getCredentials();
+  const creds = await getCredentials();
   if (!creds) return null;
 
   const resp = await fetch("https://oauth2.googleapis.com/token", {


### PR DESCRIPTION
## What
The workspace-directory module was reading the refresh token directly from `process.env.GOOGLE_EMAIL_REFRESH_TOKEN`, bypassing the DB-first storage from PR #178. Now imports `getRefreshToken()` from gmail.ts which reads from DB first with env var fallback.

## Changes
- Export `getRefreshToken()` from gmail.ts
- workspace-directory.ts imports and uses it instead of reading env vars directly
- 5 lines changed, 4 deleted

## Why
Without this fix, the directory module would fail after the env var is eventually removed, even though the token is in the database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small credential-source change that reuses existing token lookup logic; main risk is potential runtime dependency/import issues or DB unavailability affecting directory auth, with env var still as fallback.
> 
> **Overview**
> Updates Google Workspace Directory auth to reuse `gmail.getRefreshToken()` (DB-first with env fallback) instead of reading `GOOGLE_EMAIL_REFRESH_TOKEN` directly from the environment.
> 
> Exports `getRefreshToken()` from `gmail.ts` and makes `workspace-directory.ts` credential loading async so directory access token refresh uses the same centralized refresh-token source as the rest of the Google integrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 636c5b12e12750372af951226849a8a9a548ff24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->