### PR TITLE
Email tools pagination

### DIFF
--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -39,6 +39,12 @@ export interface ListEmailsOptions {
   query?: string;
   maxResults?: number;
   unreadOnly?: boolean;
+  pageToken?: string;
+}
+
+export interface ListEmailsResult {
+  emails: EmailSummary[];
+  nextPageToken?: string | null;
 }
 
 // ── OAuth2 Client ───────────────────────────────────────────────────────────
@@ -353,7 +359,7 @@ export async function sendEmail(
 async function listEmailsWithClient(
   gmailClient: any,
   options?: ListEmailsOptions,
-): Promise<EmailSummary[]> {
+): Promise<ListEmailsResult> {
   let q = options?.query || "";
   if (options?.unreadOnly) {
     q = q ? `${q} is:unread` : "is:unread";
@@ -363,12 +369,14 @@ async function listEmailsWithClient(
     userId: "me",
     maxResults: Math.min(options?.maxResults || 10, 20),
     q: q || undefined,
+    pageToken: options?.pageToken || undefined,
   });
 
+  const nextPageToken: string | null = listRes.data.nextPageToken || null;
   const messages = listRes.data.messages || [];
-  if (messages.length === 0) return [];
+  if (messages.length === 0) return { emails: [], nextPageToken };
 
-  const results: EmailSummary[] = await Promise.all(
+  const emails: EmailSummary[] = await Promise.all(
     messages.map(async (msg: any) => {
       const detail = await gmailClient.users.messages.get({
         userId: "me",
@@ -391,7 +399,7 @@ async function listEmailsWithClient(
     }),
   );
 
-  return results;
+  return { emails, nextPageToken };
 }
 
 async function getEmailWithClient(
@@ -429,11 +437,11 @@ async function getEmailWithClient(
  */
 export async function listEmails(
   options?: ListEmailsOptions,
-): Promise<EmailSummary[]> {
+): Promise<ListEmailsResult> {
   const gmail = await getGmailClient();
   if (!gmail) {
     logger.error("Gmail client not available");
-    return [];
+    return { emails: [], nextPageToken: null };
   }
 
   return listEmailsWithClient(gmail, options);
@@ -905,7 +913,7 @@ export async function deleteDraft(
 export async function readUserEmails(
   userId: string,
   options?: ListEmailsOptions,
-): Promise<EmailSummary[] | null> {
+): Promise<ListEmailsResult | null> {
   const result = await getGmailClientForUser(userId);
   if (!result) return null;
 

--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -330,14 +330,14 @@ Tables:
 
 Email:
 - **send_email** — send an email from aura@realadvisor.com (to, cc, bcc, subject, body, optional reply threading)
-- **read_emails** — list recent emails with optional filters (query, unread only)
+- **read_emails** — list recent emails with optional filters (query, unread only). Supports pagination: pass page_token from a previous response's next_page_token to fetch the next page. Returns next_page_token when more results are available.
 - **read_email** — read full content of a specific email by message ID
 - **reply_to_email** — reply to an existing email thread
 
 Gmail (Executive Assistant — acts on behalf of users who granted OAuth access):
 - **create_gmail_draft** — create a draft in a user's Gmail
 - **list_gmail_drafts** — list drafts in a user's Gmail
-- **read_user_emails** — read emails from a user's Gmail inbox
+- **read_user_emails** — read emails from a user's Gmail inbox. Supports pagination: pass page_token from a previous response's next_page_token to fetch the next page. Returns next_page_token when more results are available.
 - **read_user_email** — read a specific email from a user's Gmail
 - **delete_gmail_draft** — delete a draft from a user's Gmail
 - **generate_gmail_auth_url** — generate a Google OAuth link for a user to connect their Gmail. DM the link to them.

--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -89,7 +89,7 @@ export function createEmailTools() {
 
     read_emails: tool({
       description:
-        "Read recent emails from Aura's inbox. Can filter by unread status or search query.",
+        "Read recent emails from Aura's inbox. Can filter by unread status or search query. Supports pagination via page_token.",
       inputSchema: z.object({
         query: z
           .string()
@@ -107,8 +107,12 @@ export function createEmailTools() {
           .optional()
           .default(false)
           .describe("Only show unread emails"),
+        page_token: z
+          .string()
+          .optional()
+          .describe("Page token from a previous response to fetch the next page of results"),
       }),
-      execute: async ({ query, max_results, unread_only }) => {
+      execute: async ({ query, max_results, unread_only, page_token }) => {
         try {
           const { getGmailClient, listEmails } = await import(
             "../lib/gmail.js"
@@ -122,25 +126,27 @@ export function createEmailTools() {
             };
           }
 
-          const emails = await listEmails({
+          const result = await listEmails({
             query,
             maxResults: max_results,
             unreadOnly: unread_only,
+            pageToken: page_token,
           });
 
-          if (!emails) {
+          if (!result) {
             return { ok: false, error: "Failed to list emails: no response from Gmail API" };
           }
 
           logger.info("read_emails tool called", {
             query,
-            count: emails.length,
+            count: result.emails.length,
           });
 
           return {
             ok: true,
-            emails,
-            count: emails.length,
+            emails: result.emails,
+            count: result.emails.length,
+            next_page_token: result.nextPageToken || undefined,
           };
         } catch (error: any) {
           logger.error("read_emails tool failed", {
@@ -784,7 +790,7 @@ export function createGmailEATools() {
 
     read_user_emails: tool({
       description:
-        "Read recent emails from a specific user's Gmail inbox. The user must have granted Aura OAuth access.",
+        "Read recent emails from a specific user's Gmail inbox. The user must have granted Aura OAuth access. Supports pagination via page_token.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -809,8 +815,12 @@ export function createGmailEATools() {
           .optional()
           .default(false)
           .describe("Only show unread emails"),
+        page_token: z
+          .string()
+          .optional()
+          .describe("Page token from a previous response to fetch the next page of results"),
       }),
-      execute: async ({ user_name, query, max_results, unread_only }) => {
+      execute: async ({ user_name, query, max_results, unread_only, page_token }) => {
         try {
           const userId = await resolveSlackUserId(user_name);
           if (!userId) {
@@ -821,13 +831,14 @@ export function createGmailEATools() {
           }
 
           const { readUserEmails } = await import("../lib/gmail.js");
-          const emails = await readUserEmails(userId, {
+          const result = await readUserEmails(userId, {
             query,
             maxResults: max_results,
             unreadOnly: unread_only,
+            pageToken: page_token,
           });
 
-          if (!emails) {
+          if (!result) {
             return {
               ok: false,
               error: `No Gmail access for user '${user_name}'. They need to authorize Aura via OAuth first.`,
@@ -836,8 +847,9 @@ export function createGmailEATools() {
 
           return {
             ok: true,
-            count: emails.length,
-            emails,
+            count: result.emails.length,
+            emails: result.emails,
+            next_page_token: result.nextPageToken || undefined,
           };
         } catch (error: any) {
           logger.error("read_user_emails failed", { error: error.message });


### PR DESCRIPTION
Add pagination (page_token) support to `read_emails` and `read_user_emails` tools to fix GitHub issue #240.

This PR introduces an optional `page_token` parameter to the email listing functions and tools, allowing the retrieval of subsequent pages of email results. The `next_page_token` is now returned by the tools to facilitate further pagination. Tool documentation has been updated to reflect these changes.

---
<p><a href="https://cursor.com/agents?id=bc-fe433e9a-2890-4657-be1f-fb257f606883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe433e9a-2890-4657-be1f-fb257f606883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes return types for `listEmails`/`readUserEmails` and tool response shapes, which can break existing callers expecting a plain array, but the logic change is limited to adding Gmail pagination parameters.
> 
> **Overview**
> Adds pagination support to inbox listing by extending `ListEmailsOptions` with `pageToken` and changing `listEmails`/`readUserEmails` to return a `{ emails, nextPageToken }` result (plumbed through `listEmailsWithClient` to Gmail’s `users.messages.list`).
> 
> Updates the `read_emails` and `read_user_emails` tools to accept `page_token`, pass it through to the library, and return `next_page_token` for fetching subsequent pages; the system prompt tool docs are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee76178936fdaa941f3c2728acab5ccbfc913648. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->