### PR TITLE
Encrypted credential storage UI

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import { waitUntil } from "@vercel/functions";
 import { cronApp } from "./cron/consolidate.js";
 import { heartbeatApp } from "./cron/heartbeat.js";
 import { runPipeline } from "./pipeline/index.js";
-import { publishHomeTab, ACTION_TO_SETTING, isAdmin } from "./slack/home.js";
+import { publishHomeTab, ACTION_TO_SETTING, CREDENTIAL_ACTIONS, isAdmin, openCredentialModal } from "./slack/home.js";
 import { setSetting } from "./lib/settings.js";
 import { logger } from "./lib/logger.js";
 import { recordError } from "./lib/metrics.js";
@@ -307,6 +307,49 @@ app.post("/api/slack/interactions", async (c) => {
 
         waitUntil(savePromise);
       }
+
+      const credentialKey = CREDENTIAL_ACTIONS[action.action_id];
+      if (credentialKey && payload.trigger_id) {
+        const modalPromise = openCredentialModal(
+          slackClient,
+          payload.trigger_id,
+          credentialKey,
+        ).catch((err) => {
+          recordError("interactions.credential_modal", err, {
+            userId,
+            credentialKey,
+          });
+        });
+        waitUntil(modalPromise);
+      }
+    }
+  }
+
+  if (payload.type === "view_submission") {
+    const callbackId = payload.view?.callback_id;
+    const userId = payload.user?.id;
+
+    if (callbackId === "credential_submit" && userId && isAdmin(userId)) {
+      const credentialKey = payload.view?.private_metadata;
+      const newValue =
+        payload.view?.state?.values?.credential_input_block?.credential_value
+          ?.value;
+
+      if (credentialKey && newValue) {
+        const savePromise = (async () => {
+          try {
+            const { setCredential } = await import("./lib/credentials.js");
+            await setCredential(credentialKey, newValue, userId);
+            await publishHomeTab(slackClient, userId);
+          } catch (err) {
+            recordError("interactions.credential_save", err, {
+              userId,
+              credentialKey,
+            });
+          }
+        })();
+        waitUntil(savePromise);
+      }
     }
   }
 
