### PR TITLE
fix: replace all VOICE_MAP entries with Jane Doe voice

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -46,10 +46,10 @@ const LANGUAGE_CONFIGS: Record<string, LanguageConfig> = {
 };
 
 const VOICE_MAP: Record<string, string> = {
-  es: "hvjsm0LgwcoD1EyrNAJI", // Carlos - Spanish (Peninsular)
-  fr: "OOiDJrD1goukqfTpiySr", // Greg - French (Parisian)
-  it: "o4b57JYAECRMJyCEXyIE", // Brando - Italian (Natural)
-  en: "SAz9YHcvj6GT2YYXdXww", // River - English (default)
+  es: "SaqYcK3ZpDKBAImA8AdW", // Jane Doe
+  fr: "SaqYcK3ZpDKBAImA8AdW", // Jane Doe
+  it: "SaqYcK3ZpDKBAImA8AdW", // Jane Doe
+  en: "SaqYcK3ZpDKBAImA8AdW", // Jane Doe
 };
 
 const DEFAULT_LANGUAGE = "en";


### PR DESCRIPTION
PR #402 introduced a VOICE_MAP with hardcoded voice IDs (Carlos, Greg, Brando, River) that don't exist in our ElevenLabs voice library, causing error 1002 on every outbound call.

All 4 entries now point to Jane Doe (`SaqYcK3ZpDKBAImA8AdW`) which is confirmed working.

**Root cause:** Cursor agent fabricated voice IDs when implementing issue #401. None of Carlos, Greg, Brando, or River exist in our library.

**Impact:** 6 of last 7 outbound calls failed immediately (2-second duration, error 1002).