### PR TITLE
Cached sandbox timeout

### DIFF
--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -8,6 +8,20 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 let cachedSandbox: any | null = null;
 
 /**
+ * Clear the cached sandbox reference so the next call to
+ * getOrCreateSandbox() creates a fresh instance. Call this when a
+ * sandbox becomes unresponsive (e.g. after a command timeout).
+ */
+export function clearCachedSandbox(): void {
+  if (cachedSandbox) {
+    logger.info("Clearing cached sandbox reference", {
+      sandboxId: cachedSandbox.sandboxId,
+    });
+    cachedSandbox = null;
+  }
+}
+
+/**
  * Dynamically import the E2B SDK.
  * Kept as dynamic import so the module only loads when sandbox
  * tools are actually called (not on every cold start).
@@ -83,6 +97,14 @@ export async function getOrCreateSandbox(): Promise<any> {
       const sandbox = await Sandbox.connect(savedId, {
         timeoutMs: DEFAULT_TIMEOUT_MS,
       });
+
+      // Health check: verify the sandbox is actually responsive
+      const healthCheck = await sandbox.commands.run("echo ok", {
+        timeoutMs: 5_000,
+      });
+      if (healthCheck.exitCode !== 0) {
+        throw new Error("Health check failed after resume");
+      }
 
       cachedSandbox = sandbox;
       logger.info("E2B sandbox resumed", { sandboxId: savedId });

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -4,6 +4,7 @@ import {
   getOrCreateSandbox,
   getSandboxEnvs,
   truncateOutput,
+  clearCachedSandbox,
 } from "../lib/sandbox.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
@@ -93,6 +94,7 @@ export function createSandboxTools(context?: ScheduleContext) {
           });
 
           if (error.message?.includes("timed out")) {
+            clearCachedSandbox();
             return {
               ok: false,
               error: `Command timed out after ${timeout_seconds} seconds. Try increasing timeout_seconds or breaking the command into smaller steps.`,


### PR DESCRIPTION
Clear cached sandbox after timeout and add a health check on resume to prevent zombie reuse and fix #188.

---
<p><a href="https://cursor.com/agents?id=bc-e83d7c07-de6d-45d1-ae51-fe4e5bf67abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e83d7c07-de6d-45d1-ae51-fe4e5bf67abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to sandbox lifecycle and error handling; primary risk is false negatives/extra sandbox creation if the health check or timeout detection is overly strict.
> 
> **Overview**
> Improves E2B sandbox resiliency by avoiding reuse of “zombie” cached sandboxes.
> 
> Adds `clearCachedSandbox()` to reset the per-invocation sandbox cache (with logging) and calls it when `run_command` hits a timeout so subsequent executions create a fresh sandbox.
> 
> When resuming a saved sandbox ID, `getOrCreateSandbox()` now runs a short `echo ok` health check and falls back to creating a new sandbox if the resumed instance isn’t responsive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24297d9b98f7b362b1b6b6df7b408d65b6741cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->