### PR TITLE
Chat stream message handling

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -333,7 +333,11 @@ function formatForSlack(text: string): string {
   });
 
   // Headers → bold (### heading, ## heading, # heading)
-  result = result.replace(/^#{1,6}\s+(.+)$/gm, "*$1*");
+  // Strip inline bold/emphasis markers within headers since the whole header becomes bold
+  result = result.replace(/^#{1,6}\s+(.+)$/gm, (_, content) => {
+    const cleaned = content.replace(/\*\*(.+?)\*\*/g, "$1").replace(/__(.+?)__/g, "$1");
+    return `*${cleaned}*`;
+  });
   // Bold: **text** → *text*
   result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
   // Bold: __text__ → *text*


### PR DESCRIPTION
Fixes `chatStream` `msg_too_long` errors and improves fallback message formatting.

This PR addresses issue #216 by:
- Lowering `chatStream` message length thresholds (7k-9.5k) to align with its ~10k limit, preventing `msg_too_long` errors.
- Converting raw LLM markdown to Slack mrkdwn for fallback `chat.postMessage` responses, ensuring correct display.
- Adding specific handling for `msg_too_long` errors in `streamer.stop()` to finalize streams gracefully when the limit is reached.

---
<p><a href="https://cursor.com/agents?id=bc-f61c9cd1-c2bb-4499-9683-daca57adc3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f61c9cd1-c2bb-4499-9683-daca57adc3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Slack streaming/fallback messaging paths and modifies message splitting/formatting, which can impact user-visible output and stream finalization behavior if edge cases are missed.
> 
> **Overview**
> Reduces `chatStream` continuation split thresholds to align with Slack’s ~10k character limit, lowering the chance of `msg_too_long` errors during streaming.
> 
> When streaming falls back to `chat.postMessage`, it now converts LLM Markdown into Slack `mrkdwn` (e.g., headings/bold) while preserving code blocks, and uses this formatted text for both message `blocks` and top-level `text`.
> 
> Adds explicit handling for `msg_too_long` from `streamer.stop()` by finalizing the stream without a payload and logging the event instead of failing the response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 073e4856f3385f4d792e3c7f53c1c87f9b65583b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->