### PR TITLE
fix: add checkout step before claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,9 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -48,6 +51,9 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Problem
The Claude Code Action crashes with `git hash-object` errors when PRs add or delete files. Without a checkout step, the action has no local tree and can't resolve file refs from the diff.

Upstream: https://github.com/anthropics/claude-code-action/issues/730

## Fix
Add `actions/checkout@v4` with `fetch-depth: 0` before both Claude Code steps. Full history ensures it can access any PR branch ref.

## Testing
Trigger `@claude` on any PR with new files.