### PR TITLE
feat: switch directory to People API (no admin needed)

### DIFF
--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -46,7 +46,7 @@ const SCOPES = [
   "https://www.googleapis.com/auth/gmail.send",
   "https://www.googleapis.com/auth/gmail.readonly",
   "https://www.googleapis.com/auth/gmail.modify",
-  "https://www.googleapis.com/auth/admin.directory.user.readonly",
+  "https://www.googleapis.com/auth/directory.readonly",
   "https://www.googleapis.com/auth/calendar.readonly",
   "https://www.googleapis.com/auth/calendar.events",
 ];

--- a/src/lib/workspace-directory.ts
+++ b/src/lib/workspace-directory.ts
@@ -9,11 +9,6 @@ export interface DirectoryUser {
   title?: string;
   department?: string;
   phone?: string;
-  orgUnitPath?: string;
-  isAdmin: boolean;
-  suspended: boolean;
-  lastLoginTime?: string;
-  thumbnailPhotoUrl?: string;
 }
 
 // ── Auth ────────────────────────────────────────────────────────────────────
@@ -69,83 +64,31 @@ async function getAccessToken(): Promise<string | null> {
   return data.access_token;
 }
 
-// ── Directory API ───────────────────────────────────────────────────────────
+// ── People API ──────────────────────────────────────────────────────────────
 
