### PR TITLE
fix: surface triage error in TriageSummary return

### DIFF
--- a/src/lib/email-triage.ts
+++ b/src/lib/email-triage.ts
@@ -17,6 +17,7 @@ export interface TriageSummary {
   triaged: number;
   errors: number;
   breakdown: Record<string, number>;
+  lastError?: string;
 }
 
 // ── Haiku Triage Gate ───────────────────────────────────────────────────────
@@ -151,12 +152,14 @@ export async function triageEmails(
         }
       }
     } catch (err) {
+      const errStr = String(err);
       logger.error("Triage batch failed", {
         userId,
         batchStart: i,
-        error: String(err),
+        error: errStr,
       });
       summary.errors += batch.length;
+      summary.lastError = errStr;
     }
   }
 


### PR DESCRIPTION
## Problem
Email triage fails on all 494+ untriaged emails but we can't see why -- the catch block only logs to `logger.error` (Vercel stdout) which is inaccessible from outside the runtime.

## Fix
Add `lastError?: string` to `TriageSummary` interface. Capture the actual error string in the catch block. The `sync_emails` tool already returns the full `triageResult` object, so `lastError` will be visible in the tool response.

## Impact
Next time triage fails, we'll see the exact error message instead of just "errors: 494".