### PR TITLE
fix: use valid inputs for claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
+          claude_args: "--model claude-sonnet-4-20250514"
 
   auto-review:
     if: |
@@ -51,9 +51,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
-          review_trigger: "auto"
-          review_prompt: |
+          claude_args: "--model claude-sonnet-4-20250514"
+          prompt: |
             Review this PR for:
             1. TypeScript type safety and correctness
             2. Slack API usage patterns (mrkdwn formatting, API limits, error handling)


### PR DESCRIPTION
## Problem

Every Claude Code Action run fails because the workflow uses invalid input names:
- `model` -- not a valid input (the warning is in the logs: `Unexpected input(s) 'model'`)
- `review_trigger` -- doesn't exist
- `review_prompt` -- doesn't exist (the real input is `prompt`)

These were introduced when bugbot auto-fixed the original workflow and hallucinated input names.

## Fix

- `model: claude-sonnet-4-20250514` -> `claude_args: "--model claude-sonnet-4-20250514"`
- Removed `review_trigger: "auto"` (not needed -- the `if` condition already gates on PR events)
- `review_prompt` -> `prompt`

Validated against the [official action.yml](https://github.com/anthropics/claude-code-action/blob/main/action.yml).