-function parseUser(user: Record<string, unknown>): DirectoryUser {
-  const primaryEmail = (user.primaryEmail as string) || "";
-  const name = user.name as Record<string, string> | undefined;
-  const fullName = name?.fullName || `${name?.givenName || ""} ${name?.familyName || ""}`.trim();
+interface PeopleConnection {
+  names?: Array<{ displayName?: string }>;
+  emailAddresses?: Array<{ value?: string }>;
+  organizations?: Array<{ title?: string; department?: string }>;
+  phoneNumbers?: Array<{ value?: string }>;
+}
+
+function parsePerson(person: PeopleConnection): DirectoryUser | null {
+  const email = person.emailAddresses?.[0]?.value;
+  const name = person.names?.[0]?.displayName;
+  if (!email || !name) return null;
 
   return {
-    email: primaryEmail,
-    name: fullName,
-    title: (user.organizations as Array<Record<string, string>>)?.[0]?.title,
-    department: (user.organizations as Array<Record<string, string>>)?.[0]?.department,
-    phone: (user.phones as Array<Record<string, string>>)?.[0]?.value,
-    orgUnitPath: user.orgUnitPath as string | undefined,
-    isAdmin: (user.isAdmin as boolean) || false,
-    suspended: (user.suspended as boolean) || false,
-    lastLoginTime: user.lastLoginTime as string | undefined,
-    thumbnailPhotoUrl: user.thumbnailPhotoUrl as string | undefined,
+    email,
+    name,
+    title: person.organizations?.[0]?.title,
+    department: person.organizations?.[0]?.department,
+    phone: person.phoneNumbers?.[0]?.value,
   };
 }
 
 /**
- * List all users in the Google Workspace directory.
- */
-export async function listDirectoryUsers(
-  options: { maxResults?: number; query?: string; orderBy?: string } = {}
-): Promise<DirectoryUser[] | null> {
-  const token = await getAccessToken();
-  if (!token) return null;
-
-  const params = new URLSearchParams({
-    customer: "my_customer",
-    maxResults: String(options.maxResults || 100),
-    projection: "full",
-    orderBy: options.orderBy || "email",
-  });
-
-  if (options.query) {
-    params.set("query", options.query);
-  }
-
-  const allUsers: DirectoryUser[] = [];
-  let pageToken: string | undefined;
-
-  do {
-    if (pageToken) params.set("pageToken", pageToken);
-
-    const resp = await fetch(
-      `https://admin.googleapis.com/admin/directory/v1/users?${params}`,
-      { headers: { Authorization: `Bearer ${token}` } }
-    );
-
-    if (!resp.ok) {
-      const body = await resp.text();
-      logger.error("Directory API list users failed", {
-        status: resp.status,
-        body,
-      });
-      return null;
-    }
-
-    const data = (await resp.json()) as {
-      users?: Record<string, unknown>[];
-      nextPageToken?: string;
-    };
-
-    if (data.users) {
-      allUsers.push(...data.users.map(parseUser));
-    }
-    pageToken = data.nextPageToken;
-  } while (pageToken && allUsers.length < (options.maxResults || 100));
-
-  return allUsers;
-}
-
-/**
- * Search for a user by name or email in the directory.
+ * Search the workspace directory by name or email.
  */
 export async function searchDirectoryUser(
   query: string
@@ -153,68 +96,64 @@ export async function searchDirectoryUser(
   const token = await getAccessToken();
   if (!token) return null;
 
-  // Try exact email lookup first
-  if (query.includes("@")) {
-    const resp = await fetch(
-      `https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(query)}?projection=full`,
-      { headers: { Authorization: `Bearer ${token}` } }
-    );
-
-    if (resp.ok) {
-      const user = (await resp.json()) as Record<string, unknown>;
-      return [parseUser(user)];
-    }
-    // Fall through to search if exact lookup fails
-  }
-
-  // Search by name or email prefix
-  // The Directory API supports queries like: name:'John' email:'john@'
+  // People API directory search
   const params = new URLSearchParams({
-    customer: "my_customer",
-    maxResults: "10",
-    projection: "full",
-    query: `name:'${query}' email:'${query}'`,
+    query,
+    readMask: "names,emailAddresses,organizations,phoneNumbers",
+    sources: "DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE",
+    pageSize: "10",
   });
 
   const resp = await fetch(
-    `https://admin.googleapis.com/admin/directory/v1/users?${params}`,
+    `https://people.googleapis.com/v1/people:searchDirectoryPeople?${params}`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
 
   if (!resp.ok) {
-    // Try with just name query (OR doesn't work, need separate call)
-    const nameParams = new URLSearchParams({
-      customer: "my_customer",
-      maxResults: "10",
-      projection: "full",
-      query: `name:'${query}'`,
+    const body = await resp.text();
+    logger.error("People API directory search failed", {
+      status: resp.status,
+      body,
+      query,
     });
-
-    const nameResp = await fetch(
-      `https://admin.googleapis.com/admin/directory/v1/users?${nameParams}`,
-      { headers: { Authorization: `Bearer ${token}` } }
-    );
-
-    if (!nameResp.ok) {
-      const body = await nameResp.text();
-      logger.error("Directory API search failed", {
-        status: nameResp.status,
-        body,
-        query,
-      });
-      return null;
-    }
-
-    const nameData = (await nameResp.json()) as {
-      users?: Record<string, unknown>[];
-    };
-    return nameData.users?.map(parseUser) || [];
+    return null;
   }
 
-  const data = (await resp.json()) as {
-    users?: Record<string, unknown>[];
-  };
-  return data.users?.map(parseUser) || [];
+  const data = (await resp.json()) as { people?: PeopleConnection[] };
+  return (data.people || []).map(parsePerson).filter(Boolean) as DirectoryUser[];
+}
+
+/**
+ * List workspace directory users.
+ */
+export async function listDirectoryUsers(
+  maxResults = 100
+): Promise<DirectoryUser[] | null> {
+  const token = await getAccessToken();
+  if (!token) return null;
+
+  const params = new URLSearchParams({
+    readMask: "names,emailAddresses,organizations,phoneNumbers",
+    sources: "DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE",
+    pageSize: String(Math.min(maxResults, 200)),
+  });
+
+  const resp = await fetch(
+    `https://people.googleapis.com/v1/people:listDirectoryPeople?${params}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    logger.error("People API directory list failed", {
+      status: resp.status,
+      body,
+    });
+    return null;
+  }
+
+  const data = (await resp.json()) as { people?: PeopleConnection[] };
+  return (data.people || []).map(parsePerson).filter(Boolean) as DirectoryUser[];
 }
 
 /**
@@ -223,25 +162,12 @@ export async function searchDirectoryUser(
 export async function getDirectoryUser(
   email: string
 ): Promise<DirectoryUser | null> {
-  const token = await getAccessToken();
-  if (!token) return null;
-
-  const resp = await fetch(
-    `https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(email)}?projection=full`,
-    { headers: { Authorization: `Bearer ${token}` } }
+  // Search by email and find exact match
+  const results = await searchDirectoryUser(email);
+  if (!results) return null;
+  return (
+    results.find(
+      (u) => u.email.toLowerCase() === email.toLowerCase()
+    ) || results[0] || null
   );
-
-  if (!resp.ok) {
-    if (resp.status === 404) return null;
-    const body = await resp.text();
-    logger.error("Directory API get user failed", {
-      status: resp.status,
-      body,
-      email,
-    });
-    return null;
-  }
-
-  const user = (await resp.json()) as Record<string, unknown>;
-  return parseUser(user);
 }

--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -280,7 +280,7 @@ export function createEmailTools() {
             return {
               ok: false,
               error:
-                "Workspace Directory is not configured or the API returned an error. The OAuth token may need the admin.directory.user.readonly scope.",
+                "Workspace Directory is not configured or the API returned an error. The OAuth token may need the directory.readonly scope.",
             };
           }
 
@@ -304,7 +304,6 @@ export function createEmailTools() {
               name: u.name,
               title: u.title || undefined,
               department: u.department || undefined,
-              isAdmin: u.isAdmin,
             })),
           };
         } catch (error: any) {
@@ -335,9 +334,7 @@ export function createEmailTools() {
           const { listDirectoryUsers } = await import(
             "../lib/workspace-directory.js"
           );
-          const users = await listDirectoryUsers({
-            maxResults: max_results,
-          });
+          const users = await listDirectoryUsers(max_results);
           if (!users) {
             return {
               ok: false,
@@ -353,14 +350,11 @@ export function createEmailTools() {
           return {
             ok: true,
             count: users.length,
-            users: users
-              .filter((u) => !u.suspended)
-              .map((u) => ({
+            users: users.map((u) => ({
                 email: u.email,
                 name: u.name,
                 title: u.title || undefined,
                 department: u.department || undefined,
-                isAdmin: u.isAdmin,
               })),
           };
         } catch (error: any) {


### PR DESCRIPTION
## What
Replaces #181 (which had build errors). Switches Workspace Directory from Admin SDK to People API.

## Changes
- **People API** instead of Admin SDK (`searchDirectoryPeople` / `listDirectoryPeople`)
- **`directory.readonly`** scope instead of `admin.directory.user.readonly`
- No admin role needed for `aura@realadvisor.com`
- Removed `isAdmin`/`suspended` fields (not in People API)
- Fixed tool definitions in email.ts to match new interface
- Net -80 lines

## After merge
One OAuth re-auth to pick up `directory.readonly` + Calendar scopes.

Closes #169

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external Google API endpoints and required OAuth scopes, which can break directory features until tokens are re-consented and People API responses match assumptions (email/name present, page sizing).
> 
> **Overview**
> Switches Workspace Directory lookups from the Admin SDK Directory API to the Google People API (`people:searchDirectoryPeople` / `people:listDirectoryPeople`), removing admin-only fields and simplifying pagination/limits.
> 
> Updates OAuth consent scopes from `admin.directory.user.readonly` to `directory.readonly`, and aligns the email tools (`lookup_workspace_user`, `list_workspace_users`) with the new `DirectoryUser` shape and `listDirectoryUsers(maxResults)` signature (dropping `isAdmin`/`suspended` handling and updating error messaging).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d574c0f73b30b2c2eb6e49172ba3666d8c7bb00d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->