### PR TITLE
Make call tool evolution

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -115,6 +115,7 @@ interface ElevenLabsCacheData {
 let elevenLabsCache: ElevenLabsCacheData | null = null;
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 15_000;
 
 async function getElevenLabsData(): Promise<ElevenLabsCacheData> {
   if (elevenLabsCache && Date.now() - elevenLabsCache.ts < CACHE_TTL_MS) {
@@ -127,19 +128,22 @@ async function getElevenLabsData(): Promise<ElevenLabsCacheData> {
   const headers = { "xi-api-key": apiKey };
 
   const [agentsRes, phonesRes, voicesRes] = await Promise.all([
-    fetch(`${ELEVENLABS_API_BASE}/convai/agents`, { headers }),
-    fetch(`${ELEVENLABS_API_BASE}/convai/phone-numbers`, { headers }),
-    fetch(`${ELEVENLABS_API_BASE}/voices`, { headers }),
+    fetch(`${ELEVENLABS_API_BASE}/convai/agents`, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
+    fetch(`${ELEVENLABS_API_BASE}/convai/phone-numbers`, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
+    fetch(`${ELEVENLABS_API_BASE}/voices`, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
   ]);
 
-  if (!agentsRes.ok) {
-    throw new Error(`Agents API error (${agentsRes.status}): ${(await agentsRes.text()).substring(0, 200)}`);
-  }
-  if (!phonesRes.ok) {
-    throw new Error(`Phone numbers API error (${phonesRes.status}): ${(await phonesRes.text()).substring(0, 200)}`);
-  }
-  if (!voicesRes.ok) {
-    throw new Error(`Voices API error (${voicesRes.status}): ${(await voicesRes.text()).substring(0, 200)}`);
+  const responses = [agentsRes, phonesRes, voicesRes];
+  const failed = responses.find((r) => !r.ok);
+  if (failed) {
+    const label =
+      failed === agentsRes ? "Agents" :
+      failed === phonesRes ? "Phone numbers" : "Voices";
+    const errorText = await failed.text();
+    for (const r of responses) {
+      if (r !== failed) { try { await r.body?.cancel(); } catch {} }
+    }
+    throw new Error(`${label} API error (${failed.status}): ${errorText.substring(0, 200)}`);
   }
 
   const agentsData = (await agentsRes.json()) as { agents?: Array<{ name: string; agent_id: string }> };
@@ -151,23 +155,26 @@ async function getElevenLabsData(): Promise<ElevenLabsCacheData> {
   }>;
   const voicesData = (await voicesRes.json()) as { voices?: Array<{ name: string; voice_id: string; category?: string }> };
 
-  const agents: ElevenLabsAgent[] = (agentsData.agents ?? []).map((a) => ({
-    name: a.name,
-    agent_id: a.agent_id,
-  }));
+  const agents: ElevenLabsAgent[] = (agentsData.agents ?? [])
+    .filter((a): a is NonNullable<typeof a> => a != null)
+    .map((a) => ({ name: a.name, agent_id: a.agent_id }));
 
-  const phones: ElevenLabsPhone[] = (Array.isArray(phonesData) ? phonesData : []).map((p) => ({
-    phone_number: p.phone_number,
-    label: p.label ?? "",
-    phone_number_id: p.phone_number_id,
-    agent_id: p.assigned_agent?.agent_id ?? null,
-  }));
+  const phones: ElevenLabsPhone[] = (Array.isArray(phonesData) ? phonesData : [])
+    .filter((p): p is NonNullable<typeof p> => p != null)
+    .map((p) => ({
+      phone_number: p.phone_number,
+      label: p.label ?? "",
+      phone_number_id: p.phone_number_id,
+      agent_id: p.assigned_agent?.agent_id ?? null,
+    }));
 
-  const voices: ElevenLabsVoice[] = (voicesData.voices ?? []).map((v) => ({
-    name: v.name,
-    voice_id: v.voice_id,
-    category: v.category ?? "unknown",
-  }));
+  const voices: ElevenLabsVoice[] = (voicesData.voices ?? [])
+    .filter((v): v is NonNullable<typeof v> => v != null)
+    .map((v) => ({
+      name: v.name,
+      voice_id: v.voice_id,
+      category: v.category ?? "unknown",
+    }));
 
   elevenLabsCache = { agents, phones, voices, ts: Date.now() };
   return elevenLabsCache;
@@ -179,7 +186,7 @@ async function fetchAgentConfig(
 ): Promise<ElevenLabsAgentConfigResponse> {
   const response = await fetch(
     `${ELEVENLABS_API_BASE}/convai/agents/${agentId}`,
-    { headers: { "xi-api-key": apiKey } },
+    { headers: { "xi-api-key": apiKey }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
   );
   if (!response.ok) {
     const text = await response.text();
@@ -282,9 +289,9 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
     });
 
     // ── make_call ───────────────────────────────────────────────────
-    const DEFAULT_AGENT_ID = "agent_9301kj9tjcqaermrz71vvr0fpv4v";
-    const DEFAULT_FROM_NUMBER = "+14158860211";
-    const DEFAULT_VOICE_ID = "upcns7xCtWHwsgL2HKV5";
+    const DEFAULT_AGENT_ID = process.env.ELEVENLABS_AGENT_ID ?? "agent_9301kj9tjcqaermrz71vvr0fpv4v";
+    const DEFAULT_FROM_NUMBER = process.env.ELEVENLABS_FROM_NUMBER ?? "+14158860211";
+    const DEFAULT_VOICE_ID = process.env.ELEVENLABS_VOICE_ID ?? "upcns7xCtWHwsgL2HKV5";
 
     tools.make_call = tool({
       description:
@@ -494,6 +501,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
                 "Content-Type": "application/json",
               },
               body: JSON.stringify(outboundBody),
+              signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
             },
           );
 
@@ -687,7 +695,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
               status: "completed",
               callContext: message,
             })
-            .onConflictDoNothing();
+            .onConflictDoNothing({ target: voiceCalls.conversationId });
         } catch (dbError: any) {
           logger.error("send_sms DB insert failed (SMS was sent)", {
             error: dbError.message,


### PR DESCRIPTION
Evolve `make_call` tool with agent selection, voice override, and dynamic variable sync.

This PR adds new optional parameters (`agent_id`, `voice_id`, `language`, `to_number`) to the `make_call` tool. It implements dynamic variable validation by fetching agent configuration and ensuring all required variables are present before initiating a call, preventing instant hang-ups. It also fixes the dynamic variable passing format and includes voice override in the `conversation_config_override`. Backward compatibility is maintained for existing parameters and default behaviors.

---
<p><a href="https://cursor.com/agents/bc-cbbff8f3-ea62-472d-b50e-3f6971824bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbbff8f3-ea62-472d-b50e-3f6971824bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound calling flow and ElevenLabs/Twilio integration, so misconfiguration or API contract mismatches could break call initiation or tracking despite added validation and error handling.
> 
> **Overview**
> Adds an admin-only `list_voice_agents` tool that discovers ElevenLabs agents, phone numbers, and voices (with a 10-minute cache) so callers can resolve human-friendly selections to IDs.
> 
> Evolves `make_call` to accept explicit `agent_id`, `from_number`, `to_number`, and `voice_id`, validates `to_number` as E.164, fetches agent config to ensure required dynamic variables are present (or filled from defaults), and switches outbound calling from the `@elevenlabs/elevenlabs-js` client to direct ElevenLabs HTTP requests with better error handling and call-tracking fallbacks.
> 
> Removes DB-based person-name phone resolution and the hardcoded language→voice mapping, and tightens DB insert idempotency by targeting `voiceCalls.conversationId` conflicts (also applied to `send_sms`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97641b012e5777885ec3c55c71dd70a682937f53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->