### PR TITLE
Thread context memory query

### DIFF
--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -34,11 +34,19 @@ export async function assemblePrompt(
 ): Promise<AssembledPrompt> {
   const start = Date.now();
 
+  // Build a richer query from thread context for better memory retrieval.
+  // Use the last 5 thread messages instead of just the latest message,
+  // falling back to the single message text if no thread is available.
+  const threadMessages = conversation.thread;
+  const queryText = threadMessages && threadMessages.length > 1
+    ? threadMessages.slice(-5).map(m => m.text).join('\n')
+    : context.text;
+
   // Embed the query once, then share the vector with both retrieval functions.
   // If the embedding API is unavailable, degrade gracefully (no memories/conversations).
   let queryEmbedding: number[] | undefined;
   try {
-    queryEmbedding = await embedText(context.text);
+    queryEmbedding = await embedText(queryText);
   } catch (error) {
     logger.error("Embedding failed, proceeding without memory context", {
       error: String(error),
@@ -49,7 +57,7 @@ export async function assemblePrompt(
   const [memories, conversations, userProfile] = await Promise.all([
     queryEmbedding
       ? retrieveMemories({
-          query: context.text,
+          query: queryText,
           queryEmbedding,
           currentUserId: context.userId,
           limit: 15,
@@ -57,7 +65,7 @@ export async function assemblePrompt(
       : Promise.resolve([] as Memory[]),
     queryEmbedding
       ? retrieveConversations({
-          query: context.text,
+          query: queryText,
           queryEmbedding,
           threadLimit: 3,
           matchLimit: 15,


### PR DESCRIPTION
Uses thread context for memory retrieval query embedding to improve retrieval accuracy.

This PR addresses GitHub issue #286 by modifying `src/pipeline/prompt.ts` to construct the memory retrieval query from the last 3-5 messages in a thread (if available), rather than just the last message. This provides a richer context for embedding, leading to more relevant memory and conversation retrieval. The `queryEmbedding` is now computed once from this richer `queryText` and passed to both `retrieveMemories` and `retrieveConversations`.

---
<p><a href="https://cursor.com/agents?id=bc-7dc00194-1115-4812-a66d-94977cdadeef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dc00194-1115-4812-a66d-94977cdadeef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to retrieval query construction; main risk is relevance/precision shifts in memory results rather than functional breakage.
> 
> **Overview**
> Improves memory/conversation retrieval by deriving the embedding query from recent thread context: when a thread exists, it now concatenates the last ~5 thread messages (instead of only the latest message) and uses that `queryText` for `embedText`, `retrieveMemories`, and `retrieveConversations`.
> 
> Behavior remains the same when no thread context is available (falls back to `context.text`), and retrieval still degrades gracefully if embedding fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f1943b128c6541bcc0ced13a87ee9e34a6811f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->