### PR TITLE
fix: rewrite ElevenLabs tool registration script (#397)

### DIFF
--- a/scripts/register-elevenlabs-tools.ts
+++ b/scripts/register-elevenlabs-tools.ts
@@ -1,138 +1,194 @@
 /**
- * One-time script to register server tools on the ElevenLabs voice agent.
+ * Register server tools on the ElevenLabs voice agent.
+ *
+ * Creates workspace-level tools (if they don't exist) and attaches them to
+ * the agent via tool_ids. Idempotent: re-running updates existing tools
+ * and ensures the agent references them all.
  *
  * Usage:
- *   ELEVENLABS_API_KEY=... ELEVENLABS_AGENT_ID=... \\
- *   ELEVENLABS_WEBHOOK_BASE_URL=https://aura-alpha-five.vercel.app/api/webhook/elevenlabs \\
- *   ELEVENLABS_WEBHOOK_SECRET_ID=<secret-id> \\
+ *   ELEVENLABS_API_KEY=... \
+ *   ELEVENLABS_AGENT_ID=... \
+ *   ELEVENLABS_WEBHOOK_BASE_URL=https://your-app.vercel.app/api/webhook/elevenlabs \
+ *   ELEVENLABS_WEBHOOK_SECRET_ID=<workspace-secret-id> \
  *   npx tsx scripts/register-elevenlabs-tools.ts
- *
- * This registers the lookup_context and send_dm tools with the ElevenLabs
- * conversational AI agent so it can call them during voice conversations.
- * The tools are authenticated via the x-webhook-secret header using an
- * ElevenLabs Workspace Secret (referenced by secret ID).
  */
 
-const AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const API_KEY = process.env.ELEVENLABS_API_KEY;
+const AGENT_ID = process.env.ELEVENLABS_AGENT_ID;
 const BASE_URL = process.env.ELEVENLABS_WEBHOOK_BASE_URL;
 const WEBHOOK_SECRET_ID = process.env.ELEVENLABS_WEBHOOK_SECRET_ID;
 
-if (!AGENT_ID || !API_KEY || !BASE_URL || !WEBHOOK_SECRET_ID) {
+if (!API_KEY || !AGENT_ID || !BASE_URL || !WEBHOOK_SECRET_ID) {
   console.error(
-    "Required env vars: ELEVENLABS_AGENT_ID, ELEVENLABS_API_KEY, ELEVENLABS_WEBHOOK_BASE_URL, ELEVENLABS_WEBHOOK_SECRET_ID",
+    "Required env vars: ELEVENLABS_API_KEY, ELEVENLABS_AGENT_ID, ELEVENLABS_WEBHOOK_BASE_URL, ELEVENLABS_WEBHOOK_SECRET_ID",
   );
   process.exit(1);
 }
 
-const tools = [
+const headers = {
+  "xi-api-key": API_KEY,
+  "Content-Type": "application/json",
+};
+
+// ── Tool Definitions ──────────────────────────────────────────────────────
+
+interface ToolProperty {
+  type: string;
+  description: string;
+}
+
+interface ToolDef {
+  name: string;
+  description: string;
+  path: string; // appended to BASE_URL, e.g. "/tool/lookup_context"
+  properties: Record<string, ToolProperty>;
+  required?: string[];
+}
+
+const TOOLS: ToolDef[] = [
   {
-    type: "webhook" as const,
     name: "lookup_context",
     description:
-      "Look up context about a topic or person. Use 'query' for general knowledge searches, " +
-      "or 'person_name' to look up a specific team member in Slack.",
-    api_schema: {
-      url: `${BASE_URL}/tool/lookup_context`,
-      method: "POST",
-      request_headers: {
-        "x-webhook-secret": { secret_id: WEBHOOK_SECRET_ID },
+      "Look up context about a topic or person. Use 'query' for general " +
+      "knowledge searches, or 'person_name' to look up a specific team member in Slack.",
+    path: "/tool/lookup_context",
+    properties: {
+      query: {
+        type: "string",
+        description: "A question or topic to search for in the knowledge base.",
       },
-      request_body: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description: "A question or topic to search for in the knowledge base.",
-          },
-          person_name: {
-            type: "string",
-            description: "Name of the person to look up in Slack.",
-          },
-        },
+      person_name: {
+        type: "string",
+        description: "Name of the person to look up in Slack.",
       },
     },
   },
   {
-    type: "webhook" as const,
     name: "send_dm",
     description:
       "Send a direct message to a team member on Slack. " +
       "Provide the person's name and the message content.",
-    api_schema: {
-      url: `${BASE_URL}/tool/send_dm`,
-      method: "POST",
-      request_headers: {
-        "x-webhook-secret": { secret_id: WEBHOOK_SECRET_ID },
+    path: "/tool/send_dm",
+    properties: {
+      user_name: {
+        type: "string",
+        description: "Display name or username of the Slack user to message.",
       },
-      request_body: {
-        type: "object",
-        properties: {
-          user_name: {
-            type: "string",
-            description: "Display name or username of the Slack user to message.",
-          },
-          message: {
-            type: "string",
-            description: "The message to send.",
-          },
-        },
-        required: ["user_name", "message"],
+      message: {
+        type: "string",
+        description: "The message to send.",
       },
     },
+    required: ["user_name", "message"],
   },
 ];
 
-async function registerTools() {
-  // Fetch current agent config
-  const getRes = await fetch(
-    `https://api.elevenlabs.io/v1/convai/agents/${AGENT_ID}`,
-    { headers: { "xi-api-key": API_KEY! } },
-  );
-  if (!getRes.ok) {
-    console.error("Failed to fetch agent:", getRes.status, await getRes.text());
-    process.exit(1);
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function buildRequestBodySchema(def: ToolDef) {
+  const properties: Record<string, any> = {};
+  for (const [key, prop] of Object.entries(def.properties)) {
+    properties[key] = {
+      type: prop.type,
+      description: prop.description,
+      enum: null,
+      is_system_provided: false,
+      dynamic_variable: "",
+      constant_value: "",
+    };
   }
-  const agent = await getRes.json();
-
-  const existingTools: any[] = agent.conversation_config?.agent?.tools ?? [];
-  const existingNames = new Set(existingTools.map((t: any) => t.name));
-
-  const toAdd = tools.filter((t) => !existingNames.has(t.name));
-  if (toAdd.length === 0) {
-    console.log("All tools already registered:", [...existingNames].join(", "));
-    return;
-  }
-
-  const updatedTools = [...existingTools, ...toAdd];
-
-  const patchRes = await fetch(
-    `https://api.elevenlabs.io/v1/convai/agents/${AGENT_ID}`,
-    {
-      method: "PATCH",
-      headers: {
-        "xi-api-key": API_KEY!,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        conversation_config: {
-          agent: {
-            tools: updatedTools,
-          },
-        },
-      }),
-    },
-  );
-
-  if (!patchRes.ok) {
-    console.error("Failed to update agent:", patchRes.status, await patchRes.text());
-    process.exit(1);
-  }
-
-  console.log(`Registered ${toAdd.length} tool(s):`, toAdd.map((t) => t.name).join(", "));
+  return {
+    type: "object",
+    description: "",
+    required: def.required ?? [],
+    properties,
+  };
 }
 
-registerTools().catch((err) => {
+function buildToolConfig(def: ToolDef) {
+  return {
+    type: "webhook" as const,
+    name: def.name,
+    description: def.description,
+    api_schema: {
+      url: `${BASE_URL}${def.path}`,
+      method: "POST",
+      content_type: "application/json",
+      request_headers: {
+        "x-webhook-secret": { secret_id: WEBHOOK_SECRET_ID },
+      },
+      request_body_schema: buildRequestBodySchema(def),
+    },
+  };
+}
+
+async function apiCall(method: string, path: string, body?: any) {
+  const res = await fetch(`https://api.elevenlabs.io/v1${path}`, {
+    method,
+    headers,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${method} ${path} failed (${res.status}): ${text}`);
+  }
+  return res.json();
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  // 1. List existing workspace tools
+  const { tools: existingTools } = await apiCall("GET", "/convai/tools");
+  const toolsByName = new Map<string, any>();
+  for (const t of existingTools) {
+    toolsByName.set(t.tool_config?.name, t);
+  }
+
+  const toolIds: string[] = [];
+
+  for (const def of TOOLS) {
+    const config = buildToolConfig(def);
+    const existing = toolsByName.get(def.name);
+
+    if (existing) {
+      // Update existing workspace tool
+      await apiCall("PATCH", `/convai/tools/${existing.id}`, config);
+      toolIds.push(existing.id);
+      console.log(`Updated workspace tool: ${def.name} (${existing.id})`);
+    } else {
+      // Create new workspace tool
+      const created = await apiCall("POST", "/convai/tools", config);
+      toolIds.push(created.id ?? created.tool_id);
+      console.log(`Created workspace tool: ${def.name} (${created.id ?? created.tool_id})`);
+    }
+  }
+
+  // 2. Fetch current agent config
+  const agent = await apiCall("GET", `/convai/agents/${AGENT_ID}`);
+  const currentToolIds: string[] =
+    agent.conversation_config?.agent?.prompt?.tool_ids ?? [];
+
+  // Merge tool_ids (deduplicated)
+  const mergedIds = [...new Set([...currentToolIds, ...toolIds])];
+
+  // 3. Patch agent: set tool_ids, clear inline tools to avoid duplicates
+  await apiCall("PATCH", `/convai/agents/${AGENT_ID}`, {
+    conversation_config: {
+      agent: {
+        prompt: {
+          tool_ids: mergedIds,
+          tools: [],
+        },
+      },
+    },
+  });
+
+  console.log(`\nAgent ${AGENT_ID} now references ${mergedIds.length} tool(s): ${mergedIds.join(", ")}`);
+  console.log("Done.");
+}
+
+main().catch((err) => {
   console.error("Registration failed:", err);
   process.exit(1);
 });


### PR DESCRIPTION
## What

Complete rewrite of `scripts/register-elevenlabs-tools.ts`. The original script had multiple issues discovered during live debugging:

### Bugs fixed
1. **Wrong API path** -- read/wrote to `conversation_config.agent.tools` instead of `conversation_config.agent.prompt.tools`
2. **Wrong schema format** -- used `request_body` instead of `request_body_schema` with ElevenLabs' required extra fields (`enum`, `is_system_provided`, `dynamic_variable`, `constant_value`)
3. **Not idempotent** -- skipped tools by name instead of upserting. Re-running after changing a definition had no effect.
4. **Inline tools instead of workspace tools** -- PATCHed inline webhook definitions onto the agent instead of creating workspace-level tools and referencing them via `tool_ids`

### New behavior
- Creates/updates **workspace-level tools** via `POST /convai/tools` and `PATCH /convai/tools/:id`
- Attaches tools to the agent via **`tool_ids`** (the proper mechanism)
- Clears inline `tools` array to prevent duplicates
- Fully idempotent: run it 10 times, same result
- All config from env vars, zero hardcoded values

Closes #397