### PR TITLE
Slack file upload tool

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2222,6 +2222,14 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
           if (title) uploadParams.title = title;
 
+          if (thread_ts && !channel) {
+            return {
+              ok: false,
+              error:
+                "thread_ts requires a channel — provide the channel where the thread lives.",
+            };
+          }
+
           if (channel) {
             let channelId = channel;
             if (!/^[CG][A-Z0-9]+$/.test(channel)) {


### PR DESCRIPTION
Add `upload_file` tool to enable uploading files to Slack channels, addressing GitHub issue #248.

This tool uses `client.filesUploadV2()` and supports uploading both text and base64-encoded binary content, with options for channel sharing (including name-to-ID resolution) and thread attachment.

---
<p><a href="https://cursor.com/agents?id=bc-014de357-7f91-4db5-b8b8-65c491d92b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-014de357-7f91-4db5-b8b8-65c491d92b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Slack API write behavior (file uploads/sharing) and base64 decoding, which may fail or leak data if inputs/scopes are misused, but changes are localized to a single new tool.
> 
> **Overview**
> Adds a new Slack tool, `upload_file`, to upload text or base64-encoded binary files via `client.filesUploadV2()`, optionally sharing to a resolved channel and/or attaching to a thread.
> 
> Includes basic validation (requires `channel` when `thread_ts` is set), channel name→ID resolution, and returns `file_id`/`file_url` with structured logging and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7108d908022697900c13cb2222c1ab7e30c542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->