### PR TITLE
feat: generic run_subagent tool with scoped presets (#340)

### DIFF
--- a/src/lib/subagent.ts
+++ b/src/lib/subagent.ts
@@ -1,0 +1,117 @@
+import { generateText, stepCountIs, type ToolSet } from "ai";
+import { logger } from "./logger.js";
+
+/** Model type accepted by generateText */
+type GenerateTextModel = Parameters<typeof generateText>[0]["model"];
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface SubagentConfig {
+  /** Model to use for the subagent (e.g. fast model for triage, main model for investigation) */
+  model: GenerateTextModel;
+  /** Subset of tools the subagent can use */
+  tools: ToolSet;
+  /** System prompt scoped to the subagent's task */
+  systemPrompt: string;
+  /** User prompt describing what the subagent should do */
+  userPrompt: string;
+  /** Maximum number of agentic loop steps (default 50) */
+  maxSteps?: number;
+}
+
+export interface SubagentResult {
+  /** Final text output from the subagent */
+  text: string;
+  /** Token usage for the entire subagent run */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+  /** Number of steps the subagent took */
+  stepCount: number;
+  /** Tool calls made during execution (name + truncated output) */
+  toolCalls: Array<{ toolName: string; isError: boolean }>;
+}
+
+// ── Subagent Runner ──────────────────────────────────────────────────────────
+
+/**
+ * Run a subagent with isolated context.
+ *
+ * Subagents are mini agent loops that run a focused task with a scoped set of
+ * tools and their own context window. The parent agent only sees the compressed
+ * result, keeping its context clean for the broader conversation.
+ *
+ * Uses `generateText` (non-streaming) with its own tool loop.
+ */
+export async function runSubagent(config: SubagentConfig): Promise<SubagentResult> {
+  const {
+    model,
+    tools,
+    systemPrompt,
+    userPrompt,
+    maxSteps = 50,
+  } = config;
+
+  const startMs = Date.now();
+
+  logger.info("subagent: starting", {
+    toolCount: Object.keys(tools).length,
+    maxSteps,
+    promptLength: userPrompt.length,
+  });
+
+  const result = await generateText({
+    model,
+    system: systemPrompt,
+    prompt: userPrompt,
+    tools,
+    stopWhen: stepCountIs(maxSteps),
+  });
+
+  const { text, steps, totalUsage: usage } = result;
+
+  const toolCalls = steps.flatMap(
+    (step) =>
+      step.toolCalls?.map((tc) => {
+        const tr = step.toolResults?.find(
+          (r) => r.toolCallId === tc.toolCallId,
+        );
+        const output = tr?.output;
+        const isError =
+          (tr as any)?.isError === true ||
+          (output != null &&
+            typeof output === "object" &&
+            "ok" in (output as Record<string, unknown>) &&
+            (output as Record<string, unknown>).ok === false);
+        return { toolName: tc.toolName, isError };
+      }) ?? [],
+  );
+
+  const elapsedMs = Date.now() - startMs;
+
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const totalTokens = usage.totalTokens ?? (inputTokens + outputTokens);
+
+  logger.info("subagent: completed", {
+    elapsedMs,
+    stepCount: steps.length,
+    toolCallCount: toolCalls.length,
+    inputTokens,
+    outputTokens,
+    textLength: text.length,
+  });
+
+  return {
+    text: text || "Subagent completed without text output.",
+    usage: {
+      inputTokens,
+      outputTokens,
+      totalTokens,
+    },
+    stepCount: steps.length,
+    toolCalls,
+  };
+}

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -16,6 +16,7 @@ import { createConversationSearchTools } from "./conversations.js";
 import { createEmailTools, createGmailEATools } from "./email.js";
 import { createEmailSyncTools } from "./email-sync.js";
 import { createSheetsTools } from "./sheets.js";
+import { createSubagentTools } from "./subagents.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { formatForSlack } from "../lib/format.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
@@ -2873,5 +2874,8 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     // ── Conversation Search Tools (search stored messages DB) ─────────
     ...createConversationSearchTools(context),
+
+    // ── Subagent Tools (isolated context subtask delegation) ─────────
+    ...createSubagentTools(client, context),
   };
 }

