### PR TITLE
feat: email staging pipeline (Phase 1)

### DIFF
--- a/drizzle/0017_add_emails_raw.sql
+++ b/drizzle/0017_add_emails_raw.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "emails_raw" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" text NOT NULL,
+  "gmail_message_id" text NOT NULL,
+  "thread_id" text NOT NULL,
+  "subject" text,
+  "from_address" text,
+  "to_addresses" text[],
+  "cc_addresses" text[],
+  "date" timestamptz,
+  "body_markdown" text,
+  "body_html" text,
+  "labels" text[],
+  "size_bytes" integer,
+  "is_important" boolean,
+  "triage_reason" text,
+  "synced_at" timestamptz DEFAULT now() NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "emails_raw_user_message_idx" ON "emails_raw" ("user_id", "gmail_message_id");
+--> statement-breakpoint
+CREATE INDEX "emails_raw_user_date_idx" ON "emails_raw" ("user_id", "date");
+--> statement-breakpoint
+CREATE INDEX "emails_raw_thread_idx" ON "emails_raw" ("thread_id");
+--> statement-breakpoint
+CREATE INDEX "emails_raw_user_important_idx" ON "emails_raw" ("user_id", "is_important");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1771804800000,
       "tag": "0016_add_oauth_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1771891200000,
+      "tag": "0017_add_emails_raw",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@neondatabase/serverless": "^1.0.0",
         "@slack/web-api": "^7.14.0",
         "@tavily/core": "^0.7.1",
+        "@types/turndown": "^5.0.6",
         "@vercel/functions": "^3.4.2",
         "ai": "^6.0.86",
         "chalk": "4.1.2",
@@ -27,6 +28,7 @@
         "e2b": "^2.12.1",
         "google-auth-library": "^10.5.0",
         "hono": "^4.11.9",
+        "turndown": "^7.2.2",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -1145,6 +1147,11 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
+    },
     "node_modules/@neondatabase/serverless": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.2.tgz",
@@ -1275,6 +1282,11 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="
     },
     "node_modules/@upstash/redis": {
       "version": "1.36.2",
@@ -3870,6 +3882,14 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@neondatabase/serverless": "^1.0.0",
     "@slack/web-api": "^7.14.0",
     "@tavily/core": "^0.7.1",
+    "@types/turndown": "^5.0.6",
     "@vercel/functions": "^3.4.2",
     "ai": "^6.0.86",
     "chalk": "4.1.2",
@@ -35,6 +36,7 @@
     "e2b": "^2.12.1",
     "google-auth-library": "^10.5.0",
     "hono": "^4.11.9",
+    "turndown": "^7.2.2",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -343,6 +343,42 @@ export const oauthTokens = pgTable(
     index("oauth_tokens_email_idx").on(table.email),
   ],
 );
+// ── Emails Raw (email staging pipeline) ────────────────────────────────────
+
+export const emailsRaw = pgTable(
+  "emails_raw",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: text("user_id").notNull(),
+    gmailMessageId: text("gmail_message_id").notNull(),
+    threadId: text("thread_id").notNull(),
+    subject: text("subject"),
+    fromAddress: text("from_address"),
+    toAddresses: text("to_addresses").array(),
+    ccAddresses: text("cc_addresses").array(),
+    date: timestamp("date", { withTimezone: true, mode: "date" }),
+    bodyMarkdown: text("body_markdown"),
+    bodyHtml: text("body_html"),
+    labels: text("labels").array(),
+    sizeBytes: integer("size_bytes"),
+    isImportant: boolean("is_important"),
+    triageReason: text("triage_reason"),
+    syncedAt: timestamptz("synced_at").notNull().defaultNow(),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("emails_raw_user_message_idx").on(
+      table.userId,
+      table.gmailMessageId,
+    ),
+    index("emails_raw_user_date_idx").on(table.userId, table.date),
+    index("emails_raw_thread_idx").on(table.threadId),
+    index("emails_raw_user_important_idx").on(table.userId, table.isImportant),
+  ],
+);
+
 // ── Type exports ───────────────────────────────────────────────────────────
 
 export type Message = typeof messages.$inferSelect;
