### PR TITLE
Conversation search mode

### DIFF
--- a/src/tools/conversations.ts
+++ b/src/tools/conversations.ts
@@ -290,6 +290,11 @@ export function createConversationSearchTools() {
                 ) as MessageRow[];
 
                 const matchIds = new Set(thread.messages.map((m) => m.id));
+                const matchScoreMap = new Map(
+                  thread.messages
+                    .filter((m) => m.similarity_score != null)
+                    .map((m) => [m.id, m.similarity_score!]),
+                );
                 const contextIds = new Set(contextRows.map((r) => r.id));
                 const contextMessages = contextRows.map((r) => ({
                   id: r.id,
@@ -302,7 +307,14 @@ export function createConversationSearchTools() {
                       : new Date(r.created_at).toISOString(),
                   channel_id: r.channel_id,
                   channel_type: r.channel_type,
-                  ...(matchIds.has(r.id) ? { matched: true } : {}),
+                  ...(matchIds.has(r.id)
+                    ? {
+                        matched: true,
+                        ...(matchScoreMap.has(r.id)
+                          ? { similarity_score: matchScoreMap.get(r.id) }
+                          : {}),
+                      }
+                    : {}),
                 }));
                 const missingMatches = thread.messages
                   .filter((m) => !contextIds.has(m.id))


### PR DESCRIPTION
Add a `mode` parameter to the `search_my_conversations` tool to enable semantic search.

This PR introduces a `mode` parameter (`"text"` or `"semantic"`, defaulting to `"text"`) to the `search_my_conversations` tool. When `mode: "semantic"`, the tool performs a cosine similarity search using message embeddings, returning results ordered by similarity and including a `similarity_score`. The existing text search functionality remains unchanged when `mode: "text"` or omitted.

---
<p><a href="https://cursor.com/agents?id=bc-f425554a-3a2e-46ac-950c-e8ba56dfa9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f425554a-3a2e-46ac-950c-e8ba56dfa9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new DB query path using embeddings/vector ops and changes the tool response shape to optionally include similarity scores, which could affect performance and consumers expecting prior output.
> 
> **Overview**
> Adds a new `mode` parameter to the `search_my_conversations` tool (`text` default, `semantic`) and updates the tool description/schema to document both search behaviors.
> 
> In `semantic` mode, the tool embeds the query via `embedText` and runs a vector-similarity SQL query against `messages.embedding`, returning results ordered by similarity and surfacing `similarity_score` on matched messages (including when thread context is expanded). Logging and responses now include the selected `mode`, and semantic mode enforces that `query` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c201e0c93485ae383f6e8bbafcefce27864e659b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->