### PR TITLE
Email sync query parameters

### DIFF
--- a/src/lib/email-sync.ts
+++ b/src/lib/email-sync.ts
@@ -14,7 +14,7 @@ import { logger } from "./logger.js";
 export interface SyncOptions {
   /** Gmail search query, e.g. "newer_than:7d" */
   query?: string;
-  /** Max number of messages to fetch per call (default 100) */
+  /** Max number of messages to fetch per call (default 500) */
   maxMessages?: number;
 }
 
@@ -111,7 +111,7 @@ export async function syncEmails(
   const { client: gmail, email: userEmail } = gmailResult;
 
   const query = options.query || "newer_than:7d";
-  const maxMessages = options.maxMessages || 100;
+  const maxMessages = options.maxMessages || 500;
 
   let allMessageIds: string[] = [];
   let pageToken: string | undefined;

--- a/src/tools/email-sync.ts
+++ b/src/tools/email-sync.ts
@@ -19,7 +19,7 @@ export function createEmailSyncTools(
   return {
     sync_emails: tool({
       description:
-        "Sync recent emails from a user's Gmail into the staging pipeline. Fetches from Gmail, converts HTML to markdown, and stores in emails_raw. Optionally runs Haiku triage. The user must have authorized Aura to access their Gmail. Admin-only.",
+        "Sync emails from a user's Gmail into the staging pipeline. Supports date windows (after/before), relative dates (newer_than), or raw Gmail queries. Resumable — re-running with the same query skips already-synced emails. Admin-only.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -32,12 +32,44 @@ export function createEmailSyncTools(
           .describe(
             "Gmail date filter, e.g. '2025/01/01'. Translated to 'after:<date>' query. Default: '2025/01/01'",
           ),
+        before: z
+          .string()
+          .optional()
+          .describe(
+            "Gmail date filter, e.g. '2025/06/01'. Translated to 'before:<date>' query.",
+          ),
+        newer_than: z
+          .string()
+          .optional()
+          .describe(
+            "Gmail relative date filter, e.g. '7d', '30d', '1y'. Translated to 'newer_than:<value>' query.",
+          ),
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Raw Gmail search query override. If provided, ignores after/before/newer_than. E.g. 'from:investor@fund.com newer_than:30d'",
+          ),
+        max_messages: z
+          .number()
+          .optional()
+          .describe(
+            "Max messages to fetch per sync call. Default 500 for backfills. Use smaller values (50-100) for quick syncs.",
+          ),
         triage: z
           .boolean()
           .optional()
           .describe("Run Haiku triage after sync (default true)"),
       }),
-      execute: async ({ user_name, after, triage }) => {
+      execute: async ({
+        user_name,
+        after,
+        before,
+        newer_than,
+        query: rawQuery,
+        triage,
+        max_messages,
+      }) => {
         if (!isAdmin(context?.userId)) {
           return {
             ok: false,
@@ -55,10 +87,23 @@ export function createEmailSyncTools(
           }
 
           const { syncEmails } = await import("../lib/email-sync.js");
-          const afterDate = after || "2025/01/01";
+
+          let gmailQuery: string;
+          if (rawQuery) {
+            gmailQuery = rawQuery;
+          } else if (newer_than) {
+            gmailQuery = `newer_than:${newer_than}`;
+          } else {
+            const afterDate = after || "2025/01/01";
+            gmailQuery = `after:${afterDate}`;
+            if (before) {
+              gmailQuery += ` before:${before}`;
+            }
+          }
+
           const syncResult = await syncEmails(user.id, {
-            query: `after:${afterDate}`,
-            maxMessages: 100,
+            query: gmailQuery,
+            maxMessages: max_messages || 500,
           });
 
           let triageResult = null;


### PR DESCRIPTION
Expand the `sync_emails` tool to expose full Gmail query parameters and `maxMessages` for resumable backfills and flexible email syncing.

---
<p><a href="https://cursor.com/agents?id=bc-cd6bbe2b-e2c1-459e-9e02-390de5a873cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd6bbe2b-e2c1-459e-9e02-390de5a873cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Larger default sync volumes and more flexible query construction can increase Gmail API usage and load on the email ingestion pipeline if misused, though the tool remains admin-only.
> 
> **Overview**
> Enables more flexible and resumable Gmail backfills by expanding the `sync_emails` tool to accept `before`, `newer_than`, and a raw `query` override, and by passing a configurable `max_messages` through to the underlying sync.
> 
> Increases the default per-run fetch limit from **100 → 500** in both `syncEmails` and the tool wrapper, updating docs/descriptions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6808f6dcd626f44f4e6c1a292ec55f9dc4be0e6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->