--- a/src/tools/subagents.ts
+++ b/src/tools/subagents.ts
@@ -1,0 +1,145 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { WebClient } from "@slack/web-api";
+import { logger } from "../lib/logger.js";
+import { isAdmin } from "../lib/permissions.js";
+import { runSubagent } from "../lib/subagent.js";
+import { getFastModel, getMainModel } from "../lib/ai.js";
+import type { ScheduleContext } from "../db/schema.js";
+
+import { createNoteTools } from "./notes.js";
+import { createBigQueryTools } from "./bigquery.js";
+import { createWebTools } from "./web.js";
+import { createSandboxTools } from "./sandbox.js";
+import { createEmailTools, createGmailEATools } from "./email.js";
+import { createEmailSyncTools } from "./email-sync.js";
+import { createSheetsTools } from "./sheets.js";
+import { createConversationSearchTools } from "./conversations.js";
+import { createSlackTools } from "./slack.js";
+
+/**
+ * Scope presets map scope hints to tool subsets.
+ * The parent agent picks the scope at runtime based on the task.
+ */
+function buildToolScope(
+  scope: string,
+  client: WebClient,
+  context?: ScheduleContext,
+) {
+  switch (scope) {
+    case "email":
+      return {
+        ...createEmailTools(),
+        ...createGmailEATools(),
+        ...createEmailSyncTools(client, context),
+        ...createNoteTools(context),
+      };
+    case "data":
+      return {
+        ...createBigQueryTools(context),
+        ...createSheetsTools(),
+        ...createNoteTools(context),
+      };
+    case "web":
+      return {
+        ...createWebTools(),
+        ...createSandboxTools(context),
+      };
+    case "slack":
+      return {
+        ...createSlackTools(client, context),
+      };
+    case "notes":
+      return {
+        ...createNoteTools(context),
+        ...createConversationSearchTools(context),
+      };
+    case "all":
+    default:
+      return createSlackTools(client, context);
+  }
+}
+
+export function createSubagentTools(
+  client: WebClient,
+  context?: ScheduleContext,
+) {
+  return {
+    run_subagent: tool({
+      description:
+        "Run a focused subtask in an isolated context window. The subagent gets its own conversation context and a scoped set of tools, preventing context pollution in the parent. Use for heavy tasks like email triage, data analysis, bug investigation, or any multi-step work that would bloat the main context. The subagent returns a compressed summary. Admin-only.",
+      inputSchema: z.object({
+        task: z
+          .string()
+          .describe(
+            "What the subagent should do. Be specific — this is the user prompt.",
+          ),
+        system_prompt: z
+          .string()
+          .optional()
+          .describe(
+            "Optional system prompt for the subagent. If omitted, a generic 'execute this task and return a summary' prompt is used.",
+          ),
+        scope: z
+          .enum(["email", "data", "web", "slack", "notes", "all"])
+          .default("all")
+          .describe(
+            "Tool scope hint. 'email' = email tools + notes. 'data' = BigQuery + Sheets + notes. 'web' = web search + sandbox. 'slack' = full Slack toolset. 'notes' = notes + conversation search. 'all' = everything.",
+          ),
+        model_preference: z
+          .enum(["fast", "main"])
+          .default("fast")
+          .describe(
+            "Which model to use. 'fast' = Haiku (cheap, good for triage/summarization). 'main' = same model as parent (expensive, for complex reasoning).",
+          ),
+        max_steps: z
+          .number()
+          .min(1)
+          .max(100)
+          .default(50)
+          .describe("Maximum agent loop steps for the subagent."),
+      }),
+      execute: async ({
+        task,
+        system_prompt,
+        scope,
+        model_preference,
+        max_steps,
+      }) => {
+        if (context?.userId && !isAdmin(context.userId)) {
+          return { ok: false as const, error: "Admin-only tool" };
+        }
+
+        const model =
+          model_preference === "main"
+            ? await getMainModel()
+            : await getFastModel();
+
+        const tools = buildToolScope(scope, client, context);
+
+        const safeTools = { ...tools };
+        delete (safeTools as Record<string, unknown>).run_subagent;
+
+        const defaultSystemPrompt =
+          "You are a focused subtask agent. Execute the task below thoroughly, then provide a clear, concise summary of your findings and any actions taken. Be specific with data, names, and numbers.";
+
+        const result = await runSubagent({
+          model,
+          tools: safeTools,
+          systemPrompt: system_prompt || defaultSystemPrompt,
+          userPrompt: task,
+          maxSteps: max_steps,
+        });
+
+        return {
+          ok: true as const,
+          summary: result.text,
+          usage: result.usage,
+          stepCount: result.stepCount,
+          toolCallCount: result.toolCalls.length,
+          errors: result.toolCalls.filter((tc) => tc.isError).length,
+        };
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## What

Replaces the rejected PR #355 (hardcoded email/bug subagents) with a single generic `run_subagent` tool. The parent agent chooses task, scope, and model at runtime.

**Scope presets:** `email`, `data`, `web`, `slack`, `notes`, `all` -- map to tool subsets. Generalizable and productizable.

Keeps the solid `runSubagent` primitive from #355, replaces the hardcoded tools with one generic tool.

Closes #340