### PR TITLE
fix: LanguageModelV3 type error blocking deployment

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -2,6 +2,7 @@ import { gateway, GatewayAuthenticationError } from "@ai-sdk/gateway";
 import {
   wrapLanguageModel,
   type LanguageModelMiddleware,
+  type LanguageModelV3,
 } from "ai";
 import { getSetting } from "./settings.js";
 import { logger } from "./logger.js";
@@ -98,7 +99,7 @@ function gatewayFallbackMiddleware(
  * For non-Anthropic models, returns the model unchanged.
  * For Anthropic models, wraps with fallback middleware.
  */
-function withAnthropicFallback<T>(gatewayModel: T, gatewayId: string): T {
+function withAnthropicFallback(gatewayModel: LanguageModelV3, gatewayId: string): LanguageModelV3 {
   const directId = toDirectAnthropicId(gatewayId);
   if (!directId) {
     return gatewayModel;
@@ -107,7 +108,7 @@ function withAnthropicFallback<T>(gatewayModel: T, gatewayId: string): T {
   return wrapLanguageModel({
     model: gatewayModel,
     middleware: gatewayFallbackMiddleware(directId),
-  }) as T;
+  });
 }
 
 /**


### PR DESCRIPTION
## Problem
PRs #297 (Anthropic fallback) and #301 (triage JSON fix) both merged to main but **fail to deploy** because `withAnthropicFallback<T>` uses a generic `T` that doesn't satisfy `wrapLanguageModel`'s `LanguageModelV3` parameter type.

```
src/lib/ai.ts(108,5): error TS2322: Type 'T' is not assignable to type 'LanguageModelV3'.
```

**Impact:** 509 emails stuck untriaged. Every triage attempt fails because production is running pre-#297 code (no Anthropic fallback) and pre-#301 code (broken JSON parser).

## Fix
Replace the generic `<T>` with concrete `LanguageModelV3` type. The generic was unnecessary since `wrapLanguageModel` always returns `LanguageModelV3` anyway.