### PR TITLE
fix: use any_header criteria for canvases.sections.lookup

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1692,7 +1692,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
             "canvases.sections.lookup",
             {
               canvas_id,
-              criteria: {},
+              criteria: { any_header: true },
             },
           );
 


### PR DESCRIPTION
## Problem
`read_canvas` has been broken since it was first added. Every call returns `invalid_arguments`.

## Root Cause
The Slack `canvases.sections.lookup` API requires the `criteria` parameter to contain either `section_types` (array) or `any_header` (boolean). Passing an empty object `{}` is invalid.

## Fix
Pass `{ any_header: true }` to get all sections (headings) in the canvas. One-line change.