### PR TITLE
Slack internal error fallback

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -470,17 +470,19 @@ export async function generateResponse(
         try {
           await new Promise(r => setTimeout(r, 500));
           await streamer.append(payload);
-        } catch {
+        } catch (retryErr: any) {
           streamingFailed = true;
-          logger.warn("chatStream append got internal_error twice, falling back to postMessage", {
+          logger.warn("chatStream append failed on retry after internal_error, falling back to postMessage", {
             channelId,
+            originalError: err?.data?.error,
+            retryError: retryErr?.data?.error || retryErr?.message,
           });
           logError({
             errorName: "SlackInternalError",
-            errorMessage: err?.message || "internal_error on stream append",
-            errorCode: "internal_error",
+            errorMessage: retryErr?.message || "error on stream append retry",
+            errorCode: retryErr?.data?.error || "internal_error",
             channelId,
-            context: { fallback: "postMessage", retried: true },
+            context: { fallback: "postMessage", retried: true, originalError: err?.data?.error },
           });
         }
       } else {


### PR DESCRIPTION
Fixes #217: Gracefully handle Slack streaming errors in `tryStreamAppend` by falling back to `postMessage`.

This PR adds a specific handler for Slack's `internal_error` with a retry mechanism and hardens the generic `else` clause to ensure `tryStreamAppend` never throws, preventing responses from dying mid-stream due to transient or unexpected streaming issues.

---
<p><a href="https://cursor.com/agents?id=bc-066560fe-dd5b-4ba1-91be-f5ecf7caebfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066560fe-dd5b-4ba1-91be-f5ecf7caebfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error handling that only affects Slack streaming failure behavior; primary risk is masking a real append bug by falling back more often.
> 
> **Overview**
> Hardens Slack streaming in `tryStreamAppend` so response generation no longer dies on transient or unexpected `chatStream.append` failures.
> 
> Adds a one-time retry for Slack `internal_error` (500ms delay) and changes the generic error path to **log and flip to `postMessage` fallback** instead of throwing, with additional structured error reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eb85038ef87d1f7c47636f61a6f0a9569197e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->