### PR TITLE
Channel streaming type support

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -923,7 +923,7 @@ export async function generateResponse(
           try { await streamer.stop(); } catch { /* already finalized */ }
         } else if (isChannelTypeNotSupported(stopErr)) {
           streamingUnsupportedChannels.add(channelId);
-          logger.warn("streamer.stop() hit channel_type_not_supported, finalizing gracefully", {
+          logger.warn("streamer.stop() hit channel_type_not_supported, finalizing without payload", {
             channelId,
           });
           logError({
@@ -932,6 +932,7 @@ export async function generateResponse(
             errorCode: "channel_type_not_supported",
             channelId,
           });
+          try { await streamer.stop(); } catch { /* already finalized */ }
         } else {
           throw stopErr;
         }


### PR DESCRIPTION
Fixes streaming crashes in Slack List channels by adding `channel_type_not_supported` error handling and a channel capability cache.

Slack List channels were incorrectly identified, leading to streaming attempts that failed and crashed the application. This PR introduces a module-level cache for channels that do not support streaming, gracefully handles `channel_type_not_supported` errors during streaming, and provides a fallback to post accumulated text as a regular message.

---
<p><a href="https://cursor.com/agents/bc-15e468df-80a6-4c80-bc8b-5425e541db36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15e468df-80a6-4c80-bc8b-5425e541db36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Slack response delivery path and changes error-handling/fallback behavior; mistakes could lead to dropped or duplicate messages, but changes are localized and guarded by existing `safePostMessage` behavior.
> 
> **Overview**
> Prevents repeated `chatStream` failures by introducing a process-wide cache of `channelId`s that return `channel_type_not_supported`, and skipping streaming for those channels on subsequent responses.
> 
> Adds explicit handling for `channel_type_not_supported` during `streamer.append()` and `streamer.stop()` to avoid crashes, log structured errors, and fall back to `safePostMessage`; if the overall response errors after partial accumulation, it now attempts a best-effort `postMessage` of the accumulated text before rethrowing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ca3390a2b120b05166fcc39e7415a1d868a6463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->