### PR TITLE
fix: LanguageModelV3 type import (build failure)

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -2,8 +2,10 @@ import { gateway, GatewayAuthenticationError } from "@ai-sdk/gateway";
 import {
   wrapLanguageModel,
   type LanguageModelMiddleware,
-  type LanguageModelV3,
 } from "ai";
+
+/** The model type that wrapLanguageModel accepts (LanguageModelV3, not re-exported by "ai"). */
+type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 import { getSetting } from "./settings.js";
 import { logger } from "./logger.js";
 
@@ -99,7 +101,7 @@ function gatewayFallbackMiddleware(
  * For non-Anthropic models, returns the model unchanged.
  * For Anthropic models, wraps with fallback middleware.
  */
-function withAnthropicFallback(gatewayModel: LanguageModelV3, gatewayId: string): LanguageModelV3 {
+function withAnthropicFallback(gatewayModel: WrappableModel, gatewayId: string): WrappableModel {
   const directId = toDirectAnthropicId(gatewayId);
   if (!directId) {
     return gatewayModel;


### PR DESCRIPTION
## Problem
`LanguageModelV3` is not exported from `"ai"` -- it's an internal type re-exported only from `@ai-sdk/provider` (a transitive dependency). PR #302 added this import and broke the build.

```
src/lib/ai.ts(5,8): error TS2724: '"ai"' has no exported member named 'LanguageModelV3'. Did you mean 'LanguageModel'?
```

## Fix
Extract the type from `wrapLanguageModel`'s own parameter signature:
```ts
type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
```

This is stable (derived from the public API) and doesn't depend on transitive packages.

## Verified
- `tsc` on `src/lib/ai.ts` passes with zero errors
- Unlike #302, this was checked with actual TypeScript program compilation, not just `transpileModule`

## Lesson
`ts.transpileModule()` only checks syntax. `npx tsc --noEmit` is the real check. Added this to my pre-commit process.