### PR TITLE
Upload file channel targeting

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2224,7 +2224,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     upload_file: tool({
       description:
-        "Upload a file to Slack, optionally sharing to a channel or thread. Supports text files (CSV, JSON, code, etc.) directly and binary files (images, PDFs) via base64 encoding (set is_binary=true).",
+        "Upload a file to Slack, optionally sharing to a channel or thread. Supports text files (CSV, JSON, code, etc.) directly and binary files (images, PDFs) via base64 encoding (set is_binary=true). The channel parameter accepts any Slack destination: channel name ('general'), channel ID ('C0BNVKS77'), DM channel ID ('D0AF1K2EBH8'), group DM ID ('G01234'), or a username/display name ('Joan') to open a DM. Use thread_ts to post into a specific thread (including Slack List item comment threads).",
       inputSchema: z.object({
         content: z
           .string()
@@ -2238,7 +2238,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "Channel name or ID to share the file to. If omitted, the file is uploaded but not shared to any channel.",
+            "Channel name (e.g. 'general'), channel ID ('C0BNVKS77'), DM channel ID ('D0AF1K2EBH8'), group DM ID ('G01234'), or username/display name ('Joan') to share the file to. For Slack List item threads, pass the thread_channel_id from get_slack_list_item. If omitted, the file is uploaded but not shared anywhere.",
           ),
         title: z
           .string()
@@ -2254,7 +2254,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "Thread timestamp to attach the file to a specific thread",
+            "Thread timestamp to attach the file to a specific thread. For Slack List item threads, use the thread_ts from get_slack_list_item together with thread_channel_id as the channel.",
           ),
       }),
       execute: async ({ content, filename, channel, title, is_binary, thread_ts }) => {


### PR DESCRIPTION
Update `upload_file` tool descriptions to document support for all Slack channel types and user targeting.

The `upload_file` tool's execution logic already handles various Slack destinations (channel names/IDs, DM IDs, group DMs, usernames), but its descriptions were incomplete, preventing the LLM from fully utilizing its capabilities. This PR updates the tool and parameter descriptions to accurately reflect this functionality.

---
<p><a href="https://cursor.com/agents/bc-e6c49665-a08d-4c73-87f9-cb8fd8fd2532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6c49665-a08d-4c73-87f9-cb8fd8fd2532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; runtime behavior and Slack API interactions are unchanged.
> 
> **Overview**
> Updates the `upload_file` tool’s description and parameter docs to explicitly support targeting *any* Slack destination (channel name/ID, DM/group DM IDs, or a user name to open a DM) and to clarify how to upload into threads via `thread_ts` (including Slack List item comment threads using `thread_channel_id`).
> 
> No execution logic changes; this is documentation-only to help the agent correctly choose `channel`/`thread_ts` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d632ac46b0ea542668337f4c3a41800efd079c57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->