### PR TITLE
Dm thread title logic

### DIFF
--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -590,7 +590,16 @@ async function runBackgroundTasks(params: {
       displayName,
     });
 
-    // Set or update DM thread title for the Assistant History tab
+    // Record interaction and potentially update profile
+    await recordInteraction(context.userId);
+    await updateProfileFromConversation(
+      context.userId,
+      context.text,
+      response,
+    );
+
+    // Set or update DM thread title for the Assistant History tab.
+    // Runs last so the LLM call doesn't delay critical background work above.
     if (context.isDm) {
       if (!context.threadTs) {
         // Phase 1: Generate initial title after first assistant response
@@ -613,14 +622,6 @@ async function runBackgroundTasks(params: {
         });
       }
     }
-
-    // Record interaction and potentially update profile
-    await recordInteraction(context.userId);
-    await updateProfileFromConversation(
-      context.userId,
-      context.text,
-      response,
-    );
   } catch (error: any) {
     recordError("backgroundTasks", error, { userId: context.userId });
     logError({
@@ -633,6 +634,11 @@ async function runBackgroundTasks(params: {
       stackTrace: error?.stack,
     });
   }
+}
+
+/** Strip wrapping quotes and trailing punctuation that LLMs sometimes add despite instructions. */
+function sanitizeTitle(raw: string): string {
+  return raw.trim().replace(/^["'""]+|["'""]+$/g, "").replace(/[.!;:]+$/, "").trim();
 }
 
 /**
@@ -652,19 +658,19 @@ async function setInitialDmThreadTitle(params: {
     const { getFastModel } = await import("../lib/ai.js");
     const { generateText } = await import("ai");
     const fastModel = await getFastModel();
-    const { text: title } = await generateText({
+    const { text: raw } = await generateText({
       model: fastModel,
+      maxOutputTokens: 40,
       prompt: `Summarize this conversation in 5-8 words for a thread title. Be concise and descriptive of the topic. No quotes, no punctuation at the end.\n\nUser: "${userMessage.slice(0, 300)}"\n\nAssistant: "${assistantResponse.slice(0, 500)}"`,
     });
+    const title = sanitizeTitle(raw).slice(0, 100);
+    if (!title) return;
     await client.assistant.threads.setTitle({
       channel_id: channelId,
       thread_ts: threadTs,
-      title: title.slice(0, 100),
+      title,
     });
-    logger.info("Set initial DM thread title", {
-      title: title.slice(0, 100),
-      channelId,
-    });
+    logger.info("Set initial DM thread title", { title, channelId });
   } catch (error: any) {
     logger.warn("Failed to set DM thread title", {
       error: error?.message || String(error),
@@ -704,20 +710,21 @@ async function maybeUpdateDmThreadTitle(params: {
       .map(m => `${m.displayName}: ${m.text.slice(0, 150)}`)
       .join("\n");
 
-    const { text: newTitle } = await generateText({
+    const { text: raw } = await generateText({
       model: fastModel,
+      maxOutputTokens: 40,
       prompt: `Generate a concise thread title (5-8 words) that describes the current main topic of this Slack DM conversation. No quotes, no punctuation at the end.\n\nRecent messages:\n${messagesContext}\n\nLatest assistant response: "${assistantResponse.slice(0, 300)}"`,
     });
 
-    const trimmed = newTitle.trim();
-    if (trimmed.length > 0) {
+    const newTitle = sanitizeTitle(raw).slice(0, 100);
+    if (newTitle) {
       await client.assistant.threads.setTitle({
         channel_id: channelId,
         thread_ts: threadTs,
-        title: trimmed.slice(0, 100),
+        title: newTitle,
       });
       logger.info("Updated DM thread title at checkpoint", {
-        newTitle: trimmed.slice(0, 100),
+        newTitle,
         channelId,
         messageCount: totalMessages,
       });


### PR DESCRIPTION
Overhaul DM thread title generation to provide more descriptive and dynamically updated titles.

The previous title generation logic created unhelpful titles based only on the first user message and never updated them. This PR implements two phases:
1.  **Better initial titles:** Titles are now generated after the first assistant response, using both the user's message and the assistant's response for improved context.
2.  **Periodic re-evaluation:** A new background task periodically checks if the thread topic has shifted (every ~5 messages) and updates the title using a fast model and recent messages. Error logging for title setting was also improved.

---
<p><a href="https://cursor.com/agents?id=bc-79c8157c-3851-4843-93bb-94601bc726bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79c8157c-3851-4843-93bb-94601bc726bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces additional LLM and Slack `setTitle` calls in background tasks, which could impact latency/cost/rate limits or cause unexpected title churn, but is isolated to DM thread titling.
> 
> **Overview**
> Overhauls DM thread title generation for Slack DMs by creating the initial title *after* the first assistant response (using both user + assistant text) instead of only the first user message.
> 
> Adds a periodic background re-titling checkpoint for ongoing DM threads (~every 5 messages) using recent thread context, plus `sanitizeTitle` and improved logging/guardrails; the pipeline now passes thread message count and recent messages into `runBackgroundTasks` to support this.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4407418e8b2b73374834eb7350cbd1cf5cd7da70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->