### PR TITLE
Surrounding channel messages

### DIFF
--- a/src/pipeline/slack-context.ts
+++ b/src/pipeline/slack-context.ts
@@ -321,10 +321,35 @@ export function formatConversationContext(
       thread.length <= MAX_THREAD_MESSAGES
         ? thread
         : [thread[0], ...thread.slice(-MAX_THREAD_MESSAGES + 1)];
-    const formatted = capped
+    const threadFormatted = capped
       .map((m) => formatMessage(m, timezone))
       .join("\n\n");
-    return formatted;
+
+    // Include channel messages posted before the thread root for broader context.
+    // recentMessages are in chronological order (oldest-first after the reverse
+    // in fetchConversationContext), so we take the last N that precede the root.
+    const MAX_SURROUNDING = 5;
+    const threadRootTs = parseFloat(thread[0].ts);
+    const surrounding = conversation.recentMessages
+      .filter((m) => {
+        const ts = parseFloat(m.ts);
+        return ts < threadRootTs && m.ts !== thread[0].ts;
+      })
+      .slice(-MAX_SURROUNDING);
+
+    if (surrounding.length > 0) {
+      const channelFormatted = surrounding
+        .map((m) => formatMessage(m, timezone))
+        .join("\n\n");
+      return (
+        "Channel messages near the thread (for context):\n\n" +
+        channelFormatted +
+        "\n\nRecent thread context:\n\n" +
+        threadFormatted
+      );
+    }
+
+    return threadFormatted;
   }
 
   // Fall back to recent channel/DM messages only when appropriate


### PR DESCRIPTION
Enrich thread context with surrounding channel messages to provide Aura with broader conversational context.

Previously, when Aura was in a thread, it only included thread messages, ignoring channel history. This meant Aura lacked visibility into the initial channel message that might have prompted the thread, or other relevant messages immediately preceding it. This PR resolves GitHub issue #233 by prepending up to 5 relevant channel messages before the thread context.

---
<p><a href="https://cursor.com/agents?id=bc-4f27f8aa-43be-491a-9c55-467c76f8cc43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f27f8aa-43be-491a-9c55-467c76f8cc43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to prompt formatting only; main risk is slightly larger prompts or inclusion of irrelevant nearby channel messages.
> 
> **Overview**
> When formatting Slack thread context for the system prompt, the thread-only output is now enriched with up to 5 of the most recent channel messages that occurred immediately *before* the thread root.
> 
> The formatted prompt is labeled to separate "Channel messages near the thread" from "Recent thread context", while preserving the existing 50-message cap for thread content and keeping the prior channel-history fallback behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fb551a857dc64e6684e4299ce92c3267f486969. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->