### PR TITLE
Run command timeout ceiling

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -241,7 +241,7 @@ Web:
 - **read_url** — fetch a URL and extract its readable text content (for reading links people paste)
 
 Sandbox (Linux VM):
-- **run_command** — execute any shell command in a sandboxed Linux VM. This is your universal tool for computation: file ops (cat, head, tee), git, code execution (node, python), search (rg, grep), data processing (curl, jq), and self-modification via Claude Code (\`claude\`). Install anything else with apt-get or pip.
+- **run_command** — execute any shell command in a sandboxed Linux VM (default timeout 120s, max 750s). This is your universal tool for computation: file ops (cat, head, tee), git, code execution (node, python), search (rg, grep), data processing (curl, jq), and self-modification via Claude Code (\`claude\`). Install anything else with apt-get or pip. Use higher timeouts (up to 750s) for long-running agent commands like Claude Agent SDK or Codex CLI — the 750s ceiling leaves a 50s buffer before the Vercel function timeout at 800s.
 
 Cursor Agent (async code tasks):
 - **dispatch_cursor_agent** — launch an async Cursor Cloud Agent to work on a code task in the Aura repo. Use for complex multi-file changes that would take >5 minutes. The agent runs in the background (3-30 min), creates a branch, makes changes, opens a PR, and reports back via webhook DM. Returns immediately with the agent ID. Admin-only.

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -36,9 +36,11 @@ export function createSandboxTools(context?: ScheduleContext) {
         timeout_seconds: z
           .number()
           .min(1)
-          .max(300)
+          .max(750)
           .default(120)
-          .describe("Command timeout in seconds (max 300)"),
+          .describe(
+            "Command timeout in seconds (default 120, max 750). Use higher timeouts for long-running agent commands like Claude Agent SDK or Codex CLI.",
+          ),
       }),
       execute: async ({ command, workdir, timeout_seconds }) => {
         if (!isAdmin(context?.userId) && context?.userId !== "aura") {


### PR DESCRIPTION
Raise `run_command` timeout ceiling to 750s to support long-running agent commands.

---
<p><a href="https://cursor.com/agents?id=bc-20d6ce8b-38f5-49c0-829e-7fa41178bfab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d6ce8b-38f5-49c0-829e-7fa41178bfab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config/docs change; main risk is longer sandbox commands tying up serverless execution closer to the 800s limit.
> 
> **Overview**
> Increases the `run_command` tool timeout ceiling from 300s to 750s to support longer-running sandbox operations.
> 
> Updates both the tool’s Zod schema validation and the system prompt/tool documentation to reflect the new max and provide guidance on when to use longer timeouts (noting the Vercel 800s function limit buffer).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 695f0576a64742647d7aa99441df32ff9def00b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->