@@ -365,6 +401,8 @@ export type JobExecution = typeof jobExecutions.$inferSelect;
 export type NewJobExecution = typeof jobExecutions.$inferInsert;
 export type OAuthToken = typeof oauthTokens.$inferSelect;
 export type NewOAuthToken = typeof oauthTokens.$inferInsert;
+export type EmailRaw = typeof emailsRaw.$inferSelect;
+export type NewEmailRaw = typeof emailsRaw.$inferInsert;
 
 /** Context for tools that need to know the current conversation's routing. */
 export interface ScheduleContext {

--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -979,6 +979,248 @@ export function createGmailEATools() {
       },
     }),
 
+    sync_gmail: tool({
+      description:
+        "Sync emails from a user's Gmail account into the local emails_raw staging table. Fetches emails since a given date, converts HTML to markdown, and runs a Haiku triage pass to flag important/actionable emails for a startup CEO. Returns counts of synced, important, and skipped emails.",
+      inputSchema: z.object({
+        user_name: z
+          .string()
+          .describe(
+            "The display name, real name, or username of the Gmail account owner",
+          ),
+        since: z
+          .string()
+          .optional()
+          .default("2025-01-01")
+          .describe("ISO date to sync emails from (default '2025-01-01')"),
+        max_emails: z
+          .number()
+          .min(1)
+          .max(500)
+          .optional()
+          .default(100)
+          .describe("Maximum number of emails to sync (default 100, max 500)"),
+      }),
+      execute: async ({ user_name, since, max_emails }) => {
+        try {
+          const userId = await resolveSlackUserId(user_name);
+          if (!userId) {
+            return {
+              ok: false,
+              error: `Could not resolve Slack user '${user_name}'. Make sure they exist in the workspace.`,
+            };
+          }
+
+          const { getGmailClientForUser } = await import("../lib/gmail.js");
+          const gmailResult = await getGmailClientForUser(userId);
+          if (!gmailResult) {
+            return {
+              ok: false,
+              error: `No Gmail access for user '${user_name}'. They need to authorize Aura via OAuth first.`,
+            };
+          }
+          const gmail = gmailResult.client;
+
+          // Convert since date to Unix epoch for Gmail query
+          const sinceDate = new Date(since ?? "2025-01-01");
+          const sinceEpoch = Math.floor(sinceDate.getTime() / 1000);
+
+          // Fetch message IDs
+          const listRes = await gmail.users.messages.list({
+            userId: "me",
+            q: `after:${sinceEpoch}`,
+            maxResults: max_emails ?? 100,
+          });
+
+          const messages = listRes.data.messages ?? [];
+          if (messages.length === 0) {
+            return { ok: true, synced: 0, important: 0, skipped: 0 };
+          }
+
+          // Import dependencies
+          const { db } = await import("../db/client.js");
+          const { emailsRaw } = await import("../db/schema.js");
+          const { generateText } = await import("ai");
+          const { getFastModel } = await import("../lib/ai.js");
+          const TurndownService = (await import("turndown")).default;
+          const td = new TurndownService();
+          const { sql: drizzleSql } = await import("drizzle-orm");
+
+          let synced = 0;
+          let important = 0;
+          let skipped = 0;
+
+          // Process in batches of 10
+          const BATCH_SIZE = 10;
+          for (let i = 0; i < messages.length; i += BATCH_SIZE) {
+            const batch = messages.slice(i, i + BATCH_SIZE);
+            await Promise.all(
+              batch.map(async (msg) => {
+                try {
+                  const msgId = msg.id!;
+                  const fullMsg = await gmail.users.messages.get({
+                    userId: "me",
+                    id: msgId,
+                    format: "full",
+                  });
+                  const payload = fullMsg.data.payload;
+                  const headers = payload?.headers ?? [];
+
+                  const getHeader = (name: string) =>
+                    headers.find(
+                      (h) => h.name?.toLowerCase() === name.toLowerCase(),
+                    )?.value ?? null;
+
+                  const subject = getHeader("Subject");
+                  const fromAddress = getHeader("From");
+                  const toRaw = getHeader("To");
+                  const ccRaw = getHeader("Cc");
+                  const dateRaw = getHeader("Date");
+
+                  const toAddresses = toRaw
+                    ? toRaw.split(",").map((s) => s.trim())
+                    : [];
+                  const ccAddresses = ccRaw
+                    ? ccRaw.split(",").map((s) => s.trim())
+                    : [];
+                  const date = dateRaw ? new Date(dateRaw) : null;
+
+                  const labels = fullMsg.data.labelIds ?? [];
+                  const sizeBytes = fullMsg.data.sizeEstimate ?? null;
+                  const threadId = fullMsg.data.threadId ?? "";
+
+                  // Extract HTML body recursively from parts
+                  const extractBody = (
+                    part: any,
+                  ): { html: string | null; plain: string | null } => {
+                    if (!part) return { html: null, plain: null };
+                    if (part.mimeType === "text/html" && part.body?.data) {
+                      return {
+                        html: Buffer.from(
+                          part.body.data,
+                          "base64",
+                        ).toString("utf8"),
+                        plain: null,
+                      };
+                    }
+                    if (part.mimeType === "text/plain" && part.body?.data) {
+                      return {
+                        html: null,
+                        plain: Buffer.from(
+                          part.body.data,
+                          "base64",
+                        ).toString("utf8"),
+                      };
+                    }
+                    if (part.parts) {
+                      let html: string | null = null;
+                      let plain: string | null = null;
+                      for (const p of part.parts) {
+                        const result = extractBody(p);
+                        if (result.html) html = result.html;
+                        if (result.plain) plain = result.plain;
+                      }
+                      return { html, plain };
+                    }
+                    return { html: null, plain: null };
+                  };
+
+                  const { html: bodyHtml, plain: bodyPlain } =
+                    extractBody(payload);
+                  const bodyMarkdown = bodyHtml
+                    ? td.turndown(bodyHtml)
+                    : (bodyPlain ?? null);
+
+                  // Haiku triage gate
+                  let isImportant: boolean | null = null;
+                  let triageReason: string | null = null;
+                  try {
+                    const model = await getFastModel();
+                    const preview = (bodyMarkdown ?? "").slice(0, 500);
+                    const { text: triageRaw } = await generateText({
+                      model,
+                      system:
+                        "You are an email triage assistant for a startup CEO. Classify emails as important/actionable or not. Reply with valid JSON only.",
+                      prompt: `Subject: ${subject ?? "(no subject)"}\nFrom: ${fromAddress ?? "(unknown)"}\n\nBody preview:\n${preview}\n\nReply with JSON: {"is_important": true/false, "reason": "brief explanation"}`,
+                      maxOutputTokens: 100,
+                    });
+                    const parsed = JSON.parse(
+                      triageRaw.trim().replace(/^```json\n?/, "").replace(/\n?```$/, ""),
+                    );
+                    isImportant = Boolean(parsed.is_important);
+                    triageReason = String(parsed.reason ?? "");
+                  } catch {
+                    // Triage failure is non-fatal; leave null
+                  }
+
+                  // Upsert into emails_raw
+                  await db
+                    .insert(emailsRaw)
+                    .values({
+                      userId,
+                      gmailMessageId: msgId,
+                      threadId,
+                      subject,
+                      fromAddress,
+                      toAddresses,
+                      ccAddresses,
+                      date: date ?? undefined,
+                      bodyMarkdown,
+                      bodyHtml,
+                      labels,
+                      sizeBytes,
+                      isImportant,
+                      triageReason,
+                    })
+                    .onConflictDoUpdate({
+                      target: [emailsRaw.userId, emailsRaw.gmailMessageId],
+                      set: {
+                        subject: drizzleSql`EXCLUDED.subject`,
+                        fromAddress: drizzleSql`EXCLUDED.from_address`,
+                        toAddresses: drizzleSql`EXCLUDED.to_addresses`,
+                        ccAddresses: drizzleSql`EXCLUDED.cc_addresses`,
+                        date: drizzleSql`EXCLUDED.date`,
+                        bodyMarkdown: drizzleSql`EXCLUDED.body_markdown`,
+                        bodyHtml: drizzleSql`EXCLUDED.body_html`,
+                        labels: drizzleSql`EXCLUDED.labels`,
+                        sizeBytes: drizzleSql`EXCLUDED.size_bytes`,
+                        isImportant: drizzleSql`EXCLUDED.is_important`,
+                        triageReason: drizzleSql`EXCLUDED.triage_reason`,
+                        syncedAt: drizzleSql`now()`,
+                      },
+                    });
+
+                  synced++;
+                  if (isImportant) important++;
+                } catch (emailErr: any) {
+                  logger.warn("sync_gmail: failed to process email", {
+                    msgId: msg.id,
+                    error: emailErr.message,
+                  });
+                  skipped++;
+                }
+              }),
+            );
+          }
+
+          logger.info("sync_gmail tool called", {
+            userId,
+            synced,
+            important,
+            skipped,
+          });
+
+          return { ok: true, synced, important, skipped };
+        } catch (error: any) {
+          logger.error("sync_gmail failed", { error: error.message });
+          return {
+            ok: false,
+            error: `Failed to sync Gmail: ${error.message}`,
+          };
+        }
+      },
+    }),
+
     generate_gmail_auth_url: tool({
       description:
         "Generate a Google OAuth consent URL for a user to connect their Gmail account. DM the resulting URL to the user so they can click it and authorize Aura to read their inbox and create drafts.",


### PR DESCRIPTION
Implements #254 — Phase 1 of the email staging pipeline.

## What's new

### `emails_raw` table
New staging table for ingested Gmail emails. Completely isolated from existing Slack tables.

| Column | Type | Purpose |
|--------|------|---------|
| id | UUID | Primary key |
| user_id | text | Slack user ID of Gmail owner |
| gmail_message_id | text | Gmail message ID (unique with user_id) |
| thread_id | text | Gmail thread ID |
| subject, from_address, to_addresses, cc_addresses | text/text[] | Email metadata |
| date | timestamptz | Email send date |
| body_markdown | text | HTML converted to markdown via turndown |
| body_html | text | Original HTML preserved |
| labels | text[] | Gmail labels |
| size_bytes | integer | Email size |
| is_important | boolean | Haiku triage classification |
| triage_reason | text | Haiku's explanation |
| synced_at, created_at | timestamptz | Timestamps |

**Indexes:** unique(user_id, gmail_message_id), (user_id, date), (thread_id), (user_id, is_important)

### `sync_gmail` tool
New tool added to `createGmailEATools()`:
- Resolves user → Slack ID → Gmail OAuth client
- Fetches email IDs with `after:<epoch>` query
- Processes in batches of 10 with per-email error isolation
- Extracts HTML body recursively from MIME parts
- Converts HTML → markdown via `turndown`
- Runs Haiku triage gate (getFastModel → JSON classification)
- Upserts into `emails_raw` (idempotent re-syncs)

### Migration
- `drizzle/0017_add_emails_raw.sql` with CREATE TABLE + 4 indexes

### Dependencies
- `turndown` + `@types/turndown` added

## What this does NOT touch
- `messages` table — untouched
- `memories` table — untouched  
- `user_profiles` table — untouched
- Slack pipeline — untouched
- Embedding pipeline — untouched
- All existing tools — untouched

Closes #254
