### PR TITLE
fix: remove withAnthropicFallback from embedding models (type error)

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -130,8 +130,7 @@ export async function getEmbeddingModel() {
   const override = await getSetting("model_embedding");
   const gatewayId =
     override || process.env.MODEL_EMBEDDING || "openai/text-embedding-3-small";
-  const gatewayModel = gateway.embedding(gatewayId);
-  return withAnthropicFallback(gatewayModel, gatewayId);
+  return gateway.embedding(gatewayId);
 }
 
 /**
@@ -152,7 +151,4 @@ export const fastModel = withAnthropicFallback(
   STATIC_FAST_MODEL_ID,
 );
 
-export const embeddingModel = withAnthropicFallback(
-  gateway.embedding(STATIC_EMBEDDING_MODEL_ID),
-  STATIC_EMBEDDING_MODEL_ID,
-);
+export const embeddingModel = gateway.embedding(STATIC_EMBEDDING_MODEL_ID);


### PR DESCRIPTION
## Problem

PR #297 (Anthropic fallback) wrapped **embedding models** (`EmbeddingModelV1`) through `withAnthropicFallback()` which returns `LanguageModelV3` -- incompatible types. This causes:

```
src/lib/ai.ts(108,5): error TS2322: Type 'T' is not assignable to type 'LanguageModelV3'.
```

Both #297 and #301 failed to deploy because of this.

## Fix

Remove `withAnthropicFallback` from embedding models -- they don't use `wrapLanguageModel` and don't need the fallback middleware. Embedding calls go through gateway directly.

Two places fixed:
- `getEmbeddingModel()` (async, DB-backed)
- `embeddingModel` (static export)

## Testing

`tsc` transpile check passes. The real test is the Vercel build succeeding.