### PR TITLE
Call language voice override

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -14,28 +14,34 @@ const COMPANY_NAME = process.env.COMPANY_NAME ?? "RealAdvisor";
 interface LanguageConfig {
   languageCode: string;
   firstMessage: string;
+  defaultOpener: string;
 }
 
 const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
   es: {
     languageCode: "es",
     firstMessage: `Hola {{person_name}}, soy Aura de ${COMPANY_NAME}. {{call_opener}}`,
+    defaultOpener: "Quería ponerme en contacto contigo.",
   },
   fr: {
     languageCode: "fr",
     firstMessage: `Bonjour {{person_name}}, c'est Aura de ${COMPANY_NAME}. {{call_opener}}`,
+    defaultOpener: "Je voulais prendre de vos nouvelles.",
   },
   it: {
     languageCode: "it",
     firstMessage: `Ciao {{person_name}}, sono Aura di ${COMPANY_NAME}. {{call_opener}}`,
+    defaultOpener: "Volevo mettermi in contatto con te.",
   },
   en: {
     languageCode: "en",
     firstMessage: `Hi {{person_name}}, this is Aura from ${COMPANY_NAME}. {{call_opener}}`,
+    defaultOpener: "I wanted to check in with you.",
   },
   de: {
     languageCode: "de",
     firstMessage: `Hallo {{person_name}}, hier ist Aura von ${COMPANY_NAME}. {{call_opener}}`,
+    defaultOpener: "Ich wollte mich bei Ihnen melden.",
   },
 };
 
@@ -250,11 +256,15 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
         const langConfig = getLanguageConfig(langKey);
 
         const resolvedVoiceId = voiceId ?? VOICE_MAP[langConfig.languageCode];
+        const resolvedOpener = opener || langConfig.defaultOpener;
+        const resolvedFirstMessage = langConfig.firstMessage
+          .replace("{{person_name}}", resolvedName)
+          .replace("{{call_opener}}", resolvedOpener);
 
         const dynamicVars = {
           person_name: resolvedName,
           call_context: callContext,
-          call_opener: opener || "I wanted to check in with you.",
+          call_opener: resolvedOpener,
           person_language: langConfig.languageCode,
           direction: "outbound",
         };
@@ -278,7 +288,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
                     : undefined,
                   agent: {
                     language: langConfig.languageCode,
-                    firstMessage: langConfig.firstMessage,
+                    firstMessage: resolvedFirstMessage,
                   },
                 },
               },


### PR DESCRIPTION
Implements per-call language and voice overrides for outbound calls via ElevenLabs, addressing issue #401.

---
<p><a href="https://cursor.com/agents/bc-3a4b652b-d20c-44ae-a4c9-4435cc7d0ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a4b652b-d20c-44ae-a4c9-4435cc7d0ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound-call initiation behavior and overrides sent to the ElevenLabs API, so misconfiguration could lead to incorrect language/voice or greeting text during calls.
> 
> **Overview**
> Outbound `make_call` now supports **per-call language and TTS voice overrides** via new `language` (2-letter code) and optional `voice_id` inputs, and applies these using ElevenLabs `conversationConfigOverride` (agent language, first message, and TTS voice).
> 
> Language handling is refactored to use a centralized config for localized first messages and default openers, updates phone-prefix detection (adds `de` and `+1/+44`), and switches stored/injected `person_language` from human names (e.g. "Spanish") to language codes (e.g. `es`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7682aeddaa35ed791c7f00f1098240ada3a8b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->