### PR TITLE
Timestamp format standardization

### DIFF
--- a/src/lib/temporal.ts
+++ b/src/lib/temporal.ts
@@ -77,46 +77,7 @@ export function relativeTime(date: Date, now?: Date): string {
 }
 
 /**
- * Short timezone abbreviation from Intl output.
- * Intl.DateTimeFormat with `timeZoneName: "short"` produces strings like
- * "2/20/2026, 9:32 AM CET". We extract the trailing abbreviation.
- */
-function getShortTzName(date: Date, tz: string): string {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: tz,
-      timeZoneName: "short",
-    }).formatToParts(date);
-    const tzPart = parts.find((p) => p.type === "timeZoneName");
-    return tzPart?.value || tz;
-  } catch {
-    return tz;
-  }
-}
-
-/**
- * Compact relative label for timestamps within the last 7 days.
- * Returns null for dates older than 7 days.
- */
-function compactRelative(date: Date, now: Date): string | null {
-  const diffMs = now.getTime() - date.getTime();
-  if (diffMs < 0) return "in the future";
-
-  const seconds = Math.floor(diffMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-
-  if (seconds < 60) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  if (hours < 24) return `${hours}h ago`;
-  if (days === 1) return "yesterday";
-  if (days < 7) return `${days}d ago`;
-  return null;
-}
-
-/**
- * Convert any timestamp to a human-readable string with optional timezone.
+ * Convert any timestamp to ISO 8601 in the user's timezone.
  *
  * Accepted inputs:
  *  - Slack message ts (e.g. "1740045172.123456")
@@ -124,8 +85,7 @@ function compactRelative(date: Date, now: Date): string | null {
  *  - Date object
  *  - Unix epoch in seconds or milliseconds (number)
  *
- * Output: "Fri, 20 Feb, 09:32 CET (3h ago)"
- * The relative suffix is only appended for timestamps < 7 days old.
+ * Output: "2026-02-20T14:32:54+01:00"
  *
  * @param input  Any supported timestamp format
  * @param timezone  IANA timezone string (default "UTC")
@@ -142,10 +102,8 @@ export function formatTimestamp(
   if (input instanceof Date) {
     date = input;
   } else if (typeof input === "number") {
-    // Heuristic: if < 1e12 it's seconds, otherwise milliseconds
     date = input < 1e12 ? new Date(input * 1000) : new Date(input);
   } else {
-    // String: try Slack ts (float seconds) or ISO
     const asNum = Number(input);
     if (!isNaN(asNum) && asNum > 1e8) {
       date = asNum < 1e12 ? new Date(asNum * 1000) : new Date(asNum);
@@ -156,44 +114,48 @@ export function formatTimestamp(
 
   if (isNaN(date.getTime())) return String(input);
 
-  let effectiveTz = tz;
   try {
-    const formatter = new Intl.DateTimeFormat("en-GB", {
-      timeZone: effectiveTz,
-      weekday: "short",
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-
-    const formatted = formatter.format(date);
-    const tzAbbrev = getShortTzName(date, effectiveTz);
-    const relative = compactRelative(date, new Date());
-    const suffix = relative ? ` (${relative})` : "";
-
-    return `${formatted} ${tzAbbrev}${suffix}`;
+    return toIso8601InTimezone(date, tz);
   } catch {
-    effectiveTz = "UTC";
-    const formatter = new Intl.DateTimeFormat("en-GB", {
-      timeZone: effectiveTz,
-      weekday: "short",
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-
-    const formatted = formatter.format(date);
-    const relative = compactRelative(date, new Date());
-    const suffix = relative ? ` (${relative})` : "";
-
-    return `${formatted} UTC${suffix}`;
+    return toIso8601InTimezone(date, "UTC");
   }
+}
+
+function toIso8601InTimezone(date: Date, tz: string): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "00";
+
+  const year = get("year");
+  const month = get("month");
+  const day = get("day");
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  const minute = get("minute");
+  const second = get("second");
+
+  const utcMs = date.getTime();
+  const localParts = new Date(
+    `${year}-${month}-${day}T${hour}:${minute}:${second}Z`,
+  );
+  const offsetMs = localParts.getTime() - utcMs;
+  const totalMinutes = Math.round(offsetMs / 60000);
+  const sign = totalMinutes >= 0 ? "+" : "-";
+  const absMinutes = Math.abs(totalMinutes);
+  const offH = String(Math.floor(absMinutes / 60)).padStart(2, "0");
+  const offM = String(absMinutes % 60).padStart(2, "0");
+
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}${sign}${offH}:${offM}`;
 }
 
 /**


### PR DESCRIPTION
Simplify `formatTimestamp` to output ISO 8601 to standardize timestamp display across the application.

---
<p><a href="https://cursor.com/agents?id=bc-028ee2bf-b5fa-4731-801c-dc7308ea6153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-028ee2bf-b5fa-4731-801c-dc7308ea6153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the string format emitted by `formatTimestamp`, which can affect any downstream display, parsing, or tests that expect the prior human-readable/relative output.
> 
> **Overview**
> Standardizes `formatTimestamp` to always return an ISO 8601 timestamp with numeric timezone offset (e.g. `2026-02-20T14:32:54+01:00`) for consistent display across the app.
> 
> Removes the previous human-readable formatting (weekday/month strings), timezone abbreviations, and the <7-day compact relative suffix, replacing it with a new `toIso8601InTimezone` helper and a UTC fallback when timezone formatting fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a59c4a7a19ece2eb6bf376800ff3df887d8fe094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->