### PR TITLE
Email sync error details

### DIFF
--- a/src/lib/email-sync.ts
+++ b/src/lib/email-sync.ts
@@ -8,6 +8,7 @@ import {
   hasAttachmentParts,
 } from "./gmail.js";
 import { logger } from "./logger.js";
+import { logError } from "./error-logger.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -18,10 +19,16 @@ export interface SyncOptions {
   maxMessages?: number;
 }
 
+export interface SyncError {
+  gmailMessageId: string;
+  reason: string;
+}
+
 export interface SyncResult {
   synced: number;
   skipped: number;
   errors: number;
+  errorDetails: SyncError[];
 }
 
 // ── HTML to Markdown ────────────────────────────────────────────────────────
@@ -244,7 +251,7 @@ export async function syncEmails(
   userId: string,
   options: SyncOptions = {},
 ): Promise<SyncResult> {
-  const result: SyncResult = { synced: 0, skipped: 0, errors: 0 };
+  const result: SyncResult = { synced: 0, skipped: 0, errors: 0, errorDetails: [] };
 
   const gmailResult = await getGmailClientForUser(userId);
   if (!gmailResult) {
@@ -293,7 +300,16 @@ export async function syncEmails(
     for (const id of batchIds) {
       const msg = messageMap.get(id);
       if (!msg) {
+        const reason = "batch_api_miss: message ID listed but not returned by batch API";
+        result.errorDetails.push({ gmailMessageId: id, reason });
         result.errors++;
+        logError({
+          errorName: "EmailSyncError",
+          errorMessage: reason,
+          errorCode: "email_sync_error",
+          userId,
+          context: { gmailMessageId: id },
+        });
         continue;
       }
       try {
@@ -301,15 +317,33 @@ export async function syncEmails(
         if (row) {
           rows.push(row);
         } else {
+          const reason = "messageToRow_null: missing required fields";
+          result.errorDetails.push({ gmailMessageId: id, reason });
           result.errors++;
+          logError({
+            errorName: "EmailSyncError",
+            errorMessage: reason,
+            errorCode: "email_sync_error",
+            userId,
+            context: { gmailMessageId: id },
+          });
         }
       } catch (err) {
+        const reason = String(err);
         logger.warn("Failed to process message", {
           userId,
           msgId: id,
-          error: String(err),
+          error: reason,
         });
+        result.errorDetails.push({ gmailMessageId: id, reason });
         result.errors++;
+        logError({
+          errorName: "EmailSyncError",
+          errorMessage: reason,
+          errorCode: "email_sync_error",
+          userId,
+          context: { gmailMessageId: id },
+        });
       }
     }
 

--- a/src/tools/email-sync.ts
+++ b/src/tools/email-sync.ts
@@ -131,11 +131,20 @@ export function createEmailSyncTools(
             message = syncSummary;
           }
 
+          if (syncResult.errors > 0 && syncResult.errorDetails.length > 0) {
+            const sample = syncResult.errorDetails.slice(0, 3);
+            message += `\nError samples: ${sample.map((e) => `${e.gmailMessageId}: ${e.reason}`).join("; ")}`;
+            if (syncResult.errorDetails.length > 3) {
+              message += ` (and ${syncResult.errorDetails.length - 3} more)`;
+            }
+          }
+
           return {
             ok: true,
             synced: syncResult.synced,
             skipped: syncResult.skipped,
             errors: syncResult.errors,
+            errorDetails: syncResult.errorDetails.slice(0, 20),
             threadStates,
             triageSkipped: shouldClassify && isLargeSync,
             message,


### PR DESCRIPTION
Surface email sync errors with details and log them to the `error_events` table to improve visibility and debugging.

---
<p><a href="https://cursor.com/agents?id=bc-2db80a72-4584-4781-8d32-8ffc8943dbad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db80a72-4584-4781-8d32-8ffc8943dbad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new error-event writes during sync, which could increase logging volume and DB writes on large or failure-heavy syncs; core sync behavior is otherwise unchanged.
> 
> **Overview**
> Adds per-message error tracking to Gmail sync by extending `SyncResult` with `errorDetails` (message id + reason) and emitting `logError` events when the batch API omits a message, `messageToRow` returns null, or message processing throws.
> 
> Updates the `sync_emails` tool to include a small sample of these errors in the returned `message` and return up to 20 `errorDetails` entries for debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6459f3b84485c646b8b920a71de3ed66f46575f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->