### PR TITLE
Email triage batch update

### DIFF
--- a/src/lib/email-triage.ts
+++ b/src/lib/email-triage.ts
@@ -1,6 +1,6 @@
 import { generateObject } from "ai";
 import { z } from "zod";
-import { eq, and, isNull } from "drizzle-orm";
+import { eq, and, isNull, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { emailsRaw } from "../db/schema.js";
 import { getFastModel } from "./ai.js";
@@ -111,27 +111,38 @@ export async function triageEmails(
         maxOutputTokens: 2000,
       });
 
-      for (const r of object.results) {
-        const updated = await db
-          .update(emailsRaw)
-          .set({
-            triage: r.triage,
-            triageReason: r.reason,
-            updatedAt: new Date(),
-          })
-          .where(and(eq(emailsRaw.id, r.id), eq(emailsRaw.userId, userId)))
-          .returning({ id: emailsRaw.id });
+      if (object.results.length > 0) {
+        const valueRows = object.results.map(
+          (r) => sql`(${r.id}::uuid, ${r.triage}, ${r.reason})`,
+        );
 
-        if (updated.length > 0) {
+        const updated = await db.execute(sql`
+          UPDATE emails_raw SET
+            triage = v.triage,
+            triage_reason = v.reason,
+            updated_at = now()
+          FROM (VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, triage, reason)
+          WHERE emails_raw.id = v.id
+            AND emails_raw.user_id = ${userId}
+          RETURNING emails_raw.id, v.triage AS triage_cat
+        `);
+
+        const updatedIds = new Set<string>();
+        for (const row of updated.rows as { id: string; triage_cat: string }[]) {
+          updatedIds.add(row.id);
           summary.triaged++;
-          summary.breakdown[r.triage] =
-            (summary.breakdown[r.triage] || 0) + 1;
-        } else {
-          logger.warn("Triage update matched no rows", {
-            id: r.id,
-            userId,
-          });
-          summary.errors++;
+          summary.breakdown[row.triage_cat] =
+            (summary.breakdown[row.triage_cat] || 0) + 1;
+        }
+
+        for (const r of object.results) {
+          if (!updatedIds.has(r.id)) {
+            logger.warn("Triage update matched no rows", {
+              id: r.id,
+              userId,
+            });
+            summary.errors++;
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
Replace sequential DB writes in email triage with a single batch SQL UPDATE statement to reduce database round-trips.

Previously, each email triage result was updated individually in a loop, leading to N database calls. This change consolidates all updates into a single `UPDATE ... FROM (VALUES ...)` query, significantly reducing the number of database round-trips and improving performance for email triage operations. The `RETURNING` clause ensures that per-row tracking and error detection logic remain functional.

---
<p><a href="https://cursor.com/agents?id=bc-4e1b717f-76c0-4f04-b9b1-56e7e2f9f9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e1b717f-76c0-4f04-b9b1-56e7e2f9f9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how triage writes are executed via raw SQL and type casting, which could affect update correctness or error accounting if the query shape/inputs differ from expectations.
> 
> **Overview**
> Improves email triage performance by replacing per-email `UPDATE` calls with a single batched `UPDATE ... FROM (VALUES ...)` statement per AI result batch.
> 
> The new query uses `drizzle-orm` `sql`/`db.execute` with `RETURNING` to count successful updates and build the category breakdown, while preserving warnings/errors for any triage results that did not match a row for the given `userId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4de8172c57b901f642edf1172cebf3b188fee823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->