### PR TITLE
PR identification logic

### DIFF
--- a/src/webhook/github.ts
+++ b/src/webhook/github.ts
@@ -44,26 +44,55 @@ function isOurPRSync(pr: { head?: { ref?: string }; user?: { login?: string } })
   return OUR_GITHUB_USERNAMES.includes(author);
 }
 
-async function isOurPR(pr: { head?: { ref?: string }; user?: { login?: string } }): Promise<boolean> {
+async function isOurPR(pr: { number?: number; head?: { ref?: string }; user?: { login?: string } }): Promise<boolean> {
   if (isOurPRSync(pr)) return true;
 
   // Check if this branch was created by a Cursor agent we dispatched
   // Cursor agents create PRs under joanrodriguez's account, but we track them via notes
   const branch = pr.head?.ref || "";
-  if (!branch) return false;
-
-  const trackingNotes = await db
-    .select({ topic: notes.topic })
-    .from(notes)
-    .where(
-      and(
-        like(notes.topic, 'cursor-agent:%'),
-        like(notes.content, `%${branch.replace(/[\\%_]/g, "\\$&")}%`)
+  if (branch) {
+    const trackingNotes = await db
+      .select({ topic: notes.topic })
+      .from(notes)
+      .where(
+        and(
+          like(notes.topic, 'cursor-agent:%'),
+          like(notes.content, `%${branch.replace(/[\\%_]/g, "\\$&")}%`)
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
 
-  return trackingNotes.length > 0;
+    if (trackingNotes.length > 0) return true;
+  }
+
+  // check_run PR objects lack the user field — fetch full PR to check authorship
+  if (!pr.user && pr.number) {
+    try {
+      const ghToken = await getGitHubToken();
+      if (ghToken) {
+        const res = await fetch(
+          `https://api.github.com/repos/${REPO}/pulls/${pr.number}`,
+          {
+            headers: {
+              Authorization: `token ${ghToken}`,
+              Accept: "application/vnd.github.v3+json",
+            },
+          },
+        );
+        if (res.ok) {
+          const fullPr = (await res.json()) as { user?: { login?: string } };
+          return isOurPRSync(fullPr);
+        }
+      }
+    } catch (err) {
+      logger.warn("isOurPR: failed to fetch full PR details", {
+        pr: pr.number,
+        error: String(err),
+      });
+    }
+  }
+
+  return false;
 }
 
 async function getGitHubToken(): Promise<string | null> {


### PR DESCRIPTION
Refactor `isOurPR` to correctly identify Aura's PRs and Cursor agent PRs by checking author usernames and tracking notes.

The previous implementation using branch prefixes and an incorrect bot author was unreliable, leading to missed PRs and false positives. The new approach uses the correct `aura-vidal` username and queries tracking notes for Cursor agent-dispatched branches.

---
<p><a href="https://cursor.com/agents?id=bc-136676d3-15bf-43bf-ba0c-d3692cd1b1a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-136676d3-15bf-43bf-ba0c-d3692cd1b1a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches webhook gating logic and adds DB queries + a GitHub API fetch, so misidentification or transient failures could cause missed/extra automated processing and increased external dependencies.
> 
> **Overview**
> Refactors the GitHub webhook’s “is this one of our agent PRs?” logic to stop relying on branch prefixes/old bot authors and instead accept PRs authored by `aura-vidal`, or PRs whose branch appears in `notes` tracking entries (`cursor-agent:%`).
> 
> Updates webhook handlers to await the new async `isOurPR`, and for `check_run` PR objects that omit `user`, it now optionally fetches full PR details from the GitHub API (using the stored token) before deciding whether to process the event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c04b2ef3a1be3e21c2b6eb14d1e4668375ee2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->