### PR TITLE
Posthog API key sandbox

### DIFF
--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -62,6 +62,9 @@ export async function getSandboxEnvs(): Promise<Record<string, string>> {
   if (process.env.OPENAI_API_KEY) {
     envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
   }
+  if (process.env.POSTHOG_API_KEY) {
+    envs.POSTHOG_API_KEY = process.env.POSTHOG_API_KEY;
+  }
   return envs;
 }
 


### PR DESCRIPTION
Add `POSTHOG_API_KEY` to the E2B sandbox environment to make it accessible for operations within the sandbox.

---
<p><a href="https://cursor.com/agents?id=bc-7b28663b-aabe-4d9b-a75f-198f215ee4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b28663b-aabe-4d9b-a75f-198f215ee4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only forwards an existing environment variable into the sandbox; minimal behavioral impact beyond widening secret exposure to sandboxed processes.
> 
> **Overview**
> Makes `POSTHOG_API_KEY` available inside the E2B sandbox by adding it to the env map returned by `getSandboxEnvs()` when present in the Vercel process environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8795984e5c017f959976b3a1e8261d403dea64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->