### PR TITLE
Browse tool screenshot upload

### DIFF
--- a/src/lib/slack-upload.ts
+++ b/src/lib/slack-upload.ts
@@ -1,0 +1,55 @@
+import type { WebClient } from "@slack/web-api";
+import { logger } from "./logger.js";
+
+/**
+ * Upload a file buffer to Slack using the 3-step external upload API.
+ *
+ * Steps: getUploadURLExternal → PUT file content → completeUploadExternal
+ */
+export async function uploadFileToSlack(
+  client: WebClient,
+  options: {
+    buffer: Buffer;
+    filename: string;
+    title?: string;
+    channelId?: string;
+    threadTs?: string;
+  },
+): Promise<{ fileId: string; fileUrl: string | null }> {
+  const { buffer, filename, title, channelId, threadTs } = options;
+
+  const uploadUrlResp = await client.files.getUploadURLExternal({
+    filename,
+    length: buffer.length,
+  });
+  const uploadUrl = uploadUrlResp.upload_url!;
+  const fileId = uploadUrlResp.file_id!;
+
+  const uploadResp = await fetch(uploadUrl, {
+    method: "POST",
+    body: buffer,
+    headers: { "Content-Type": "application/octet-stream" },
+  });
+  if (!uploadResp.ok) {
+    throw new Error(
+      `File upload failed: ${uploadResp.status} ${uploadResp.statusText}`,
+    );
+  }
+
+  const completeParams: Record<string, unknown> = {
+    files: [{ id: fileId, title: title || filename }],
+  };
+  if (channelId) completeParams.channel_id = channelId;
+  if (threadTs) completeParams.thread_ts = threadTs;
+
+  const completeResp = await client.files.completeUploadExternal(
+    completeParams as any,
+  );
+
+  const fileUrl =
+    (completeResp as any).files?.[0]?.permalink ?? null;
+
+  logger.info("uploadFileToSlack completed", { filename, fileId, channelId });
+
+  return { fileId, fileUrl };
+}

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -8,6 +8,7 @@ import {
 } from "../lib/browser.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
+import { uploadFileToSlack } from "../lib/slack-upload.js";
 import type { ScheduleContext } from "../db/schema.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -104,6 +105,20 @@ export function createBrowserTools(context?: ScheduleContext): Record<string, an
           .describe(
             "Timeout for the operation in seconds (default 30, max 120).",
           ),
