### PR TITLE
feat: email staging pipeline (Phase 1)

### DIFF
--- a/drizzle/0018_email_staging_pipeline.sql
+++ b/drizzle/0018_email_staging_pipeline.sql
@@ -1,0 +1,30 @@
+CREATE TABLE "emails_raw" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"gmail_message_id" text NOT NULL,
+	"gmail_thread_id" text NOT NULL,
+	"subject" text,
+	"from_email" text NOT NULL,
+	"from_name" text,
+	"to_emails" jsonb,
+	"cc_emails" jsonb,
+	"date" timestamp with time zone NOT NULL,
+	"body_markdown" text,
+	"body_size_bytes" integer,
+	"triage" text,
+	"triage_reason" text,
+	"direction" text NOT NULL,
+	"has_attachments" boolean DEFAULT false,
+	"labels" jsonb,
+	"raw_headers" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "emails_raw_user_gmail_msg_idx" ON "emails_raw" USING btree ("user_id","gmail_message_id");
+--> statement-breakpoint
+CREATE INDEX "emails_raw_user_thread_idx" ON "emails_raw" USING btree ("user_id","gmail_thread_id");
+--> statement-breakpoint
+CREATE INDEX "emails_raw_user_triage_idx" ON "emails_raw" USING btree ("user_id","triage");
+--> statement-breakpoint
+CREATE INDEX "emails_raw_user_date_idx" ON "emails_raw" USING btree ("user_id","date");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,20 @@
       "when": 1771804800000,
       "tag": "0016_add_oauth_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1772000000000,
+      "tag": "0017_narrow_iron_patriot",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1772000000000,
+      "tag": "0018_email_staging_pipeline",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@neondatabase/serverless": "^1.0.0",
         "@slack/web-api": "^7.14.0",
         "@tavily/core": "^0.7.1",
+        "@types/turndown": "^5.0.6",
         "@vercel/functions": "^3.4.2",
         "ai": "^6.0.86",
         "chalk": "4.1.2",
@@ -27,6 +28,7 @@
         "e2b": "^2.12.1",
         "google-auth-library": "^10.5.0",
         "hono": "^4.11.9",
+        "turndown": "^7.2.2",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -1145,6 +1147,11 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
+    },
     "node_modules/@neondatabase/serverless": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.2.tgz",
