### PR TITLE
fix: use section_types array for canvases.sections.lookup criteria

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1692,7 +1692,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
             "canvases.sections.lookup",
             {
               canvas_id,
-              criteria: { any_header: true },
+              criteria: { section_types: ["any_header"] },
             },
           );
 


### PR DESCRIPTION
## Problem
`read_canvas` still returns `invalid_arguments` after PR #272.

## Root Cause
PR #272 changed `criteria: {}` to `criteria: { any_header: true }`, but the Slack API expects `section_types` as an **array of type strings**, not `any_header` as a boolean.

Per the [API docs](https://docs.slack.dev/reference/methods/canvases.sections.lookup):
```json
{ "section_types": ["any_header"] }
```

## Fix
One-line change: `{ any_header: true }` → `{ section_types: ["any_header"] }`