### PR TITLE
Twilio API keys sandbox

### DIFF
--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -65,6 +65,12 @@ export async function getSandboxEnvs(): Promise<Record<string, string>> {
   if (process.env.POSTHOG_API_KEY) {
     envs.POSTHOG_API_KEY = process.env.POSTHOG_API_KEY;
   }
+  if (process.env.TWILIO_API_KEY_SID) {
+    envs.TWILIO_API_KEY_SID = process.env.TWILIO_API_KEY_SID;
+  }
+  if (process.env.TWILIO_API_KEY_SECRET) {
+    envs.TWILIO_API_KEY_SECRET = process.env.TWILIO_API_KEY_SECRET;
+  }
   return envs;
 }
 


### PR DESCRIPTION
Pass `TWILIO_API_KEY_SID` and `TWILIO_API_KEY_SECRET` to the E2B sandbox environment.

The task requested adding these to a `.bashrc` persistence block, but no such block exists in the codebase; environment variables are passed directly via the `envs` object.

---
<p><a href="https://cursor.com/agents/bc-ee7d46dc-8a83-419d-a27a-d8acf017d926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee7d46dc-8a83-419d-a27a-d8acf017d926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

