### PR TITLE
Conversation recency boost

### DIFF
--- a/src/memory/retrieve.ts
+++ b/src/memory/retrieve.ts
@@ -177,15 +177,25 @@ export async function retrieveConversations(
     }
 
     // Group by thread: use slack_thread_ts if present, otherwise slack_ts (top-level message)
-    const threadMap = new Map<string, { channelId: string; bestSimilarity: number }>();
+    const threadMap = new Map<string, { channelId: string; bestSimilarity: number; mostRecentMessageAt: Date }>();
     for (const r of relevant) {
       const threadKey = r.message.slackThreadTs || r.message.slackTs;
+      const messageDate = new Date(r.message.createdAt);
       const existing = threadMap.get(threadKey);
-      if (!existing || r.similarity > existing.bestSimilarity) {
+      if (!existing) {
         threadMap.set(threadKey, {
           channelId: r.message.channelId,
           bestSimilarity: r.similarity,
+          mostRecentMessageAt: messageDate,
         });
+      } else {
+        if (r.similarity > existing.bestSimilarity) {
+          existing.bestSimilarity = r.similarity;
+          existing.channelId = r.message.channelId;
+        }
+        if (messageDate > existing.mostRecentMessageAt) {
+          existing.mostRecentMessageAt = messageDate;
+        }
       }
     }
 
@@ -193,9 +203,16 @@ export async function retrieveConversations(
       threadMap.delete(excludeThreadTs);
     }
 
-    // Sort threads by best similarity and take top N
+    // Score threads: combine cosine similarity with recency boost
+    const now = Date.now();
     const sortedThreads = [...threadMap.entries()]
-      .sort((a, b) => b[1].bestSimilarity - a[1].bestSimilarity)
+      .map(([key, meta]) => {
+        const ageDays = (now - meta.mostRecentMessageAt.getTime()) / (1000 * 60 * 60 * 24);
+        const recencyBoost = Math.max(0, 1 - ageDays / 30);
+        const combinedScore = meta.bestSimilarity * 0.8 + recencyBoost * 0.2;
+        return [key, { ...meta, combinedScore }] as const;
+      })
+      .sort((a, b) => b[1].combinedScore - a[1].combinedScore)
       .slice(0, threadLimit);
 
     if (sortedThreads.length === 0) return [];


### PR DESCRIPTION
Adds recency boost to conversation thread retrieval to fix #275 and improve relevance.

---
<p><a href="https://cursor.com/agents?id=bc-66593568-7d95-4e30-91e7-ead7dae14cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66593568-7d95-4e30-91e7-ead7dae14cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small scoring change limited to conversation thread ranking; main risk is retrieval relevance/ordering changes rather than correctness or security.
> 
> **Overview**
> Conversation retrieval now applies a **recency boost** when ranking matched Slack threads, using each thread’s most recent message timestamp to compute a combined score.
> 
> Thread grouping metadata was expanded to track `mostRecentMessageAt`, and sorting changed from pure `bestSimilarity` to a weighted similarity/recency ranking before selecting the top `threadLimit` threads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b170fb976be39542e9d41cc88ac957119758c9c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->