@@ -1275,6 +1282,11 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="
     },
     "node_modules/@upstash/redis": {
       "version": "1.36.2",
@@ -3870,6 +3882,14 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@neondatabase/serverless": "^1.0.0",
     "@slack/web-api": "^7.14.0",
     "@tavily/core": "^0.7.1",
+    "@types/turndown": "^5.0.6",
     "@vercel/functions": "^3.4.2",
     "ai": "^6.0.86",
     "chalk": "4.1.2",
@@ -35,6 +36,7 @@
     "e2b": "^2.12.1",
     "google-auth-library": "^10.5.0",
     "hono": "^4.11.9",
+    "turndown": "^7.2.2",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -321,6 +321,45 @@ export const errorEvents = pgTable(
 );
 
 
+// ── Emails Raw (email staging pipeline) ────────────────────────────────────
+
+export const emailsRaw = pgTable(
+  "emails_raw",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: text("user_id").notNull(),
+    gmailMessageId: text("gmail_message_id").notNull(),
+    gmailThreadId: text("gmail_thread_id").notNull(),
+    subject: text("subject"),
+    fromEmail: text("from_email").notNull(),
+    fromName: text("from_name"),
+    toEmails: jsonb("to_emails").$type<string[]>(),
+    ccEmails: jsonb("cc_emails").$type<string[]>(),
+    date: timestamptz("date").notNull(),
+    bodyMarkdown: text("body_markdown"),
+    bodySizeBytes: integer("body_size_bytes"),
+    triage: text("triage"),
+    triageReason: text("triage_reason"),
+    direction: text("direction").notNull(),
+    hasAttachments: boolean("has_attachments").default(false),
+    labels: jsonb("labels").$type<string[]>(),
+    rawHeaders: jsonb("raw_headers").$type<Record<string, string>>(),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+    updatedAt: timestamptz("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("emails_raw_user_gmail_msg_idx").on(
+      table.userId,
+      table.gmailMessageId,
+    ),
+    index("emails_raw_user_thread_idx").on(table.userId, table.gmailThreadId),
+    index("emails_raw_user_triage_idx").on(table.userId, table.triage),
+    index("emails_raw_user_date_idx").on(table.userId, table.date),
+  ],
+);
+
 // ── OAuth Tokens ───────────────────────────────────────────────────────────
 
 export const oauthTokens = pgTable(
@@ -365,6 +404,8 @@ export type JobExecution = typeof jobExecutions.$inferSelect;
 export type NewJobExecution = typeof jobExecutions.$inferInsert;
 export type OAuthToken = typeof oauthTokens.$inferSelect;
 export type NewOAuthToken = typeof oauthTokens.$inferInsert;
+export type EmailRaw = typeof emailsRaw.$inferSelect;
+export type NewEmailRaw = typeof emailsRaw.$inferInsert;
 
 /** Context for tools that need to know the current conversation's routing. */
 export interface ScheduleContext {

--- a/src/lib/email-sync.ts
+++ b/src/lib/email-sync.ts
@@ -1,0 +1,227 @@
+import TurndownService from "turndown";
+import { db } from "../db/client.js";
+import { emailsRaw, type NewEmailRaw } from "../db/schema.js";
+import {
+  getGmailClientForUser,
+  getHeader,
+  extractBodyParts,
+  hasAttachmentParts,
+} from "./gmail.js";
+import { logger } from "./logger.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface SyncOptions {
+  /** Gmail search query, e.g. "newer_than:7d" */
+  query?: string;
+  /** Max number of messages to fetch per call (default 100) */
+  maxMessages?: number;
+}
+
+export interface SyncResult {
+  synced: number;
+  skipped: number;
+  errors: number;
+}
+
+// ── HTML to Markdown ────────────────────────────────────────────────────────
+
+const turndown = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+});
+
+turndown.addRule("emailSignatures", {
+  filter: (node: HTMLElement) => {
+    const text = node.textContent?.toLowerCase() || "";
+    return (
+      text.includes("sent from my iphone") ||
+      text.includes("sent from my android") ||
+      text.includes("get outlook for")
+    );
+  },
+  replacement: () => "",
+});
+
+function htmlToMarkdown(html: string): string {
+  if (!html) return "";
+  try {
+    return turndown
+      .turndown(html)
+      .replace(/\n\s*\n\s*\n/g, "\n\n")
+      .trim();
+  } catch {
+    return html;
+  }
+}
+
+// ── Parse email address ─────────────────────────────────────────────────────
+
+function parseEmailAddress(raw: string): { email: string; name: string } {
+  const match = raw.match(/^(?:"?([^"<]*)"?\s*)?<?([^>]+@[^>]+)>?$/);
+  if (match) {
+    return {
+      email: match[2].trim().toLowerCase(),
+      name: (match[1] || "").trim(),
+    };
+  }
+  return { email: raw.trim().toLowerCase(), name: "" };
+}
+
+function parseEmailList(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((e) => parseEmailAddress(e.trim()).email)
+    .filter(Boolean);
+}
+
+// ── Gmail Batch Fetch ────────────────────────────────────────
+
+/**
+ * Sync emails from a user's Gmail account into emails_raw.
+ * Fetches messages, converts HTML→markdown, and upserts rows.
+ * Does NOT run triage — call triageEmails() separately.
+ */
+export async function syncEmails(
+  userId: string,
+  options: SyncOptions = {},
+): Promise<SyncResult> {
+  const result: SyncResult = { synced: 0, skipped: 0, errors: 0 };
+
+  const gmailResult = await getGmailClientForUser(userId);
+  if (!gmailResult) {
+    throw new Error(`No Gmail access for user ${userId}`);
+  }
+  const { gmail, email: userEmail } = gmailResult;
+
+  const query = options.query || "newer_than:7d";
+  const maxMessages = options.maxMessages || 100;
+
+  // List message IDs
+  let allMessageIds: string[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const listRes = await gmail.users.messages.list({
+      userId: "me",
+      q: query,
+      maxResults: Math.min(maxMessages - allMessageIds.length, 100),
+      pageToken,
+    });
+
+    const messages = listRes.data.messages || [];
+    allMessageIds.push(...messages.map((m: any) => m.id!).filter(Boolean));
+    pageToken = listRes.data.nextPageToken || undefined;
+  } while (pageToken && allMessageIds.length < maxMessages);
+
+  allMessageIds = allMessageIds.slice(0, maxMessages);
+
+  logger.info("Email sync: fetching messages", {
+    userId,
+    count: allMessageIds.length,
+    query,
+  });
+
+  // Fetch full messages in parallel batches of 10
+  const BATCH_SIZE = 10;
+  for (let i = 0; i < allMessageIds.length; i += BATCH_SIZE) {
+    const batch = allMessageIds.slice(i, i + BATCH_SIZE);
+    const fullMessages = await Promise.all(
+      batch.map((id) =>
+        gmail.users.messages
+          .get({ userId: "me", id, format: "full" })
+          .then((r: any) => r.data)
+          .catch((err: any) => {
+            logger.warn("Failed to fetch message", {
+              userId,
+              msgId: id,
+              error: String(err),
+            });
+            result.errors++;
+            return null;
+          }),
+      ),
+    );
+
+    for (const msg of fullMessages) {
+      if (!msg?.id || !msg?.threadId) continue;
+
+      try {
+        const headers = msg.payload?.headers || [];
+        const fromRaw = getHeader(headers, "From");
+        const toRaw = getHeader(headers, "To");
+        const ccRaw = getHeader(headers, "Cc");
+        const subject = getHeader(headers, "Subject");
+        const dateStr = getHeader(headers, "Date");
+
+        const { email: fromEmail, name: fromName } =
+          parseEmailAddress(fromRaw);
+        const date = dateStr ? new Date(dateStr) : new Date();
+        const direction: "inbound" | "outbound" =
+          userEmail && fromEmail.toLowerCase() === userEmail.toLowerCase()
+            ? "outbound"
+            : "inbound";
+
+        // Extract body — prefer HTML for markdown conversion
+        const { html, plain } = extractBodyParts(msg.payload);
+        const bodyMarkdown = html ? htmlToMarkdown(html) : plain || "";
+        const bodySizeBytes = Buffer.byteLength(bodyMarkdown, "utf-8");
+
+        const labels = (msg.labelIds || []) as string[];
+        const attachments = hasAttachmentParts(msg.payload);
+
+        // Selected headers for debugging
+        const rawHeaders: Record<string, string> = {};
+        for (const h of [
+          "Message-ID",
+          "In-Reply-To",
+          "References",
+          "Reply-To",
+          "List-Unsubscribe",
+        ]) {
+          const val = getHeader(headers, h);
+          if (val) rawHeaders[h] = val;
+        }
+
+        const row: NewEmailRaw = {
+          userId,
+          gmailMessageId: msg.id!,
+          gmailThreadId: msg.threadId!,
+          subject,
+          fromEmail,
+          fromName: fromName || null,
+          toEmails: parseEmailList(toRaw),
+          ccEmails: ccRaw ? parseEmailList(ccRaw) : null,
+          date,
+          bodyMarkdown,
+          bodySizeBytes,
+          direction,
+          hasAttachments: attachments,
+          labels,
+          rawHeaders:
+            Object.keys(rawHeaders).length > 0 ? rawHeaders : null,
+        };
+
+        await db
+          .insert(emailsRaw)
+          .values(row)
+          .onConflictDoNothing({
+            target: [emailsRaw.userId, emailsRaw.gmailMessageId],
+          });
+
+        result.synced++;
+      } catch (err) {
+        logger.warn("Failed to process message", {
+          userId,
+          msgId: msg.id,
+          error: String(err),
+        });
+        result.errors++;
+      }
+    }
+  }
+
+  logger.info("Email sync completed", { userId, ...result });
+  return result;
+}

