### PR TITLE
Sandbox error output handling

### DIFF
--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -87,6 +87,26 @@ export function createSandboxTools(context?: ScheduleContext) {
             stderr: stderr || undefined,
           };
         } catch (error: any) {
+          // E2B's CommandExitError implements CommandResult with exitCode/stdout/stderr
+          if ("exitCode" in error && typeof error.exitCode === "number") {
+            const stdout = truncateOutput(error.stdout || "", 4000);
+            const stderr = truncateOutput(error.stderr || "", 2000);
+
+            logger.info("run_command tool: non-zero exit", {
+              command: command.substring(0, 100),
+              exitCode: error.exitCode,
+              stdoutLength: (error.stdout || "").length,
+              stderrLength: (error.stderr || "").length,
+            });
+
+            return {
+              ok: true,
+              exit_code: error.exitCode,
+              stdout,
+              stderr: stderr || undefined,
+            };
+          }
+
           logger.error("run_command tool failed", {
             command: command.substring(0, 100),
             error: error.message,


### PR DESCRIPTION
Fixes `sandbox.ts` to correctly extract `stdout`/`stderr` from `CommandExitError` instead of discarding them.

Previously, commands exiting with a non-zero status would return a generic "Command execution failed" message, losing valuable debugging information from `stdout` and `stderr`. This change ensures that the full command output is returned, even for failed commands, improving observability and debugging capabilities.

---
<p><a href="https://cursor.com/agents?id=bc-d6458d16-d7af-4620-ae73-e37b7a7082c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6458d16-d7af-4620-ae73-e37b7a7082c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change that only affects how non-zero exits are reported and logged; no auth or data model changes.
> 
> **Overview**
> Updates `run_command` in `src/tools/sandbox.ts` to treat E2B `CommandExitError` (non-zero exits) as a successful tool response, returning the captured `exit_code`, truncated `stdout`, and `stderr` instead of falling back to generic failure handling.
> 
> Adds dedicated logging for non-zero exits while keeping existing timeout and unexpected-error behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c45f67b151820a96bdf7a7c43d8ef74d9be87599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->