### PR TITLE
Slack group DMs

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1260,7 +1260,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
         "Send a direct message to one user or a group of users. Pass a single name for a 1:1 DM, or an array of names to open/find a group DM (MPIM). Opens the conversation if it doesn't exist.",
       inputSchema: z.object({
         user_name: z
-          .union([z.string(), z.array(z.string())])
+          .union([z.string(), z.array(z.string()).min(1)])
           .describe(
             "A single display name/username (e.g. 'Joan') for a 1:1 DM, or an array of names (e.g. ['Joan', 'Alex', 'Sam']) for a group DM.",
           ),


### PR DESCRIPTION
Extend the `send_direct_message` tool to support group DMs (MPIMs) by allowing the `user_name` parameter to accept an array of user names.

This change addresses GitHub issue #247, enabling the AI assistant to send direct messages to multiple users simultaneously while maintaining backward compatibility for single-user DMs.

---
<p><a href="https://cursor.com/agents?id=bc-38656142-133a-4233-a939-5ca6f98559ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38656142-133a-4233-a939-5ca6f98559ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Slack DM sending logic and input validation; main risk is runtime errors if Slack `conversations.open` behavior differs for multi-user IDs.
> 
> **Overview**
> Extends the Slack `send_direct_message` tool to support *group DMs (MPIM)* by allowing `user_name` to be either a single string or an array of names.
> 
> The tool now resolves and validates multiple users, opens a DM with a comma-separated list of user IDs, and updates success/error messages and logging to reflect multi-recipient sends while keeping single-user behavior compatible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aacadc8d49894ad6e77a887f71a1c9131276829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->