### PR TITLE
Browse tool image output

### DIFF
--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -320,6 +320,29 @@ export function createBrowserTools(context?: ScheduleContext): Record<string, an
           }
         }
       },
+      toModelOutput({ output }) {
+        if (!output || typeof output !== "object") {
+          return { type: "text", value: JSON.stringify(output) };
+        }
+
+        const { screenshot_base64, ...rest } = output as Record<string, unknown>;
+        const parts: Array<
+          | { type: "text"; text: string }
+          | { type: "image-data"; data: string; mediaType: string }
+        > = [];
+
+        parts.push({ type: "text", text: JSON.stringify(rest) });
+
+        if (screenshot_base64 && typeof screenshot_base64 === "string") {
+          parts.push({
+            type: "image-data",
+            data: screenshot_base64,
+            mediaType: "image/png",
+          });
+        }
+
+        return { type: "content", value: parts };
+      },
     }),
   };
   } catch (err) {


### PR DESCRIPTION
Add `toModelOutput` to the `browse` tool to return screenshots as image content parts, enabling the LLM to visually interpret them.

Previously, the `browse` tool returned `screenshot_base64` as a plain string, making the LLM "blind" to the actual image content. This change converts the base64 string into an `image-data` content part, allowing the AI SDK v6 to present the image visually to the model.

---
<p><a href="https://cursor.com/agents/bc-294a7b79-9d89-4fe5-8c3e-9a92a1f0abcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-294a7b79-9d89-4fe5-8c3e-9a92a1f0abcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to tool output formatting; risk is limited to downstream consumers expecting the previous plain JSON shape (especially `screenshot_base64`).
> 
> **Overview**
> Updates the `browse` tool to implement `toModelOutput`, converting the tool result into structured model content.
> 
> The output now strips `screenshot_base64` from the JSON text and, when present, emits it as an `image-data` part (`image/png`) alongside a text part for the remaining fields, enabling multimodal model consumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c246d86d2f50d000d52b3074b6f0e6cf5a0c317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->