### PR TITLE
Anthropic prompt caching

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -3,7 +3,7 @@ import { generateText, stepCountIs } from "ai";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "../db/schema.js";
-import { getMainModel } from "../lib/ai.js";
+import { getMainModel, withCacheControl } from "../lib/ai.js";
 import { createSlackTools } from "../tools/slack.js";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
@@ -154,7 +154,7 @@ export async function executeJob(
 
     const generateResult = await generateText({
       model,
-      system: systemPrompt,
+      system: withCacheControl(systemPrompt),
       prompt,
       tools: createSlackTools(slackClient, {
         userId: job.requestedBy,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -173,3 +173,16 @@ export const fastModel = withAnthropicFallback(
 );
 
 export const embeddingModel = gateway.embedding(STATIC_EMBEDDING_MODEL_ID);
+
+/**
+ * Wrap a system prompt string with Anthropic cache control.
+ * Returns a SystemModelMessage with providerOptions that enable ephemeral caching.
+ * Safe for non-Anthropic models — they ignore the providerOptions.anthropic key.
+ */
+export function withCacheControl(systemPrompt: string) {
+  return {
+    role: 'system' as const,
+    content: systemPrompt,
+    providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+  };
+}

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -1,6 +1,6 @@
 import { streamText, stepCountIs } from "ai";
 import type { WebClient } from "@slack/web-api";
-import { getMainModel } from "../lib/ai.js";
+import { getMainModel, withCacheControl } from "../lib/ai.js";
 import { createSlackTools } from "../tools/slack.js";
 import type { FileContentPart } from "../lib/files.js";
 import { logger } from "../lib/logger.js";
@@ -517,7 +517,7 @@ export async function generateResponse(
   // ── Build stream options ─────────────────────────────────────────────
   const streamOptions: any = {
     model,
-    system: options.systemPrompt,
+    system: withCacheControl(options.systemPrompt),
     tools: createSlackTools(options.slackClient, options.context),
     stopWhen: stepCountIs(STEP_LIMIT),
     prepareStep: createInteractivePrepareStep(options.systemPrompt),
@@ -960,7 +960,7 @@ export async function generateResponse(
 
       const retryOptions: any = {
         model,
-        system: options.systemPrompt,
+        system: withCacheControl(options.systemPrompt),
         prompt: retryPrompt,
         abortSignal: retryAbortController.signal,
       };


### PR DESCRIPTION
Implement Anthropic prompt caching for system messages to reduce token costs on repeated LLM calls.

---
<p><a href="https://cursor.com/agents/bc-a626223c-1b00-4f4e-a5c4-76808b05071e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a626223c-1b00-4f4e-a5c4-76808b05071e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to LLM request options that should be ignored by non-Anthropic providers; main risk is subtle provider-specific behavior differences in prompt handling/caching.
> 
> **Overview**
> Adds Anthropic system-prompt caching by introducing `withCacheControl()` in `src/lib/ai.ts`, which wraps system prompts with Anthropic `providerOptions.cacheControl` (ephemeral).
> 
> Updates both headless job execution (`execute-job.ts` via `generateText`) and interactive Slack responses (`respond.ts` via `streamText`, including the retry path) to pass the cache-controlled system message instead of a raw system prompt string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 637b2b385722f95457fa7ab89f885723f4b38b7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->