### PR TITLE
Agent step limit awareness

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -7,7 +7,7 @@ import { getMainModel } from "../lib/ai.js";
 import { createSlackTools } from "../tools/slack.js";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
-import { createHeadlessPrepareStep } from "../pipeline/prepare-step.js";
+import { createHeadlessPrepareStep, HEADLESS_STEP_LIMIT } from "../pipeline/prepare-step.js";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -161,7 +161,7 @@ export async function executeJob(
         channelId: job.channelId || undefined,
         threadTs: job.threadTs || undefined,
       }),
-      stopWhen: stepCountIs(350),
+      stopWhen: stepCountIs(HEADLESS_STEP_LIMIT),
       prepareStep: createHeadlessPrepareStep(systemPrompt),
     });
 

--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -1,7 +1,7 @@
 import { logger } from "../lib/logger.js";
 
-const STEP_LIMIT = 250;
-const HEADLESS_STEP_LIMIT = 350;
+export const STEP_LIMIT = 250;
+export const HEADLESS_STEP_LIMIT = 350;
 const WARNING_THRESHOLD = 200;
 const HEADLESS_WARNING_THRESHOLD = 300;
 

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -8,7 +8,7 @@ import { logError } from "../lib/error-logger.js";
 import { formatForSlack } from "../lib/format.js";
 import { TABLE_BLOCK_KEY } from "../tools/table.js";
 import { safePostMessage, isChannelTypeNotSupported, isInvalidBlocks, isMsgTooLong } from "../lib/slack-messaging.js";
-import { createInteractivePrepareStep } from "./prepare-step.js";
+import { createInteractivePrepareStep, STEP_LIMIT } from "./prepare-step.js";
 
 // ── Tool I/O Persistence ─────────────────────────────────────────────────────
 // Accumulated during streaming and attached as invisible Slack message metadata
@@ -516,7 +516,7 @@ export async function generateResponse(
     model,
     system: options.systemPrompt,
     tools: createSlackTools(options.slackClient, options.context),
-    stopWhen: stepCountIs(250),
+    stopWhen: stepCountIs(STEP_LIMIT),
     prepareStep: createInteractivePrepareStep(options.systemPrompt),
     abortSignal: abortController.signal,
   };


### PR DESCRIPTION
Implement `prepareStep` to inject a system message warning the AI when it's approaching its step limit, encouraging it to wrap up.

---
<p><a href="https://cursor.com/agents/bc-a7df0fdf-d8a2-4541-bb35-7397a49d5dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7df0fdf-d8a2-4541-bb35-7397a49d5dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a system-prompt nudge and centralizes step-limit constants without changing tool behavior or data flows.
> 
> **Overview**
> Adds a reusable `prepareStep` helper that appends a system-level “wrap up” warning when the agent nears its configured step limit (with separate thresholds/limits for interactive vs headless runs).
> 
> Wires this into both interactive Slack streaming (`respond.ts`) and headless job execution (`execute-job.ts`), replacing hardcoded `stepCountIs(250/350)` values with shared `STEP_LIMIT`/`HEADLESS_STEP_LIMIT` constants and enabling graceful wrap-up before the SDK hard-stops.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79713b4ffd9824c4a7e7d4ce69b524fcc88b0d39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->