### PR TITLE
Conversation message truncation

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -453,7 +453,7 @@ function formatConversations(conversations: ConversationThread[]): string {
         .map((m) => {
           const timeAgo = relativeTime(new Date(m.createdAt));
           const speaker = m.role === "assistant" ? "Aura" : m.userId;
-          return `  ${speaker} (${timeAgo}): ${m.content.length > 300 ? m.content.substring(0, 300) + "…" : m.content}`;
+          return `  ${speaker} (${timeAgo}): ${m.content.length > 800 ? m.content.substring(0, 800) + "…" : m.content}`;
         })
         .join("\n");
       return `Thread in ${thread.channelId} (similarity: ${thread.bestSimilarity.toFixed(2)}):\n${msgs}`;


### PR DESCRIPTION
Bump conversation thread message truncation from 300 to 800 characters to fix GitHub issue #274.

---
<p><a href="https://cursor.com/agents?id=bc-5d7ae43a-c400-4b52-8062-19dd285d075e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d7ae43a-c400-4b52-8062-19dd285d075e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small prompt-only change; main impact is slightly higher token usage and potential context-window pressure, with no logic/security changes.
> 
> **Overview**
> In `formatConversations` (`src/personality/system-prompt.ts`), increases the per-message truncation limit for retrieved “Relevant past conversations” from **300** to **800** characters, so more thread context is injected into the system prompt before being ellipsized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e003174a1a44cf1f6505495161c6fa45906ff34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->