### PR TITLE
XAI Grok model entries

### DIFF
--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -22,7 +22,7 @@ const MAIN_MODELS: ModelOption[] = [
   { value: "openai/gpt-4o", label: "GPT-4o" },
   { value: "google/gemini-3-pro-preview", label: "Gemini 3 Pro" },
   { value: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-  { value: "xai/grok-4.1", label: "Grok 4.1" },
+  { value: "xai/grok-4.1-fast-reasoning", label: "Grok 4.1 Fast" },
   { value: "deepseek/deepseek-v3.2-thinking", label: "DeepSeek V3.2 Thinking" },
 ];
 
@@ -33,6 +33,8 @@ const FAST_MODELS: ModelOption[] = [
   { value: "openai/gpt-4o-mini", label: "GPT-4o Mini" },
   { value: "google/gemini-3-flash", label: "Gemini 3 Flash" },
   { value: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  { value: "xai/grok-4.1-fast-non-reasoning", label: "Grok 4.1 Fast NR" },
+  { value: "xai/grok-code-fast-1", label: "Grok Code Fast 1" },
   { value: "deepseek/deepseek-v3.2", label: "DeepSeek V3.2" },
 ];
 


### PR DESCRIPTION
Update xAI Grok model entries to use correct and available Vercel AI Gateway model IDs.

---
<p><a href="https://cursor.com/agents?id=bc-cdc947f8-17fa-4c9c-a1d0-e66d708023e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc947f8-17fa-4c9c-a1d0-e66d708023e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts static model option IDs/labels used in the Slack Home dropdowns; primary risk is selecting a non-existent model ID at runtime.
> 
> **Overview**
> Updates the Slack Home model dropdown catalog to use the currently supported Vercel AI Gateway xAI Grok model IDs.
> 
> Replaces the previous `xai/grok-4.1` entry with `xai/grok-4.1-fast-reasoning` in the main model list, and adds `xai/grok-4.1-fast-non-reasoning` plus `xai/grok-code-fast-1` to the fast model list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d68cdd97eef3de28b94c8b60137b69ff5f2309cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->