### PR TITLE
Voice language and company

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -9,6 +9,8 @@ import { logger } from "../lib/logger.js";
 
 // ── Language Config ──────────────────────────────────────────────────────────
 
+const COMPANY_NAME = process.env.COMPANY_NAME ?? "RealAdvisor";
+
 interface LanguageConfig {
   languageCode: string;
   firstMessage: string;
@@ -17,29 +19,31 @@ interface LanguageConfig {
 const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
   es: {
     languageCode: "es",
-    firstMessage:
-      "Hola {{person_name}}, soy Aura de RealAdvisor. {{call_opener}}",
+    firstMessage: `Hola {{person_name}}, soy Aura de ${COMPANY_NAME}. {{call_opener}}`,
   },
   fr: {
     languageCode: "fr",
-    firstMessage:
-      "Bonjour {{person_name}}, c'est Aura de RealAdvisor. {{call_opener}}",
+    firstMessage: `Bonjour {{person_name}}, c'est Aura de ${COMPANY_NAME}. {{call_opener}}`,
   },
   it: {
     languageCode: "it",
-    firstMessage:
-      "Ciao {{person_name}}, sono Aura di RealAdvisor. {{call_opener}}",
+    firstMessage: `Ciao {{person_name}}, sono Aura di ${COMPANY_NAME}. {{call_opener}}`,
   },
   en: {
     languageCode: "en",
-    firstMessage:
-      "Hi {{person_name}}, this is Aura from RealAdvisor. {{call_opener}}",
+    firstMessage: `Hi {{person_name}}, this is Aura from ${COMPANY_NAME}. {{call_opener}}`,
   },
   de: {
     languageCode: "de",
-    firstMessage:
-      "Hallo {{person_name}}, hier ist Aura von RealAdvisor. {{call_opener}}",
+    firstMessage: `Hallo {{person_name}}, hier ist Aura von ${COMPANY_NAME}. {{call_opener}}`,
   },
+};
+
+const VOICE_MAP: Record<string, string> = {
+  es: "hvjsm0LgwcoD1EyrNAJI", // Carlos - Spanish (Peninsular)
+  fr: "OOiDJrD1goukqfTpiySr", // Greg - French (Parisian)
+  it: "o4b57JYAECRMJyCEXyIE", // Brando - Italian (Natural)
+  en: "SAz9YHcvj6GT2YYXdXww", // River - English (default)
 };
 
 const DEFAULT_LANGUAGE = "en";
@@ -245,6 +249,8 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
         const langKey = language || detectLanguageFromPhone(resolvedPhone);
         const langConfig = getLanguageConfig(langKey);
 
+        const resolvedVoiceId = voiceId ?? VOICE_MAP[langConfig.languageCode];
+
         const dynamicVars = {
           person_name: resolvedName,
           call_context: callContext,
@@ -267,7 +273,9 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
               conversationInitiationClientData: {
                 dynamicVariables: dynamicVars,
                 conversationConfigOverride: {
-                  tts: voiceId ? { voiceId } : undefined,
+                  tts: resolvedVoiceId
+                    ? { voiceId: resolvedVoiceId }
+                    : undefined,
                   agent: {
                     language: langConfig.languageCode,
                     firstMessage: langConfig.firstMessage,


### PR DESCRIPTION
Refactor voice tool to use `COMPANY_NAME` environment variable and automatically select native ElevenLabs voices based on language.

---
<p><a href="https://cursor.com/agents/bc-534b6b7a-e057-4cdd-8561-a8d5d81b00f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-534b6b7a-e057-4cdd-8561-a8d5d81b00f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound call configuration sent to ElevenLabs/Twilio (greeting text and default TTS voice selection), which could affect production call behavior if mappings or env vars are incorrect.
> 
> **Overview**
> Updates the `make_call` voice tool to parameterize Aura’s greeting using `COMPANY_NAME` (defaulting to `RealAdvisor`) instead of a hardcoded brand.
> 
> Adds a language→ElevenLabs `voiceId` mapping and changes outbound call initiation to automatically pick a voice based on detected/requested language when `voice_id` isn’t provided (while still allowing explicit override).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bfbc4e1333a8fdb34195dd7f45571fd210b9860. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->