### PR TITLE
Email thread state override

### DIFF
--- a/src/tools/email-sync.ts
+++ b/src/tools/email-sync.ts
@@ -9,6 +9,7 @@ import { db } from "../db/client.js";
 import { emailsRaw } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { resolveUserByName } from "./slack.js";
+import { threadStateValues } from "../lib/email-triage.js";
 
 // ── Tool Definitions ────────────────────────────────────────────────────────
 
@@ -396,13 +397,7 @@ export function createEmailSyncTools(
               "Search by subject (partial match) if thread ID unknown",
             ),
           thread_state: z
-            .enum([
-              "junk",
-              "resolved",
-              "awaiting_your_reply",
-              "awaiting_their_reply",
-              "fyi",
-            ])
+            .enum(threadStateValues)
             .describe("New state"),
           reason: z
             .string()
@@ -442,7 +437,8 @@ export function createEmailSyncTools(
           if (gmail_thread_id) {
             conditions.push(eq(emailsRaw.gmailThreadId, gmail_thread_id));
           } else if (subject_search) {
-            conditions.push(ilike(emailsRaw.subject, `%${subject_search}%`));
+            const escaped = subject_search.replace(/[\\%_]/g, "\\$&");
+            conditions.push(ilike(emailsRaw.subject, `%${escaped}%`));
           }
 
           // Find distinct threads that match


### PR DESCRIPTION
Adds `update_email_thread` tool to allow users to manually override email thread states, closing #362.

---
<p><a href="https://cursor.com/agents/bc-fc4b9c66-b59a-42d9-b761-4cc84fb7ce54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc4b9c66-b59a-42d9-b761-4cc84fb7ce54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new write path that updates `emailsRaw` rows (by thread ID or subject search); mistakes in matching/authorization could incorrectly reclassify multiple threads, though updates are scoped to the current user unless admin.
> 
> **Overview**
> Adds a new `update_email_thread` tool to manually override an email thread’s triage state (and optional reason), updating all `emails_raw` rows in matching threads.
> 
> The tool can target threads by exact `gmail_thread_id` or by partial subject match (case-insensitive), and enforces that non-admins may only update their own threads; it logs updates and returns a summary of affected threads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c39fdfe9ea5d8018593aeeab93aacd1c067ce4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->