### PR TITLE
Canvas toolkit completion

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2063,6 +2063,8 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
           // user_ids and channel_ids are mutually exclusive in the API,
           // so make separate calls when both are provided
+          let usersShared = false;
+
           if (user_ids?.length) {
             const userResult = await (client as any).apiCall(
               "canvases.access.set",
@@ -2074,6 +2076,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
                 error: `Failed to share canvas with users: ${userResult.error || "unknown error"}`,
               };
             }
+            usersShared = true;
           }
 
           if (channel_ids?.length) {
@@ -2085,6 +2088,9 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
               return {
                 ok: false,
                 error: `Failed to share canvas with channels: ${channelResult.error || "unknown error"}`,
+                partial_success: usersShared
+                  ? "Users were successfully shared before channel sharing failed."
+                  : undefined,
               };
             }
           }


### PR DESCRIPTION
Completes the Slack canvas toolkit by fixing bugs, adding new tools, and expanding `edit_canvas` functionality to address issue #228.

This PR fixes the `read_canvas` and `edit_canvas` rename bugs, adds `delete_canvas`, `share_canvas`, and `list_canvases` tools, and expands the `edit_canvas` tool to support `insert_before`, `insert_after`, and `delete` section operations. These changes enable canvases as a more robust shared output medium for the AI assistant.

---
<p><a href="https://cursor.com/agents?id=bc-6776c6df-55b5-4c33-995b-dc79a5224097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6776c6df-55b5-4c33-995b-dc79a5224097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Slack Canvas mutation capabilities (delete, permission changes, richer edits) that can permanently remove content or broaden access if misused. Changes are localized but depend on correct Slack API semantics and token configuration.
> 
> **Overview**
> Completes the Slack Canvas toolset by fixing API-call issues in `read_canvas` and `edit_canvas`, and expanding supported canvas operations.
> 
> `edit_canvas` now validates required inputs and adds new section-level operations (`insert_before`, `insert_after`, `delete`) alongside improved rename handling. New tools `delete_canvas`, `share_canvas`, and `list_canvases` enable deleting canvases, granting access to users/channels, and listing canvases via `files.list` (user-token required).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75c21e2682c631677e3ad8845c1f39d309672991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->