--- a/src/lib/email-triage.ts
+++ b/src/lib/email-triage.ts
@@ -1,0 +1,158 @@
+import { generateText } from "ai";
+import { eq, and, isNull } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { emailsRaw } from "../db/schema.js";
+import { getFastModel } from "./ai.js";
+import { logger } from "./logger.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface TriageResult {
+  id: string;
+  triage: "junk" | "fyi" | "actionable" | "urgent";
+  reason: string;
+}
+
+export interface TriageSummary {
+  triaged: number;
+  errors: number;
+  breakdown: Record<string, number>;
+}
+
+// ── Haiku Triage Gate ───────────────────────────────────────────────────────
+
+const TRIAGE_PROMPT = `You are an email triage assistant. Classify each email into exactly one category:
+
+- **junk**: spam, marketing, newsletters, automated notifications, no action needed
+- **fyi**: informational, worth seeing but no reply needed (order confirmations, status updates, CC'd threads)
+- **actionable**: requires a response or action within a reasonable timeframe
+- **urgent**: time-sensitive, needs immediate attention (client escalations, broken systems, deadlines today)
+
+For each email, respond with a JSON array of objects:
+[{"id": "<email_id>", "triage": "<category>", "reason": "<one-line explanation>"}]
+
+Only output the JSON array, no other text.`;
+
+/**
+ * Triage un-classified emails in emails_raw using Claude Haiku.
+ * Processes in batches of up to 50.
+ */
+export async function triageEmails(
+  userId: string,
+  options: { batchSize?: number; limit?: number } = {},
+): Promise<TriageSummary> {
+  const batchSize = options.batchSize ?? 50;
+  const limit = options.limit ?? 500;
+  const summary: TriageSummary = { triaged: 0, errors: 0, breakdown: {} };
+
+  // Fetch untriaged emails
+  const untriaged = await db
+    .select({
+      id: emailsRaw.id,
+      subject: emailsRaw.subject,
+      fromEmail: emailsRaw.fromEmail,
+      fromName: emailsRaw.fromName,
+      direction: emailsRaw.direction,
+      bodyMarkdown: emailsRaw.bodyMarkdown,
+      labels: emailsRaw.labels,
+    })
+    .from(emailsRaw)
+    .where(and(eq(emailsRaw.userId, userId), isNull(emailsRaw.triage)))
+    .limit(limit);
+
+  if (untriaged.length === 0) {
+    logger.info("No untriaged emails found", { userId });
+    return summary;
+  }
+
+  logger.info("Triaging emails", {
+    userId,
+    count: untriaged.length,
+    batchSize,
+  });
+
+  // Process in batches
+  for (let i = 0; i < untriaged.length; i += batchSize) {
+    const batch = untriaged.slice(i, i + batchSize);
+
+    const emailDescriptions = batch.map((email) => {
+      const bodyPreview = (email.bodyMarkdown || "").slice(0, 500);
+      const fromDisplay = email.fromName
+        ? `${email.fromName} <${email.fromEmail}>`
+        : email.fromEmail;
+      const labelsStr =
+        (email.labels as string[] | null)?.join(", ") || "none";
+      return [
+        "ID: " + email.id,
+        "Subject: " + (email.subject || "(no subject)"),
+        "From: " + fromDisplay,
+        "Direction: " + email.direction,
+        "Labels: " + labelsStr,
+        "Body preview: " + bodyPreview,
+      ].join("\n");
+    });
+
+    const prompt =
+      TRIAGE_PROMPT +
+      "\n\nHere are " +
+      batch.length +
+      " emails to classify:\n\n" +
+      emailDescriptions.join("\n---\n");
+
+    try {
+      const model = await getFastModel();
+      const { text } = await generateText({
+        model,
+        prompt,
+        maxTokens: 2000,
+      });
+
+      // Parse the JSON response
+      const jsonMatch = text.match(/\[[\s\S]*\]/);
+      if (!jsonMatch) {
+        logger.warn("Triage response was not valid JSON", {
+          userId,
+          text: text.slice(0, 200),
+        });
+        summary.errors += batch.length;
+        continue;
+      }
+
+      const results: TriageResult[] = JSON.parse(jsonMatch[0]);
+
+      for (const r of results) {
+        const validCategories = ["junk", "fyi", "actionable", "urgent"];
+        if (!validCategories.includes(r.triage)) {
+          logger.warn("Invalid triage category", {
+            id: r.id,
+            triage: r.triage,
+          });
+          summary.errors++;
+          continue;
+        }
+
+        await db
+          .update(emailsRaw)
+          .set({
+            triage: r.triage,
+            triageReason: r.reason,
+            updatedAt: new Date(),
+          })
+          .where(eq(emailsRaw.id, r.id));
+
+        summary.triaged++;
+        summary.breakdown[r.triage] = (summary.breakdown[r.triage] || 0) + 1;
+      }
+    } catch (err) {
+      logger.error("Triage batch failed", {
+        userId,
+        batchStart: i,
+        error: String(err),
+      });
+      summary.errors += batch.length;
+    }
+  }
+
+  logger.info("Email triage completed", { userId, ...summary });
+  return summary;
+}

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -314,7 +314,7 @@ function buildMimeMessage(
   return parts.join("\r\n");
 }
 