@@ -507,8 +550,8 @@ app.post("/api/webhook/cursor-agent", async (c) => {
         const prMatch = prUrl.match(/\/pull\/(\d+)$/);
         if (prMatch) {
           try {
-            const ghToken =
-              process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+            const { getCredential } = await import("./lib/credentials.js");
+            const ghToken = await getCredential("github_token");
             if (ghToken) {
               const prNumber = prMatch[1];
               const repoMatch = prUrl.match(

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,0 +1,93 @@
+import crypto from "node:crypto";
+import { getSetting, setSetting } from "./settings.js";
+import { logger } from "./logger.js";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_ENV = "CREDENTIALS_KEY";
+const DB_PREFIX = "credential:";
+
+const ENV_FALLBACKS: Record<string, string[]> = {
+  github_token: ["GH_TOKEN", "GITHUB_TOKEN"],
+};
+
+function getKeyBuffer(): Buffer | null {
+  const hex = process.env[KEY_ENV];
+  if (!hex) return null;
+  return Buffer.from(hex, "hex");
+}
+
+export function encryptCredential(plaintext: string): string {
+  const key = getKeyBuffer();
+  if (!key) throw new Error(`${KEY_ENV} is not configured`);
+
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return `${iv.toString("hex")}:${authTag.toString("hex")}:${encrypted.toString("hex")}`;
+}
+
+export function decryptCredential(ciphertext: string): string {
+  const key = getKeyBuffer();
+  if (!key) throw new Error(`${KEY_ENV} is not configured`);
+
+  const [ivHex, authTagHex, encryptedHex] = ciphertext.split(":");
+  if (!ivHex || !authTagHex || !encryptedHex) {
+    throw new Error("Invalid ciphertext format");
+  }
+
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    key,
+    Buffer.from(ivHex, "hex"),
+  );
+  decipher.setAuthTag(Buffer.from(authTagHex, "hex"));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(encryptedHex, "hex")),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString("utf8");
+}
+
+export async function getCredential(key: string): Promise<string | null> {
+  if (getKeyBuffer()) {
+    try {
+      const raw = await getSetting(`${DB_PREFIX}${key}`);
+      if (raw) return decryptCredential(raw);
+    } catch (error) {
+      logger.error("Failed to read credential from DB, falling back to env", {
+        key,
+        error,
+      });
+    }
+  }
+
+  const envNames = ENV_FALLBACKS[key];
+  if (envNames) {
+    for (const name of envNames) {
+      if (process.env[name]) return process.env[name]!;
+    }
+  }
+
+  return null;
+}
+
+export async function setCredential(
+  key: string,
+  value: string,
+  updatedBy?: string,
+): Promise<void> {
+  const encrypted = encryptCredential(value);
+  await setSetting(`${DB_PREFIX}${key}`, encrypted, updatedBy);
+  logger.info("Credential stored", { key, updatedBy });
+}
+
+export function maskCredential(value: string): string {
+  if (value.length <= 12) return "••••••••";
+  return `${value.slice(0, 8)}...${value.slice(-4)}`;
+}

--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -1,4 +1,5 @@
 import { getSetting, setSetting } from "./settings.js";
+import { getCredential } from "./credentials.js";
 import { logger } from "./logger.js";
 
 const SANDBOX_NOTE_KEY = "e2b_sandbox_id";
@@ -42,11 +43,12 @@ async function loadE2B() {
  * unreliable (see e2b-dev/E2B#884). Per-command `envs` is the only
  * mechanism that works consistently.
  */
-export function getSandboxEnvs(): Record<string, string> {
+export async function getSandboxEnvs(): Promise<Record<string, string>> {
   const envs: Record<string, string> = {};
-  if (process.env.GITHUB_TOKEN) {
-    envs.GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-    envs.GH_TOKEN = process.env.GITHUB_TOKEN;
+  const ghToken = await getCredential("github_token");
+  if (ghToken) {
+    envs.GITHUB_TOKEN = ghToken;
+    envs.GH_TOKEN = ghToken;
   }
   if (process.env.ANTHROPIC_API_KEY) {
     envs.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
@@ -87,7 +89,7 @@ export async function getOrCreateSandbox(): Promise<any> {
   }
 
   const Sandbox = await loadE2B();
-  const envs = getSandboxEnvs();
+  const envs = await getSandboxEnvs();
 
   // Try to resume a previously paused sandbox
   const savedId = await getSetting(SANDBOX_NOTE_KEY);

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -2,6 +2,7 @@ import type { WebClient } from "@slack/web-api";
 import { getAllSettings } from "../lib/settings.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
+import { getCredential, maskCredential } from "../lib/credentials.js";
 
 // ── Model Catalog ────────────────────────────────────────────────────────────
 
@@ -49,6 +50,27 @@ const DEFAULTS: Record<string, string> = {
   model_embedding: process.env.MODEL_EMBEDDING || "openai/text-embedding-3-small",
 };
 
+// ── Credential Definitions ───────────────────────────────────────────────────
+
+interface CredentialDef {
+  key: string;
+  label: string;
+  description: string;
+}
+
+const CREDENTIALS: CredentialDef[] = [
+  {
+    key: "github_token",
+    label: "GitHub Token",
+    description: "For issues, PRs, and code access",
+  },
+];
+
+/** Map credential button action IDs to credential keys */
+export const CREDENTIAL_ACTIONS: Record<string, string> = {
+  credential_edit_github_token: "github_token",
+};
+
 // ── Block Kit Helpers ────────────────────────────────────────────────────────
 
 function buildDropdown(
@@ -82,6 +104,93 @@ function buildDropdown(
       initial_option: initialOption,
     },
   };
+}
+
+async function buildCredentialBlocks(): Promise<any[]> {
+  const blocks: any[] = [
+    { type: "divider" },
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Credentials" },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "Encrypted and stored in the database. Values are never logged or displayed in full.",
+        },
+      ],
+    },
+  ];
+
+  for (const cred of CREDENTIALS) {
+    const value = await getCredential(cred.key);
+    const status = value ? `\`${maskCredential(value)}\`` : "_not set_";
+
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${cred.label}*  —  ${cred.description}\nCurrent: ${status}`,
+      },
+      accessory: {
+        type: "button",
+        text: { type: "plain_text", text: value ? "Update" : "Set" },
+        action_id: `credential_edit_${cred.key}`,
+      },
+    });
+  }
+
+  return blocks;
+}
+
+/**
+ * Open a modal for editing a credential value.
+ */
+export async function openCredentialModal(
+  client: WebClient,
+  triggerId: string,
+  credentialKey: string,
+): Promise<void> {
+  const cred = CREDENTIALS.find((c) => c.key === credentialKey);
+  if (!cred) return;
+
+  await client.views.open({
+    trigger_id: triggerId,
+    view: {
+      type: "modal",
+      callback_id: "credential_submit",
+      private_metadata: credentialKey,
+      title: { type: "plain_text", text: `Update ${cred.label}` },
+      submit: { type: "plain_text", text: "Save" },
+      close: { type: "plain_text", text: "Cancel" },
+      blocks: [
+        {
+          type: "input",
+          block_id: "credential_input_block",
+          label: { type: "plain_text", text: cred.label },
+          element: {
+            type: "plain_text_input",
+            action_id: "credential_value",
+            placeholder: {
+              type: "plain_text",
+              text: "Paste the new token here",
+            },
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `This will replace the current ${cred.label}. The value is encrypted at rest with AES-256-GCM.`,
+            },
+          ],
+        },
+      ],
+    },
+  });
 }
 
 // ── Publish Home Tab ─────────────────────────────────────────────────────────
@@ -166,6 +275,11 @@ export async function publishHomeTab(
           },
         },
       );
+    }
+
+    if (admin) {
+      const credBlocks = await buildCredentialBlocks();
+      blocks.push(...credBlocks);
     }
 
     blocks.push(

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -58,7 +58,7 @@ export function createSandboxTools(context?: ScheduleContext) {
 
         try {
           const sandbox = await getOrCreateSandbox();
-          const envs = getSandboxEnvs();
+          const envs = await getSandboxEnvs();
 
           logger.info("run_command tool: executing", {
             command: command.substring(0, 100),


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds encrypted, DB-backed credential storage with a Slack App Home UI to fix GitHub issue #242.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR introduces a secure way to manage credentials by encrypting them and storing them in the existing `settings` table, accessible and configurable via the Slack App Home. It includes a graceful fallback to environment variables if the encryption key is not set, ensuring zero-config compatibility with existing deployments.

---
<p><a href="https://cursor.com/agents?id=bc-db0d15e9-fb14-433f-af7b-2568748e6d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db0d15e9-fb14-433f-af7b-2568748e6d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret handling and Slack interaction flows; mistakes could expose or break token usage, though values are encrypted and masked and there is an env fallback path.
> 
> **Overview**
> Adds encrypted credential storage on top of the existing `settings` table (`credential:*` keys), using AES-256-GCM with a `CREDENTIALS_KEY` and an env-var fallback when the key/DB value is unavailable.
> 
> Extends the Slack App Home admin UI to display credential status (masked) and lets admins set/update credentials via a modal; adds interaction handling for credential edit buttons and modal submissions.
> 
> Switches GitHub token usage in the Cursor webhook PR-title lookup and E2B sandbox env injection to read from the new credential store instead of directly from `GH_TOKEN`/`GITHUB_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4947edf3a51eedbf59cebc5a70f65af3cb33396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->