### PR TITLE
Email triage parsing

### DIFF
--- a/src/lib/email-triage.ts
+++ b/src/lib/email-triage.ts
@@ -1,4 +1,5 @@
-import { generateText } from "ai";
+import { generateObject } from "ai";
+import { z } from "zod";
 import { eq, and, isNull } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { emailsRaw } from "../db/schema.js";
@@ -7,18 +8,24 @@ import { logger } from "./logger.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-interface TriageResult {
-  id: string;
-  triage: "junk" | "fyi" | "actionable" | "urgent";
-  reason: string;
-}
-
 export interface TriageSummary {
   triaged: number;
   errors: number;
   breakdown: Record<string, number>;
   lastError?: string;
 }
+
+// ── Zod schema for structured output ────────────────────────────────────────
+
+const triageResultSchema = z.object({
+  id: z.string(),
+  triage: z.enum(["junk", "fyi", "actionable", "urgent"]),
+  reason: z.string(),
+});
+
+const triageBatchSchema = z.object({
+  results: z.array(triageResultSchema),
+});
 
 // ── Haiku Triage Gate ───────────────────────────────────────────────────────
 
@@ -29,10 +36,7 @@ const TRIAGE_PROMPT = `You are an email triage assistant. Classify each email in
 - **actionable**: requires a response or action within a reasonable timeframe
 - **urgent**: time-sensitive, needs immediate attention (client escalations, broken systems, deadlines today)
 
-For each email, respond with a JSON array of objects:
-[{"id": "<email_id>", "triage": "<category>", "reason": "<one-line explanation>"}]
-
-Only output the JSON array, no other text.`;
+For each email, return an object with "id", "triage" (the category), and "reason" (one-line explanation).`;
 
 /**
  * Triage un-classified emails in emails_raw using Claude Haiku.
@@ -100,35 +104,14 @@ export async function triageEmails(
 
     try {
       const model = await getFastModel();
-      const { text } = await generateText({
+      const { object } = await generateObject({
         model,
+        schema: triageBatchSchema,
         prompt,
         maxOutputTokens: 2000,
       });
 
-      const jsonMatch = text.match(/\[[\s\S]*\]/);
-      if (!jsonMatch) {
-        logger.warn("Triage response was not valid JSON", {
-          userId,
-          text: text.slice(0, 200),
-        });
-        summary.errors += batch.length;
-        continue;
-      }
-
-      const results: TriageResult[] = JSON.parse(jsonMatch[0]);
-
-      for (const r of results) {
-        const validCategories = ["junk", "fyi", "actionable", "urgent"];
-        if (!validCategories.includes(r.triage)) {
-          logger.warn("Invalid triage category", {
-            id: r.id,
-            triage: r.triage,
-          });
-          summary.errors++;
-          continue;
-        }
-
+      for (const r of object.results) {
         const updated = await db
           .update(emailsRaw)
           .set({


### PR DESCRIPTION
Replace manual JSON parsing in email triage with Zod structured output to fix LLM response parsing failures.

The previous regex + `JSON.parse` method was fragile and broke when the LLM (Haiku) returned multiple JSON arrays instead of a single combined one, leading to 100% email triage failure. This PR switches to Vercel AI SDK's `generateObject` with a Zod schema, ensuring robust and validated extraction of triage results.

---
<p><a href="https://cursor.com/agents?id=bc-04fcc4bf-72b4-4675-b917-b52771ab8e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04fcc4bf-72b4-4675-b917-b52771ab8e37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the LLM response contract and parsing path for updating email triage fields; failures will affect batch triage completion but are limited to this workflow.
> 
> **Overview**
> Email triage now uses `generateObject` with a Zod schema to get **structured, validated** classification results from the LLM instead of regex extraction and `JSON.parse`.
> 
> The triage prompt/output contract is updated to return a typed `results` object, and the previous manual JSON matching plus category validation logic is removed in favor of schema enforcement before updating `emails_raw`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 916f1b5ffb6a1ad2e58311707ca5c570c6e3fcf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->