### PR TITLE
File upload and DMs

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2306,7 +2306,9 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
           if (channelId) completeParams.channel_id = channelId;
           if (thread_ts) completeParams.thread_ts = thread_ts;
 
-          await client.files.completeUploadExternal(completeParams as any);
+          const completeResp = await client.files.completeUploadExternal(completeParams as any);
+
+          const fileUrl = (completeResp as any).files?.[0]?.permalink ?? null;
 
           logger.info("upload_file tool called", {
             filename,
@@ -2317,7 +2319,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
           return {
             ok: true,
             file_id: fileId,
-            file_url: null,
+            file_url: fileUrl,
           };
         } catch (error: any) {
           logger.error("upload_file tool failed", {


### PR DESCRIPTION
Fixes `upload_file` tool by replacing deprecated `filesUploadV2` with the 3-step modern API and adds DM channel resolution.

The previous `filesUploadV2` method returned `null` for `file_id` and `file_url`, causing files to upload but not be visibly shared. This PR implements the explicit 3-step upload process to ensure files are properly shared and introduces robust DM channel resolution for direct message uploads.

---
<p><a href="https://cursor.com/agents/bc-75ef3076-752b-49d5-828b-44082280b893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ef3076-752b-49d5-828b-44082280b893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Slack file-upload flow and channel resolution; mistakes could cause uploads to fail or files to not be shared, but the change is localized to `upload_file`.
> 
> **Overview**
> Fixes the `upload_file` Slack tool by replacing the deprecated `filesUploadV2` call with Slack’s 3-step external upload flow (`files.getUploadURLExternal` → POST file bytes → `files.completeUploadExternal`), ensuring a real `file_id` and shareable permalink are returned.
> 
> Improves `channel` handling for uploads by accepting DM channel IDs (`D…`) directly and, when a non-ID value isn’t a channel, attempting to resolve it as a user and open a DM via `conversations.open` before failing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75a79715a9e5fa2cf0abab66589820ab89eb2dbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->