### PR TITLE
Streaming response splitting

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -702,7 +702,7 @@ export async function generateResponse(
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           resetTimer();
 
-          if (currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
+          if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
             if (!await splitToNewStream() && streamingFailed) {
               fallbackStartIdx = accumulatedText.length;
             }
@@ -745,7 +745,7 @@ export async function generateResponse(
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           resetTimer();
 
-          if (currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
+          if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
             if (!await splitToNewStream() && streamingFailed) {
               fallbackStartIdx = accumulatedText.length;
             }


### PR DESCRIPTION
Split long streaming responses into multiple Slack messages to prevent `msg_too_long` errors and truncation.

This PR addresses GitHub issue #192 by implementing a robust splitting mechanism for long streaming responses. It introduces `estimateAppendSize()` to accurately track the combined length of text and rendered tool cards. When the accumulated length approaches Slack's message limit, a new message is posted at the same thread level using the `splitToNewStream()` helper. A fallback `isMsgTooLong()` error handler ensures graceful recovery if proactive splitting is insufficient, and a maximum of 5 continuation messages are supported.

---
<p><a href="https://cursor.com/agents?id=bc-22f8e459-dcde-4ec7-ba72-7dc75eb64904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22f8e459-dcde-4ec7-ba72-7dc75eb64904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Slack streaming loop and error handling; mistakes could cause truncated/missing output or unexpected fallback behavior, but the change is bounded and includes explicit caps and logging.
> 
> **Overview**
> Prevents Slack `chatStream` failures for long responses by proactively splitting streaming output into up to `MAX_CONTINUATIONS` continuation messages and tracking per-stream size more accurately.
> 
> Adds explicit detection/logging for `msg_too_long`, introduces `estimateAppendSize()` so tool card updates contribute to `currentStreamLength`, and centralizes stream rollover logic in `splitToNewStream()` (including periodic splits after tool updates and a fallback to `postMessage` when splitting or streaming fails).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acd5128d61a7a523d38d9bc3037fede7f6516016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->