### PR TITLE
docs: update bot token scopes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Go to **OAuth & Permissions** in the sidebar. Under **Bot Token Scopes**, add:
 |---|---|
 | `app_mentions:read` | Receive @Aura mentions in channels |
 | `channels:history` | Read messages in public channels |
-| `channels:read` | List channels Aura is in |
+| `channels:read` | List public channels in the workspace |
 | `channels:join` | Join public channels |
 | `channels:manage` | Create channels, set topic, invite users |
 | `chat:write` | Send, edit, delete messages |
@@ -113,12 +113,14 @@ Go to **OAuth & Permissions** in the sidebar. Under **Bot Token Scopes**, add:
 | `mpim:history` | Read group DM messages |
 | `mpim:read` | Access group DM channel info |
 | `users:read` | Look up user profiles |
+| `users:read.email` | Access user email addresses |
 | `reactions:write` | Add/remove emoji reactions |
 | `reactions:read` | Read reactions on messages |
 | `lists:read` | Read Slack List items |
 | `lists:write` | Create/update/delete Slack List items |
 | `canvases:read` | Read Canvas content |
 | `canvases:write` | Create/edit Canvases |
+| `files:read` | List and read files (canvases, uploads) |
 | `users.profile:write` | Set bot's own status |
 | `assistant:write` | Loading shimmer & status indicators (auto-added by Agents & AI Apps toggle) |
 


### PR DESCRIPTION
- channels:read description: 'List channels Aura is in' -> 'List public channels in the workspace' (reflects actual behavior)
- Add files:read (needed for list_canvases / files.list)
- Add users:read.email (needed for email lookups)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that doesn’t affect runtime behavior; risk is limited to potentially incorrect setup guidance if the scopes are still incomplete.
> 
> **Overview**
> Updates the README’s Slack app setup instructions by clarifying the `channels:read` scope description (it lists *public* workspace channels, not just channels the bot is in).
> 
> Adds the missing `users:read.email` and `files:read` bot token scopes to the documented required permissions to match features that look up user emails and access/read files (e.g., canvases/uploads).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3967648a462a05af08a60953452e756fda88c874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->