### PR TITLE
Sandbox environment keys

### DIFF
--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -43,6 +43,9 @@ export function getSandboxEnvs(): Record<string, string> {
   if (process.env.VERCEL_TOKEN) {
     envs.VERCEL_TOKEN = process.env.VERCEL_TOKEN;
   }
+  if (process.env.OPENAI_API_KEY) {
+    envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+  }
   return envs;
 }
 


### PR DESCRIPTION
Pass `OPENAI_API_KEY` to the E2B sandbox environment to resolve GitHub issue #168.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-feca0ef0-d235-4324-bd98-51e045acb20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-feca0ef0-d235-4324-bd98-51e045acb20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change that only expands the set of forwarded environment variables; main risk is unintended key exposure inside the sandbox runtime.
> 
> **Overview**
> Passes `OPENAI_API_KEY` through `getSandboxEnvs()` so E2B sandbox commands inherit the OpenAI credential alongside existing tokens.
> 
> This enables OpenAI-dependent tooling inside the sandbox without additional manual configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 562d19b273dcce4afeaed25b827f61d3d93b5c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->