### PR TITLE
fix: return response_action:clear for modal submissions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -351,6 +351,9 @@ app.post("/api/slack/interactions", async (c) => {
         waitUntil(savePromise);
       }
     }
+
+    // Slack modals require empty response or response_action to close properly
+    return c.json({ response_action: "clear" });
   }
 
   // Acknowledge immediately


### PR DESCRIPTION
## Problem
Clicking 'Save' on the credential update modal in App Home shows 'unexpected error' in Slack.

## Root Cause
The `view_submission` handler fell through to `return c.json({ ok: true })`, which Slack doesn't recognize for modal submissions. Slack expects either an empty 200 response or a `{ response_action: 'clear' }` object.

## Fix
Return `{ response_action: 'clear' }` early for `view_submission` events, which tells Slack to close the modal successfully.

3-line change. Zero risk.