### PR TITLE
Slack channel type compatibility

### DIFF
--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -6,7 +6,7 @@ import {
   type MessageContext,
 } from "./context.js";
 import { assemblePrompt } from "./prompt.js";
-import { generateResponse } from "./respond.js";
+import { generateResponse, isChannelTypeNotSupported } from "./respond.js";
 import {
   fetchConversationContext,
   resolveDisplayName,
@@ -378,15 +378,14 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
         thread_ts: replyThreadTs,
       });
     } catch (notifyErr: any) {
-      const slackCode = notifyErr?.data?.error;
-      if (slackCode === "channel_type_not_supported") {
+      if (isChannelTypeNotSupported(notifyErr)) {
         logger.info("Error notification skipped — channel type does not support postMessage", {
           channelId: context.channelId,
         });
       } else {
         logger.error("Failed to send error message to Slack", {
           channelId: context.channelId,
-          slackError: slackCode,
+          slackError: notifyErr?.data?.error,
           error: notifyErr?.message || String(notifyErr),
         });
       }

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -291,7 +291,7 @@ export interface LLMResponse {
  * an API method (e.g. `chat.startStream`, `chat.postMessage`) is called on
  * a channel type that doesn't support it (e.g. Slack List internal channels).
  */
-function isChannelTypeNotSupported(error: any): boolean {
+export function isChannelTypeNotSupported(error: any): boolean {
   const msg = error?.message || "";
   const code = error?.data?.error || "";
   return (


### PR DESCRIPTION
Fixes pipeline crashes in Slack List channels by gracefully handling `channel_type_not_supported` errors during `postMessage` operations.

In Slack List channels, the LLM's work is delivered via tool calls (e.g., `send_thread_reply`). Therefore, the final summary `postMessage` is optional, and its failure due to `channel_type_not_supported` should not crash the pipeline or error notification.

---
<p><a href="https://cursor.com/agents?id=bc-398caaf0-3805-411d-a4c6-cf5669789809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398caaf0-3805-411d-a4c6-cf5669789809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling/logging changes around Slack API failures; main risk is unintentionally suppressing legitimate `postMessage` errors in edge cases.
> 
> **Overview**
> Improves compatibility with Slack channel types (e.g. Slack List internal channels) by treating `channel_type_not_supported` as a non-fatal condition when attempting to send messages.
> 
> `respond.ts` generalizes the helper to `isChannelTypeNotSupported`, uses it for both streaming fallback and final `chat.postMessage` fallback handling, and avoids throwing when `postMessage` is unsupported (logging whether tool calls already delivered the response). `index.ts` similarly suppresses error-notification `postMessage` failures for unsupported channels and adds richer logging for other notification failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a11c5e08a84813ff752b4814412fb53680b3cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->