### PR TITLE
Browse tool loading

### DIFF
--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -320,7 +320,7 @@ export function createBrowserTools(context?: ScheduleContext): Record<string, an
     }),
   };
   } catch (err) {
-    logger.error("Failed to create browser tools:", err);
+    logger.error("Failed to create browser tools", { error: String(err) });
     return {};
   }
 }


### PR DESCRIPTION
Fixes the `browse` tool disappearing at runtime by removing top-level `playwright-core` imports and defensively wrapping tool creation.

The `browse` tool was absent at runtime on Vercel because the bundler failed to process `playwright-core` due to a top-level `import type` statement in `src/tools/browser.ts`. This PR removes all module-level references to `playwright-core` (including type imports) and replaces Playwright-specific types with `any`. Additionally, `createBrowserTools` is now wrapped in a `try/catch` to ensure that tool registration never throws, returning an empty object if `playwright-core` cannot be loaded, thus preventing other tools from being affected.

---
<p><a href="https://cursor.com/agents/bc-a15ac1cb-54d0-4fb7-b23f-a4a44b35af5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a15ac1cb-54d0-4fb7-b23f-a4a44b35af5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes plus a defensive `try/catch` around tool registration; behavior is unchanged except that failures now degrade gracefully and could hide underlying init errors.
> 
> **Overview**
> Prevents the `browse` tool from failing to register in some runtime/bundler environments by removing the top-level `playwright-core` type import and replacing `Browser`/`Page`/`BrowserContext` annotations with `any`.
> 
> Wraps `createBrowserTools` in a `try/catch` so tool creation can’t throw during module initialization; on failure it logs `Failed to create browser tools` and returns `{}`, avoiding breaking aggregated tool registration (e.g., in `src/tools/slack.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad50b06d38cede7ed9cbd3c577d504547872ce67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->