### PR TITLE
Email thread state Haiku

### DIFF
--- a/drizzle/0019_add_thread_state_reason.sql
+++ b/drizzle/0019_add_thread_state_reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "emails_raw" ADD COLUMN "thread_state_reason" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1771891200000,
       "tag": "0018_add_thread_state",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1771977600000,
+      "tag": "0019_add_thread_state_reason",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -347,6 +347,7 @@ export const emailsRaw = pgTable(
     labels: jsonb("labels").$type<string[]>(),
     rawHeaders: jsonb("raw_headers").$type<Record<string, string>>(),
     threadState: text("thread_state"),
+    threadStateReason: text("thread_state_reason"),
     threadStateUpdatedAt: timestamptz("thread_state_updated_at"),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),

--- a/src/lib/email-thread-state.ts
+++ b/src/lib/email-thread-state.ts
@@ -1,6 +1,8 @@
+import { generateText } from "ai";
 import { eq, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { emailsRaw } from "../db/schema.js";
+import { getFastModel } from "./ai.js";
 import { logger } from "./logger.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -17,45 +19,130 @@ export interface ThreadStateSummary {
   breakdown: Record<ThreadState, number>;
 }
 
-interface ThreadMessage {
+interface ThreadEmail {
   gmailThreadId: string;
   direction: string;
   date: Date;
   triage: string | null;
+  fromEmail: string;
+  fromName: string | null;
+  toEmails: string[] | null;
+  ccEmails: string[] | null;
+  subject: string | null;
+  bodyMarkdown: string | null;
 }
 
-// ── Core Logic ──────────────────────────────────────────────────────────────
+interface ClassificationResult {
+  state: ThreadState;
+  reason: string;
+}
 
-function computeStateForThread(messages: ThreadMessage[]): ThreadState {
-  if (messages.length === 0) return "junk";
+const MAX_BODY_CHARS = 500;
+const LLM_CONCURRENCY = 8;
 
-  const allJunk = messages.every((m) => m.triage === "junk");
-  if (allJunk) return "junk";
+// ── Transcript builder ──────────────────────────────────────────────────────
 
-  const allJunkOrFyi = messages.every(
-    (m) => m.triage === "junk" || m.triage === "fyi",
+function buildTranscript(messages: ThreadEmail[]): string {
+  return messages
+    .map((m) => {
+      const dateStr = m.date.toISOString().replace("T", " ").slice(0, 16);
+      const from = m.fromName ? `${m.fromName} <${m.fromEmail}>` : m.fromEmail;
+      const to = (m.toEmails ?? []).join(", ") || "unknown";
+      const cc = m.ccEmails?.length ? `\nCC: ${m.ccEmails.join(", ")}` : "";
+      const subject = m.subject ? `\nSubject: ${m.subject}` : "";
+      const body = (m.bodyMarkdown || "").slice(0, MAX_BODY_CHARS);
+      return `[${dateStr}] FROM: ${from} TO: ${to}${cc}${subject}\n${body}`;
+    })
+    .join("\n\n");
+}
+
+// ── Derive user email from outbound messages in the thread ──────────────────
+
+function deriveUserEmail(messages: ThreadEmail[]): string | null {
+  const outbound = messages.find((m) => m.direction === "outbound");
+  return outbound?.fromEmail ?? null;
+}
+
+// ── LLM classification for inbound threads ──────────────────────────────────
+
+async function classifyInboundThread(
+  messages: ThreadEmail[],
+  userEmail: string,
+): Promise<ClassificationResult> {
+  const transcript = buildTranscript(messages);
+  const model = await getFastModel();
+
+  const { text } = await generateText({
+    model,
+    prompt: `You are triaging an email thread for ${userEmail}.
+Given the conversation below, classify the thread state:
+- "resolved" — no response needed (thank-you, confirmation, FYI, newsletter, notification)
+- "awaiting_your_reply" — ${userEmail} needs to respond to this thread
+- "fyi" — ${userEmail} is CC'd or not the primary addressee; no response expected
+
+Respond with ONLY a JSON object: {"state": "resolved"|"awaiting_your_reply"|"fyi", "reason": "one sentence"}
+
+Thread:
+${transcript}`,
+    maxOutputTokens: 200,
+  });
+
+  try {
+    const cleaned = text.replace(/```json\s*|```\s*/g, "").trim();
+    const parsed = JSON.parse(cleaned) as {
+      state: string;
+      reason: string;
+    };
+    const validStates = new Set(["resolved", "awaiting_your_reply", "fyi"]);
+    if (!validStates.has(parsed.state)) {
+      return { state: "awaiting_your_reply", reason: `LLM returned unknown state "${parsed.state}", defaulting` };
+    }
+    return {
+      state: parsed.state as ThreadState,
+      reason: parsed.reason || "",
+    };
+  } catch {
+    logger.warn("Failed to parse LLM classification response", {
+      text: text.slice(0, 200),
+    });
+    return { state: "awaiting_your_reply", reason: "LLM response unparseable, defaulting" };
+  }
+}
+
+// ── Concurrency limiter ─────────────────────────────────────────────────────
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      results[i] = await fn(items[i]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker()),
   );
-  if (allJunkOrFyi) return "fyi";
-
-  const last = messages[messages.length - 1];
-
-  if (last.direction === "outbound") {
-    return "awaiting_their_reply";
-  }
-
-  // Last message is inbound
-  if (last.triage === "fyi" || last.triage === "junk") {
-    return "fyi";
-  }
-
-  return "awaiting_your_reply";
+  return results;
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
 /**
- * Compute thread-level state for all threads belonging to a user,
- * then denormalize the state onto every row in each thread.
+ * Compute thread-level state for all threads belonging to a user.
+ *
+ * SQL pre-filters (no LLM needed):
+ *   - Last message outbound → awaiting_their_reply
+ *   - All messages junk → junk
+ *
+ * For inbound threads, calls Haiku to classify as
+ * resolved / awaiting_your_reply / fyi.
  */
 export async function computeThreadStates(
   userId: string,
@@ -77,6 +164,12 @@ export async function computeThreadStates(
       direction: emailsRaw.direction,
       date: emailsRaw.date,
       triage: emailsRaw.triage,
+      fromEmail: emailsRaw.fromEmail,
+      fromName: emailsRaw.fromName,
+      toEmails: emailsRaw.toEmails,
+      ccEmails: emailsRaw.ccEmails,
+      subject: emailsRaw.subject,
+      bodyMarkdown: emailsRaw.bodyMarkdown,
     })
     .from(emailsRaw)
     .where(eq(emailsRaw.userId, userId))
@@ -88,7 +181,7 @@ export async function computeThreadStates(
   }
 
   // Group by thread
-  const threads = new Map<string, ThreadMessage[]>();
+  const threads = new Map<string, ThreadEmail[]>();
   for (const row of rows) {
     const existing = threads.get(row.gmailThreadId);
     if (existing) {
@@ -98,26 +191,96 @@ export async function computeThreadStates(
     }
   }
 
-  // Compute state per thread and batch the updates
-  const stateMap = new Map<ThreadState, string[]>();
-  for (const [threadId, messages] of threads) {
-    const state = computeStateForThread(messages);
-    summary.threadsProcessed++;
-    summary.breakdown[state]++;
+  // Classify: SQL pre-filter first, collect inbound threads for LLM
+  type ThreadUpdate = { threadId: string; state: ThreadState; reason: string };
+  const sqlUpdates: ThreadUpdate[] = [];
+  const inboundThreads: { threadId: string; messages: ThreadEmail[] }[] = [];
 
-    const existing = stateMap.get(state);
-    if (existing) {
-      existing.push(threadId);
+  for (const [threadId, messages] of threads) {
+    summary.threadsProcessed++;
+    const last = messages[messages.length - 1];
+
+    const allJunk = messages.every((m) => m.triage === "junk");
+    if (allJunk) {
+      sqlUpdates.push({ threadId, state: "junk", reason: "all messages triaged as junk" });
+      continue;
+    }
+
+    if (last.direction === "outbound") {
+      sqlUpdates.push({ threadId, state: "awaiting_their_reply", reason: "last message is outbound" });
+      continue;
+    }
+
+    // Last message is inbound → needs LLM classification
+    inboundThreads.push({ threadId, messages });
+  }
+
+  // Derive user email from any outbound message across all threads
+  let userEmail: string | null = null;
+  for (const [, messages] of threads) {
+    userEmail = deriveUserEmail(messages);
+    if (userEmail) break;
+  }
+  if (!userEmail) {
+    userEmail = "user";
+  }
+
+  // Run LLM classification with concurrency limit
+  if (inboundThreads.length > 0) {
+    logger.info("Classifying inbound threads with LLM", {
+      userId,
+      count: inboundThreads.length,
+    });
+
+    const llmResults = await mapWithConcurrency(
+      inboundThreads,
+      LLM_CONCURRENCY,
+      async ({ threadId, messages }) => {
+        try {
+          const result = await classifyInboundThread(messages, userEmail!);
+          return { threadId, state: result.state, reason: result.reason };
+        } catch (err) {
+          logger.error("LLM classification failed for thread", {
+            threadId,
+            error: String(err),
+          });
+          return {
+            threadId,
+            state: "awaiting_your_reply" as ThreadState,
+            reason: `LLM error: ${String(err).slice(0, 100)}`,
+          };
+        }
+      },
+    );
+
+    sqlUpdates.push(...llmResults);
+  }
+
+  // Tally breakdown
+  for (const { state } of sqlUpdates) {
+    summary.breakdown[state]++;
+  }
+
+  // Batch UPDATE per state+reason: group by state, then bulk update
+  const stateGroups = new Map<ThreadState, { threadIds: string[]; reasons: Map<string, string[]> }>();
+  for (const { threadId, state, reason } of sqlUpdates) {
+    let group = stateGroups.get(state);
+    if (!group) {
+      group = { threadIds: [], reasons: new Map() };
+      stateGroups.set(state, group);
+    }
+    group.threadIds.push(threadId);
+    const reasonThreads = group.reasons.get(reason);
+    if (reasonThreads) {
+      reasonThreads.push(threadId);
     } else {
-      stateMap.set(state, [threadId]);
+      group.reasons.set(reason, [threadId]);
     }
   }
 
-  // Batch UPDATE per state value to minimise round-trips
   const now = new Date();
-  for (const [state, threadIds] of stateMap) {
+  for (const [state, { threadIds }] of stateGroups) {
     if (threadIds.length === 0) continue;
-
     const threadIdValues = threadIds.map((id) => sql`${id}`);
     await db.execute(sql`
       UPDATE emails_raw
@@ -129,9 +292,25 @@ export async function computeThreadStates(
     `);
   }
 
+  // Write per-thread reasons (via VALUES join for efficiency)
+  const allReasonUpdates = sqlUpdates.filter((u) => u.reason);
+  if (allReasonUpdates.length > 0) {
+    const valueRows = allReasonUpdates.map(
+      (u) => sql`(${u.threadId}, ${u.reason})`,
+    );
+    await db.execute(sql`
+      UPDATE emails_raw SET
+        thread_state_reason = v.reason
+      FROM (VALUES ${sql.join(valueRows, sql`, `)}) AS v(thread_id, reason)
+      WHERE emails_raw.user_id = ${userId}
+        AND emails_raw.gmail_thread_id = v.thread_id
+    `);
+  }
+
   logger.info("Thread state computation completed", {
     userId,
     ...summary,
+    llmClassified: inboundThreads.length,
   });
 
   return summary;


### PR DESCRIPTION
Reworks thread state classification to use Haiku LLM for inbound threads to improve accuracy beyond simple SQL rules.

---
<p><a href="https://cursor.com/agents?id=bc-3a32d1d6-0219-472d-bd9c-14a32621522e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a32d1d6-0219-472d-bd9c-14a32621522e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces LLM-dependent classification and new DB writes for thread metadata, which can change behavior and adds failure/latency/cost considerations despite having conservative fallbacks.
> 
> **Overview**
> Thread state computation is reworked to use an LLM (Haiku via `getFastModel` + `generateText`) for threads whose last message is inbound, while keeping SQL-only shortcuts for *all-junk* threads and *last outbound* threads.
> 
> The classifier now builds a lightweight transcript (sender/recipients/subject + truncated body), runs with a concurrency cap, defaults safely on parse/errors, and writes a new per-thread `thread_state_reason` alongside `thread_state` back onto `emails_raw` (new column + bulk update).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c093a8188404c600a77888bd81e6708f293c5d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->