### PR TITLE
Slack canvas content

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -145,18 +145,26 @@ function htmlToMarkdown(html: string): string {
   // Strikethrough
   s = s.replace(/<(s|strike|del)[^>]*>([\s\S]*?)<\/\1>/gi, "~$2~");
 
-  // Inline code
-  s = s.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, "`$1`");
+  // Code blocks: handle <pre><code>...</code></pre> as a single fenced block
+  s = s.replace(/<pre[^>]*>\s*<code[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/gi, "\n```\n$1\n```\n");
 
-  // Code blocks / pre
+  // Remaining standalone <pre> blocks
   s = s.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, "\n```\n$1\n```\n");
+
+  // Inline code (after pre blocks are handled)
+  s = s.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, "`$1`");
 
   // Links
   s = s.replace(/<a[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, "[$2]($1)");
 
-  // Images — use alt text or URL
-  s = s.replace(/<img[^>]*alt="([^"]*)"[^>]*src="([^"]*)"[^>]*\/?>/gi, "![$1]($2)");
-  s = s.replace(/<img[^>]*src="([^"]*)"[^>]*\/?>/gi, "![]($1)");
+  // Images — use alt text or URL (handles alt/src in any order)
+  s = s.replace(/<img[^>]*\/?>/gi, (tag) => {
+    const srcMatch = tag.match(/src="([^"]*)"/i);
+    const altMatch = tag.match(/alt="([^"]*)"/i);
+    const src = srcMatch ? srcMatch[1] : "";
+    const alt = altMatch ? altMatch[1] : "";
+    return `![${alt}](${src})`;
+  });
 
   // List items (before removing <ul>/<ol> tags)
   s = s.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "- $1\n");


### PR DESCRIPTION
Rewrite `read_canvas` tool to fetch canvas content via `files.info` and `url_private` download, as the previous implementation was broken.

The previous `canvases.sections.lookup` only returned section IDs, not content. This PR replaces it with a working implementation that fetches the canvas's HTML content and converts it to markdown using a new `htmlToMarkdown` helper. It also attempts to retrieve section IDs for compatibility with `edit_canvas`.

---
<p><a href="https://cursor.com/agents?id=bc-a911cc3a-2d33-4b14-8f91-801766b34d18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a911cc3a-2d33-4b14-8f91-801766b34d18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Slack Canvas retrieval to rely on authenticated `url_private` downloads and a regex-based HTML parser, which may be brittle to Slack HTML changes and could fail if token/scopes differ.
> 
> **Overview**
> Fixes the `read_canvas` Slack tool to return actual Canvas content by fetching the canvas file via `files.info`, downloading `url_private` HTML with auth, and converting it to readable Markdown.
> 
> Adds an `htmlToMarkdown` helper for basic HTML-to-Markdown conversion and keeps a best-effort `canvases.sections.lookup` call to return section IDs when available for `edit_canvas` compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff4900b625e1187000e72e0b01566edde3e7d023. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->