-function getHeader(
+export function getHeader(
   headers: { name?: string | null; value?: string | null }[],
   name: string,
 ): string {
@@ -353,6 +353,50 @@ function extractBody(payload: any): string {
   }
 
   return "";
+}
+
+/**
+ * Extract both HTML and plain-text body from a Gmail message payload.
+ * Recurses into multipart/* containers.
+ */
+export function extractBodyParts(payload: any): {
+  html: string;
+  plain: string;
+} {
+  let html = "";
+  let plain = "";
+
+  function walk(part: any): void {
+    const mime: string = part.mimeType || "";
+
+    if (mime === "text/html" && part.body?.data) {
+      html = html || Buffer.from(part.body.data, "base64").toString("utf-8");
+    } else if (mime === "text/plain" && part.body?.data) {
+      plain = plain || Buffer.from(part.body.data, "base64").toString("utf-8");
+    } else if (mime.startsWith("multipart/") && part.parts) {
+      for (const child of part.parts) walk(child);
+    }
+  }
+
+  walk(payload);
+  return { html, plain };
+}
+
+/**
+ * Returns true if the message payload contains any attachment parts
+ * (i.e. parts with a non-empty filename).
+ */
+export function hasAttachmentParts(payload: any): boolean {
+  function walk(part: any): boolean {
+    if (part.filename && part.filename.length > 0) return true;
+    if (part.parts) {
+      for (const child of part.parts) {
+        if (walk(child)) return true;
+      }
+    }
+    return false;
+  }
+  return walk(payload);
 }
 
 function extractAttachments(

--- a/src/tools/email-sync.ts
+++ b/src/tools/email-sync.ts
@@ -1,0 +1,260 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { eq, and, desc, sql } from "drizzle-orm";
+import { formatDistanceToNow } from "date-fns";
+import type { WebClient } from "@slack/web-api";
+import { logger } from "../lib/logger.js";
+import { db } from "../db/client.js";
+import { emailsRaw } from "../db/schema.js";
+import type { ScheduleContext } from "../db/schema.js";
+
+// ── User Resolution Helper ──────────────────────────────────────────────────
+
+async function resolveSlackUserId(
+  client: WebClient,
+  userName: string,
+): Promise<string | null> {
+  try {
+    const { getUserList } = await import("./slack.js");
+    const users = await getUserList(client);
+
+    const normalizedInput = userName.replace(/^@/, "").toLowerCase().trim();
+
+    for (const user of users) {
+      if (
+        user.displayName.toLowerCase() === normalizedInput ||
+        user.realName.toLowerCase() === normalizedInput ||
+        user.username.toLowerCase() === normalizedInput
+      ) {
+        return user.id;
+      }
+    }
+
+    for (const user of users) {
+      if (
+        user.displayName.toLowerCase().startsWith(normalizedInput) ||
+        user.realName.toLowerCase().startsWith(normalizedInput) ||
+        user.username.toLowerCase().startsWith(normalizedInput)
+      ) {
+        return user.id;
+      }
+    }
+
+    return null;
+  } catch (error: any) {
+    logger.error("Failed to resolve Slack user ID", {
+      userName,
+      error: error.message,
+    });
+    return null;
+  }
+}
+
+// ── Tool Definitions ────────────────────────────────────────────────────────
+
+export function createEmailSyncTools(
+  client: WebClient,
+  _context?: ScheduleContext,
+) {
+  return {
+    sync_emails: tool({
+      description:
+        "Sync recent emails from a user's Gmail into the staging pipeline. Fetches from Gmail, converts HTML to markdown, and stores in emails_raw. Optionally runs Haiku triage. The user must have authorized Aura to access their Gmail.",
+      inputSchema: z.object({
+        user_name: z
+          .string()
+          .describe(
+            "Display name, username, or user ID of the Gmail account owner",
+          ),
+        query: z
+          .string()
+          .optional()
+          .describe("Gmail search query, e.g. 'newer_than:7d' (default)"),
+        max_messages: z
+          .number()
+          .optional()
+          .describe("Max messages to fetch (default 100)"),
+        run_triage: z
+          .boolean()
+          .optional()
+          .describe("Run Haiku triage after sync (default true)"),
+      }),
+      execute: async ({ user_name, query, max_messages, run_triage }) => {
+        try {
+          const userId = await resolveSlackUserId(client, user_name);
+          if (!userId) {
+            return {
+              ok: false,
+              error: `Could not resolve user '${user_name}'. They need to exist in the workspace.`,
+            };
+          }
+
+          // Dynamic import to avoid loading gmail on every request
+          const { syncEmails } = await import("../lib/email-sync.js");
+          const result = await syncEmails(userId, {
+            query: query || "newer_than:7d",
+            maxMessages: max_messages || 100,
+          });
+
+          // Optionally run Haiku triage
+          let triageResult = null;
+          if (run_triage !== false) {
+            const { triageEmails } = await import("../lib/email-triage.js");
+            triageResult = await triageEmails(userId);
+          }
+
+          return {
+            ok: true,
+            synced: result.synced,
+            skipped: result.skipped,
+            errors: result.errors,
+            triage: triageResult,
+            message: `Synced ${result.synced} emails (${result.skipped} already existed, ${result.errors} errors)${
+              triageResult
+                ? `, triaged ${triageResult.triaged} (${Object.entries(triageResult.breakdown)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join(", ")})`
+                : ""
+            }`,
+          };
+        } catch (error: any) {
+          logger.error("sync_emails tool failed", {
+            userName: user_name,
+            error: error.message,
+          });
+          return { ok: false, error: `Sync failed: ${error.message}` };
+        }
+      },
+    }),
+
+    email_digest: tool({
+      description:
+        "Get an email digest for a user: urgent items, threads awaiting reply, sorted by importance. Reads from the emails_raw staging table.",
+      inputSchema: z.object({
+        user_name: z
+          .string()
+          .describe(
+            "Display name, username, or user ID of the Gmail account owner",
+          ),
+        include_fyi: z
+          .boolean()
+          .optional()
+          .describe("Include FYI-level threads (default false)"),
+      }),
+      execute: async ({ user_name, include_fyi }) => {
+        try {
+          const userId = await resolveSlackUserId(client, user_name);
+          if (!userId) {
+            return {
+              ok: false,
+              error: `Could not resolve user '${user_name}'.`,
+            };
+          }
+
+          // Get triage stats
+          const triageStats = await db
+            .select({
+              triage: emailsRaw.triage,
+              count: sql<number>`count(*)::int`,
+            })
+            .from(emailsRaw)
+            .where(eq(emailsRaw.userId, userId))
+            .groupBy(emailsRaw.triage);
+
+          const statsMap: Record<string, number> = {};
+          for (const s of triageStats) {
+            statsMap[s.triage || "untriaged"] = s.count;
+          }
+
+          // Get recent threads, grouped by gmail_thread_id, most recent first
+          const emails = await db
+            .select({
+              gmailThreadId: emailsRaw.gmailThreadId,
+              subject: emailsRaw.subject,
+              fromEmail: emailsRaw.fromEmail,
+              fromName: emailsRaw.fromName,
+              date: emailsRaw.date,
+              triage: emailsRaw.triage,
+              triageReason: emailsRaw.triageReason,
+            })
+            .from(emailsRaw)
+            .where(
+              and(
+                eq(emailsRaw.userId, userId),
+                include_fyi
+                  ? sql`1=1`
+                  : sql`(${emailsRaw.triage} IS NULL OR ${emailsRaw.triage} != 'junk')`,
+              ),
+            )
+            .orderBy(
+              sql`CASE ${emailsRaw.triage}
+                WHEN 'urgent' THEN 1
+                WHEN 'actionable' THEN 2
+                WHEN 'fyi' THEN 3
+                WHEN 'junk' THEN 4
+                ELSE 0 END`,
+              desc(emailsRaw.date),
+            )
+            .limit(200);
+
+          // Dedupe to latest per thread
+          const threadMap = new Map<string, (typeof emails)[0]>();
+          for (const email of emails) {
+            const existing = threadMap.get(email.gmailThreadId);
+            if (
+              !existing ||
+              (email.date && existing.date && email.date > existing.date)
+            ) {
+              threadMap.set(email.gmailThreadId, email);
+            }
+          }
+
+          const threads = [...threadMap.values()].map((t) => ({
+            subject: t.subject || "(no subject)",
+            from: t.fromName
+              ? `${t.fromName} <${t.fromEmail}>`
+              : t.fromEmail,
+            triage: t.triage || "untriaged",
+            triage_reason: t.triageReason || "",
+            last_message: t.date
+              ? formatDistanceToNow(t.date, { addSuffix: true })
+              : "unknown",
+          }));
+
+          // Build summary
+          const urgent = threads.filter((t) => t.triage === "urgent");
+          const actionable = threads.filter((t) => t.triage === "actionable");
+          const fyi = threads.filter((t) => t.triage === "fyi");
+
+          let summary = `📧 **Email Digest** (${threads.length} threads)\n`;
+          if (urgent.length > 0)
+            summary += `🚨 **${urgent.length} urgent**\n`;
+          if (actionable.length > 0)
+            summary += `⚡ **${actionable.length} actionable**\n`;
+          if (fyi.length > 0) summary += `ℹ️ **${fyi.length} FYI**\n`;
+
+          if (urgent.length > 0 || actionable.length > 0) {
+            summary += "\n**Priority threads:**\n";
+            [...urgent, ...actionable].slice(0, 10).forEach((t) => {
+              const icon = t.triage === "urgent" ? "🚨" : "⚡";
+              summary += `${icon} **${t.subject}** from ${t.from} • ${t.last_message}\n`;
+            });
+          }
+
+          return {
+            ok: true,
+            message: summary,
+            stats: statsMap,
+            threads,
+          };
+        } catch (error: any) {
+          logger.error("email_digest tool failed", {
+            userName: user_name,
+            error: error.message,
+          });
+          return { ok: false, error: `Digest failed: ${error.message}` };
+        }
+      },
+    }),
+  };
+}

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -13,6 +13,7 @@ import { createTableTools } from "./table.js";
 import { createCursorAgentTools } from "./cursor-agent.js";
 import { createConversationSearchTools } from "./conversations.js";
 import { createEmailTools, createGmailEATools } from "./email.js";
+import { createEmailSyncTools } from "./email-sync.js";
 import { createSheetsTools } from "./sheets.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { formatForSlack } from "../lib/format.js";
@@ -2604,6 +2605,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     // ── Email Tools (Gmail) ──────────────────────────────────────────────
     ...createEmailTools(),
     ...createGmailEATools(),
+    ...createEmailSyncTools(client, context),
 
     // ── Google Sheets Tools ───────────────────────────────────────────────
     ...createSheetsTools(),


### PR DESCRIPTION
## Implements #254 — Phase 1: Email staging pipeline

### What this does
Adds a complete email ingestion pipeline that syncs Gmail → staging table with triage classification. **Zero changes to existing tables.**

### New files
- **`drizzle/0018_email_staging_pipeline.sql`** — Migration for `emails_raw` table
- **`src/lib/email-sync.ts`** — Gmail batch fetch → HTML-to-markdown (turndown) → upsert pipeline
- **`src/lib/email-triage.ts`** — Haiku triage gate: classifies emails as junk/fyi/actionable/urgent
- **`src/tools/email-sync.ts`** — Two new tools: `sync_emails` and `email_digest`

### Modified files
- **`src/db/schema.ts`** — Add `emailsRaw` table definition (20 columns, 4 indexes)
- **`src/lib/gmail.ts`** — Export `getHeader`, add `extractBodyParts` + `hasAttachmentParts`
- **`src/tools/slack.ts`** — Register `createEmailSyncTools` in tool chain
- **`package.json`** — Add `turndown` + `@types/turndown`

### Key design decisions
- `emails_raw` is fully isolated — no FK to `messages`, `memories`, or any existing table
- HTML→markdown via turndown with email signature stripping
- Triage uses `getFastModel()` (Haiku) in batches of 50
- Upsert with `onConflictDoNothing` on (user_id, gmail_message_id) — safe to re-run
- Direction tracking (inbound/outbound) enables "who's waiting for your reply?" queries
