### PR TITLE
feat: browser automation tool (Playwright + Browserbase)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "e2b": "^2.12.1",
         "google-auth-library": "^10.5.0",
         "hono": "^4.11.9",
+        "playwright-core": "^1.58.2",
         "turndown": "^7.2.2",
         "zod": "^3.24.4"
       },
@@ -2833,6 +2834,17 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "e2b": "^2.12.1",
     "google-auth-library": "^10.5.0",
     "hono": "^4.11.9",
+    "playwright-core": "^1.58.2",
     "turndown": "^7.2.2",
     "zod": "^3.24.4"
   },

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,0 +1,187 @@
+import { logger } from "./logger.js";
+
+/** Environment variables required for Browserbase integration */
+export interface BrowserbaseConfig {
+  apiKey: string;
+  projectId: string;
+}
+
+/** Options for creating a new browser session */
+export interface CreateSessionOptions {
+  /** Custom browser settings */
+  browserSettings?: {
+    fingerprint?: {
+      locales?: string[];
+      viewport?: { width: number; height: number };
+    };
+  };
+  /** Session timeout in seconds */
+  timeoutSeconds?: number;
+}
+
+/** Browser session information */
+export interface BrowserSession {
+  id: string;
+  projectId: string;
+  status: string;
+  createdAt: string;
+  connectUrl: string;
+  seleniumUrl: string;
+}
+
+/** Error response from Browserbase API */
+export interface BrowserbaseError {
+  error: string;
+  message: string;
+}
+
+/**
+ * Get Browserbase configuration from environment variables
+ */
+function getBrowserbaseConfig(): BrowserbaseConfig {
+  const apiKey = process.env.BROWSERBASE_API_KEY;
+  const projectId = process.env.BROWSERBASE_PROJECT_ID;
+
+  if (!apiKey) {
+    throw new Error(
+      "BROWSERBASE_API_KEY is not configured. Browser automation is not available.",
+    );
+  }
+
+  if (!projectId) {
+    throw new Error(
+      "BROWSERBASE_PROJECT_ID is not configured. Browser automation is not available.",
+    );
+  }
+
+  return { apiKey, projectId };
+}
+
+/**
+ * Create a new browser session via Browserbase REST API
+ */
+export async function createSession(
+  options: CreateSessionOptions = {},
+): Promise<BrowserSession> {
+  const config = getBrowserbaseConfig();
+
+  const requestBody = {
+    projectId: config.projectId,
+    browserSettings: {
+      fingerprint: {
+        locales: ["en-US"],
+        ...options.browserSettings?.fingerprint,
+      },
+      ...options.browserSettings,
+    },
+  };
+
+  logger.info("Creating Browserbase session", {
+    projectId: config.projectId,
+    options,
+  });
+
+  try {
+    const response = await fetch("https://api.browserbase.com/v1/sessions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-bb-api-key": config.apiKey,
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as BrowserbaseError;
+      throw new Error(`Browserbase API error: ${error.message || error.error}`);
+    }
+
+    const session = (await response.json()) as BrowserSession;
+
+    logger.info("Browserbase session created", {
+      sessionId: session.id,
+      status: session.status,
+    });
+
+    return session;
+  } catch (error: any) {
+    logger.error("Failed to create Browserbase session", {
+      error: error.message,
+    });
+    throw new Error(`Failed to create browser session: ${error.message}`);
+  }
+}
+
+/**
+ * Connect to an existing browser session via Chrome DevTools Protocol
+ */
+export async function connectSession(sessionId: string): Promise<any> {
+  const config = getBrowserbaseConfig();
+
+  logger.info("Connecting to Browserbase session", { sessionId });
+
+  try {
+    // Dynamic import to keep Playwright as an optional dependency
+    const { chromium } = await import("playwright-core");
+
+    const connectUrl = `wss://connect.browserbase.com?apiKey=${config.apiKey}&sessionId=${sessionId}`;
+
+    const browser = await chromium.connectOverCDP(connectUrl);
+
+    logger.info("Connected to Browserbase session", { sessionId });
+
+    return browser;
+  } catch (error: any) {
+    logger.error("Failed to connect to Browserbase session", {
+      sessionId,
+      error: error.message,
+    });
+    throw new Error(`Failed to connect to browser session: ${error.message}`);
+  }
+}
+
+/**
+ * Release a browser session, freeing up resources
+ */
+export async function releaseSession(sessionId: string): Promise<void> {
+  const config = getBrowserbaseConfig();
+
+  logger.info("Releasing Browserbase session", { sessionId });
+
+  try {
+    const response = await fetch(
+      `https://api.browserbase.com/v1/sessions/${sessionId}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-bb-api-key": config.apiKey,
+        },
+        body: JSON.stringify({
+          status: "REQUEST_RELEASE",
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as BrowserbaseError;
+      throw new Error(`Browserbase API error: ${error.message || error.error}`);
+    }
+
+    logger.info("Browserbase session released", { sessionId });
+  } catch (error: any) {
+    logger.error("Failed to release Browserbase session", {
+      sessionId,
+      error: error.message,
+    });
+    // Don't throw here - we want to be resilient to release failures
+    logger.warn("Continuing despite session release failure", { sessionId });
+  }
+}
+
+/**
+ * Convert a Buffer to base64 string for JSON serialization
+ */
+export function bufferToBase64(buffer: Buffer): string {
+  return buffer.toString("base64");
+}

--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -244,6 +244,9 @@ Web:
 - **web_search** — search the web for current information, documentation, news, etc.
 - **read_url** — fetch a URL and extract its readable text content (for reading links people paste)
 
+Browser (Browserbase + Playwright):
+- **browse** — automate a remote Chromium browser via Browserbase. Two modes: (1) Simple mode: provide a URL to navigate, take a screenshot, and extract text/accessibility/HTML. (2) Code mode: provide Playwright JS code for multi-step automation (page, context, browser variables available). Supports session reuse for multi-step flows, custom headers, stealth fingerprinting, and configurable timeouts. Admin-only.
+
 Sandbox (Linux VM):
 - **run_command** — execute any shell command in a sandboxed Linux VM (default timeout 120s, max 750s). This is your universal tool for computation: file ops (cat, head, tee), git, code execution (node, python), search (rg, grep), data processing (curl, jq), and self-modification via Claude Code (\`claude\`). Install anything else with apt-get or pip. Use higher timeouts (up to 750s) for long-running agent commands like Claude Agent SDK or Codex CLI — the 750s ceiling leaves a 50s buffer before the Vercel function timeout at 800s.
 
@@ -302,6 +305,7 @@ Status:
 Web access:
 - Use web_search when someone asks about external topics, current events, documentation, or anything outside the workspace.
 - Use read_url when someone pastes a link and asks "what does this say?" or "can you read this?"
+- Use browse when you need to interact with a webpage beyond simple fetching — clicking buttons, filling forms, taking screenshots, or running multi-step Playwright automations. For simple text extraction, prefer read_url.
 - Don't search the web for things you can find in the workspace (use search_messages or read_channel_history instead).
 
 Email:

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -1,0 +1,322 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { Browser, Page, BrowserContext } from "playwright-core";
+import {
+  createSession,
+  connectSession,
+  releaseSession,
+  bufferToBase64,
+} from "../lib/browser.js";
+import { isAdmin } from "../lib/permissions.js";
+import { logger } from "../lib/logger.js";
+import type { ScheduleContext } from "../db/schema.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Truncate text to a max length */
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + `\n...(truncated, ${text.length} chars total)`;
+}
+
+/** Extract text content from a page */
+async function extractContent(
+  page: Page,
+  mode: "text" | "accessibility" | "html",
+): Promise<string> {
+  switch (mode) {
+    case "text":
+      return truncate((await page.innerText("body")).trim(), 16000);
+    case "html":
+      return truncate(await page.content(), 32000);
+    case "accessibility": {
+      const snapshot = await page.accessibility.snapshot();
+      return truncate(JSON.stringify(snapshot, null, 2), 16000);
+    }
+    default:
+      return truncate((await page.innerText("body")).trim(), 16000);
+  }
+}
+
+/** Collect console errors during page operations */
+function setupConsoleCollector(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      errors.push(msg.text());
+    }
+  });
+  page.on("pageerror", (err) => {
+    errors.push(err.message);
+  });
+  return errors;
+}
+
+// ── Tool Definition ──────────────────────────────────────────────────────────
+
+export function createBrowserTools(context?: ScheduleContext) {
+  return {
+    browse: tool({
+      description:
+        "Browse a webpage or automate browser interactions using Browserbase (remote Chromium). Two modes: (1) Simple: provide a URL to navigate, take screenshots, and extract content. (2) Code: provide Playwright JS code for multi-step automation (variables `page`, `context`, `browser` are available). Returns screenshot as base64, extracted text/HTML/accessibility tree, and console errors. Admin-only.",
+      inputSchema: z.object({
+        url: z
+          .string()
+          .optional()
+          .describe(
+            "URL to navigate to (simple mode). Mutually exclusive with code.",
+          ),
+        code: z
+          .string()
+          .optional()
+          .describe(
+            "Playwright JS code to execute (code mode). Has access to `page`, `context`, `browser`. Must return a result object or void. Mutually exclusive with url.",
+          ),
+        session_id: z
+          .string()
+          .optional()
+          .describe(
+            "Reuse an existing Browserbase session ID. If omitted, a new session is created and released after.",
+          ),
+        screenshot: z
+          .boolean()
+          .default(true)
+          .describe("Take a screenshot after navigation (default true)."),
+        extract: z
+          .enum(["text", "accessibility", "html"])
+          .optional()
+          .describe(
+            "Extract content from the page. 'text' = innerText, 'accessibility' = a11y tree, 'html' = raw HTML.",
+          ),
+        headers: z
+          .record(z.string())
+          .optional()
+          .describe("Custom HTTP headers to set before navigation."),
+        stealth: z
+          .boolean()
+          .default(true)
+          .describe("Use stealth fingerprinting (default true)."),
+        timeout_seconds: z
+          .number()
+          .min(5)
+          .max(120)
+          .default(30)
+          .describe(
+            "Timeout for the operation in seconds (default 30, max 120).",
+          ),
+      }),
+      execute: async ({
+        url,
+        code,
+        session_id,
+        screenshot,
+        extract,
+        headers,
+        stealth,
+        timeout_seconds,
+      }) => {
+        // Admin-only check
+        if (!isAdmin(context?.userId) && context?.userId !== "aura") {
+          return {
+            ok: false,
+            error: "Only admins can use the browse tool.",
+          };
+        }
+
+        // Validate input
+        if (!url && !code) {
+          return {
+            ok: false,
+            error:
+              "Provide either 'url' (simple mode) or 'code' (code mode).",
+          };
+        }
+        if (url && code) {
+          return {
+            ok: false,
+            error:
+              "Provide either 'url' or 'code', not both.",
+          };
+        }
+
+        if (
+          !process.env.BROWSERBASE_API_KEY ||
+          !process.env.BROWSERBASE_PROJECT_ID
+        ) {
+          return {
+            ok: false,
+            error:
+              "Browser automation is not available. BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID must be configured.",
+          };
+        }
+
+        const ownSession = !session_id;
+        let browser: Browser | null = null;
+        let currentSessionId = session_id || "";
+
+        try {
+          // Create or reuse session
+          if (ownSession) {
+            const session = await createSession({
+              browserSettings: stealth
+                ? { fingerprint: { locales: ["en-US"] } }
+                : undefined,
+            });
+            currentSessionId = session.id;
+          }
+
+          // Connect to the session
+          browser = await connectSession(currentSessionId);
+          const contexts = browser.contexts();
+          const browserContext: BrowserContext =
+            contexts.length > 0 ? contexts[0] : await browser.newContext();
+          const pages = browserContext.pages();
+          const page: Page =
+            pages.length > 0 ? pages[0] : await browserContext.newPage();
+
+          // Set custom headers if provided
+          if (headers) {
+            await page.setExtraHTTPHeaders(headers);
+          }
+
+          const consoleErrors = setupConsoleCollector(page);
+
+          const timeoutMs = timeout_seconds * 1000;
+
+          let resultUrl = page.url();
+          let resultTitle = "";
+          let screenshotBase64: string | undefined;
+          let extractedContent: string | undefined;
+          let codeResult: unknown;
+
+          if (url) {
+            // ── Simple mode ──
+            logger.info("browse tool: navigating", {
+              url,
+              sessionId: currentSessionId,
+            });
+
+            await page.goto(url, {
+              waitUntil: "domcontentloaded",
+              timeout: timeoutMs,
+            });
+
+            // Wait a bit for dynamic content
+            await page.waitForTimeout(1000);
+
+            resultUrl = page.url();
+            resultTitle = await page.title();
+
+            if (screenshot) {
+              const buf = await page.screenshot({
+                type: "png",
+                fullPage: false,
+              });
+              screenshotBase64 = bufferToBase64(buf);
+            }
+
+            if (extract) {
+              extractedContent = await extractContent(page, extract);
+            }
+          } else if (code) {
+            // ── Code mode ──
+            logger.info("browse tool: executing code", {
+              codeLength: code.length,
+              sessionId: currentSessionId,
+            });
+
+            // Create a sandboxed function with page, context, browser available
+            const AsyncFunction = Object.getPrototypeOf(
+              async function () {},
+            ).constructor;
+            const fn = new AsyncFunction(
+              "page",
+              "context",
+              "browser",
+              code,
+            );
+
+            codeResult = await Promise.race([
+              fn(page, browserContext, browser),
+              new Promise((_, reject) =>
+                setTimeout(
+                  () => reject(new Error("Code execution timed out")),
+                  timeoutMs,
+                ),
+              ),
+            ]);
+
+            resultUrl = page.url();
+            resultTitle = await page.title();
+
+            if (screenshot) {
+              const buf = await page.screenshot({
+                type: "png",
+                fullPage: false,
+              });
+              screenshotBase64 = bufferToBase64(buf);
+            }
+
+            if (extract) {
+              extractedContent = await extractContent(page, extract);
+            }
+          }
+
+          const result: Record<string, unknown> = {
+            ok: true,
+            url: resultUrl,
+            title: resultTitle,
+            session_id: currentSessionId,
+            console_errors: consoleErrors.slice(0, 10),
+          };
+
+          if (screenshotBase64) {
+            result.screenshot_base64 = screenshotBase64;
+          }
+          if (extractedContent) {
+            result.extracted_content = extractedContent;
+          }
+          if (codeResult !== undefined) {
+            result.code_result =
+              typeof codeResult === "string"
+                ? codeResult
+                : JSON.stringify(codeResult);
+          }
+
+          logger.info("browse tool: completed", {
+            url: resultUrl,
+            title: resultTitle,
+            sessionId: currentSessionId,
+            hasScreenshot: !!screenshotBase64,
+            hasExtract: !!extractedContent,
+            consoleErrors: consoleErrors.length,
+          });
+
+          return result;
+        } catch (error: any) {
+          logger.error("browse tool: failed", {
+            error: error.message,
+            sessionId: currentSessionId,
+          });
+          return {
+            ok: false,
+            error: error.message,
+            session_id: currentSessionId || undefined,
+          };
+        } finally {
+          // Clean up
+          if (browser) {
+            try {
+              await browser.close();
+            } catch {
+              // ignore close errors
+            }
+          }
+          if (ownSession && currentSessionId) {
+            await releaseSession(currentSessionId);
+          }
+        }
+      },
+    }),
+  };
+}

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -7,6 +7,7 @@ import { createNoteTools } from "./notes.js";
 import { createJobTools } from "./jobs.js";
 import { createListWriteTools } from "./lists.js";
 import { createSandboxTools } from "./sandbox.js";
+import { createBrowserTools } from "./browser.js";
 import { createWebTools } from "./web.js";
 import { createBigQueryTools } from "./bigquery.js";
 import { createTableTools } from "./table.js";
@@ -2795,6 +2796,9 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     // ── Sandbox Tools ────────────────────────────────────────────────────
     ...createSandboxTools(context),
+
+    // ── Browser Tools (Browserbase + Playwright) ──────────────────────────
+    ...createBrowserTools(context),
 
     // ── BigQuery Tools ────────────────────────────────────────────────────
     ...createBigQueryTools(context),


### PR DESCRIPTION
Implements #314. Browser automation via Browserbase remote Chromium + Playwright.

## New files
- **src/lib/browser.ts** (186 lines) — Session management: `createSession()`, `connectSession()`, `releaseSession()`
- **src/tools/browser.ts** (322 lines) — `browse` tool with two modes:
  - **Simple mode**: `browse({ url, screenshot?, extract?, headers? })` — navigate, screenshot, extract text/accessibility/HTML
  - **Code mode**: `browse({ code, session_id? })` — execute Playwright JS for multi-step flows

## Modified files
- **src/tools/slack.ts** — Register `createBrowserTools(context)`
- **src/personality/system-prompt.ts** — Add browse tool docs
- **package.json** — Add `playwright-core` dependency

## Key design decisions
- Admin-only (`isAdmin` check, same as `run_command`)
- Extract modes: `text` (innerText), `accessibility` (a11y snapshot), `html` (raw markup)
- Session reuse via `session_id` for multi-step flows
- Auto-release sessions when created fresh
- Dynamic `playwright-core` import to avoid cold-start cost

> **Note:** tsc could not run in E2B sandbox (482MB RAM, tsc needs ~500MB+). Syntax parsing verified. Full type-check will run in CI.