+        upload_channel: z
+          .string()
+          .optional()
+          .describe(
+            "Channel name, ID, or username to upload the screenshot to. When set, the screenshot PNG is automatically uploaded to Slack.",
+          ),
+        upload_thread_ts: z
+          .string()
+          .optional()
+          .describe("Thread timestamp to attach the uploaded screenshot to."),
+        upload_title: z
+          .string()
+          .optional()
+          .describe("Title for the uploaded screenshot file in Slack."),
       }),
       execute: async ({
         url,
@@ -114,6 +129,9 @@ export function createBrowserTools(context?: ScheduleContext): Record<string, an
         headers,
         stealth,
         timeout_seconds,
+        upload_channel,
+        upload_thread_ts,
+        upload_title,
       }) => {
         // Admin-only check
         if (!isAdmin(context?.userId) && context?.userId !== "aura") {
@@ -284,6 +302,60 @@ export function createBrowserTools(context?: ScheduleContext): Record<string, an
               typeof codeResult === "string"
                 ? codeResult
                 : JSON.stringify(codeResult);
+          }
+
+          if (upload_channel && screenshotBase64) {
+            try {
+              const token = process.env.SLACK_BOT_TOKEN;
+              if (!token) {
+                result.upload_error = "SLACK_BOT_TOKEN not configured";
+              } else {
+                const { WebClient } = await import("@slack/web-api");
+                const slackClient = new WebClient(token);
+
+                const { resolveChannelByName, resolveUserByName } = await import("../tools/slack.js");
+
+                let channelId: string | undefined;
+                if (/^[CDG][A-Z0-9]+$/.test(upload_channel)) {
+                  channelId = upload_channel;
+                } else {
+                  const resolved = await resolveChannelByName(slackClient, upload_channel);
+                  if (resolved) {
+                    channelId = resolved.id;
+                  } else {
+                    const user = await resolveUserByName(slackClient, upload_channel);
+                    if (user?.id) {
+                      const dm = await slackClient.conversations.open({ users: user.id });
+                      channelId = dm.channel?.id;
+                    }
+                  }
+                }
+
+                if (!channelId) {
+                  result.upload_error = `Could not resolve channel or user "${upload_channel}"`;
+                } else {
+                  const screenshotBuffer = Buffer.from(screenshotBase64, "base64");
+                  const filename = upload_title
+                    ? `${upload_title.replace(/[^a-zA-Z0-9_-]/g, "_")}.png`
+                    : "screenshot.png";
+
+                  const { fileId, fileUrl } = await uploadFileToSlack(slackClient, {
+                    buffer: screenshotBuffer,
+                    filename,
+                    title: upload_title || `Screenshot of ${resultTitle || resultUrl}`,
+                    channelId,
+                    threadTs: upload_thread_ts,
+                  });
+                  result.file_id = fileId;
+                  result.file_url = fileUrl;
+                }
+              }
+            } catch (uploadErr: any) {
+              logger.error("browse tool: screenshot upload failed", {
+                error: uploadErr.message,
+              });
+              result.upload_error = `Screenshot upload failed: ${uploadErr.message}`;
+            }
           }
 
           logger.info("browse tool: completed", {

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -21,6 +21,7 @@ import { createVoiceTools } from "./voice.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { formatForSlack } from "../lib/format.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
+import { uploadFileToSlack } from "../lib/slack-upload.js";
 import { formatTimestamp } from "../lib/temporal.js";
 import { downloadSlackFile, MAX_FILE_SIZE } from "../lib/files.js";
 
@@ -2301,39 +2302,12 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
             }
           }
 
-          // 1. Get upload URL
-          const uploadUrlResp = await client.files.getUploadURLExternal({
+          const { fileId, fileUrl } = await uploadFileToSlack(client, {
+            buffer: fileBuffer,
             filename,
-            length: fileBuffer.length,
-          });
-          const uploadUrl = uploadUrlResp.upload_url!;
-          const fileId = uploadUrlResp.file_id!;
-
-          // 2. Upload the file content to the presigned URL
-          const uploadResp = await fetch(uploadUrl, {
-            method: "POST",
-            body: fileBuffer,
-            headers: { "Content-Type": "application/octet-stream" },
-          });
-          if (!uploadResp.ok) {
-            throw new Error(`File upload failed: ${uploadResp.status} ${uploadResp.statusText}`);
-          }
-
-          // 3. Complete upload and share to channel
-          const completeParams: Record<string, unknown> = {
-            files: [{ id: fileId, title: title || filename }],
-          };
-          if (channelId) completeParams.channel_id = channelId;
-          if (thread_ts) completeParams.thread_ts = thread_ts;
-
-          const completeResp = await client.files.completeUploadExternal(completeParams as any);
-
-          const fileUrl = (completeResp as any).files?.[0]?.permalink ?? null;
-
-          logger.info("upload_file tool called", {
-            filename,
-            channel,
-            fileId,
+            title: title || undefined,
+            channelId,
+            threadTs: thread_ts,
           });
 
           return {


### PR DESCRIPTION
Add optional Slack screenshot upload to the `browse` tool and refactor Slack file upload into a shared helper.

---
<p><a href="https://cursor.com/agents/bc-320d4fe0-08fc-4746-9cad-ace0860ee462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-320d4fe0-08fc-4746-9cad-ace0860ee462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new outbound Slack API calls and channel/user resolution paths from the browser tool, which can fail due to token/config/scope issues and changes runtime behavior when the new parameters are used.
> 
> **Overview**
> The `browse` tool can now optionally upload its generated screenshot PNG to Slack when `upload_channel` is provided (with optional `upload_thread_ts` and `upload_title`), resolving the destination from a channel ID/name or username and returning `file_id`/`file_url` (or `upload_error`) in the tool result.
> 
> Slack’s 3-step external upload flow is refactored into a reusable `uploadFileToSlack` helper (`src/lib/slack-upload.ts`), and the existing Slack `upload_file` tool is updated to use it instead of duplicating the upload sequence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d6d0fc55975ac26f92ede7dc8a7fa38e4df03f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->