### PR TITLE
Message text file IDs

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -242,7 +242,7 @@ function extractFullMessageText(msg: any): string {
     for (const file of msg.files) {
       const fileName = file.title || file.name || "unnamed file";
       const fileType = file.filetype || "unknown";
-      parts.push(`[file: ${fileName} (${fileType})]`);
+      parts.push(`[file: ${fileName} (${fileType}) id:${file.id}]`);
     }
   }
   return parts.filter(Boolean).join("\n") || "";


### PR DESCRIPTION
Fixes #423: Include file IDs in `extractMessageText` output to enable LLM to use `download_slack_file`.

---
<p><a href="https://cursor.com/agents/bc-26a9c885-ca26-4bd5-8c51-ca7bdf62b5ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a9c885-ca26-4bd5-8c51-ca7bdf62b5ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized string-format change in Slack message rendering; main risk is minor downstream breakage if any code/tests depend on exact extracted text formatting.
> 
> **Overview**
> Slack message text extraction now includes each shared file’s Slack `id` in the `[file: ...]` marker produced by `extractFullMessageText`.
> 
> This makes downstream consumers (e.g., LLM tool calls) able to reference the correct file identifier when invoking `download_slack_file`, but slightly changes the textual output of all Slack history/thread/DM reads that use this extraction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5649e166f51220f5041b73415d1e5d912c36ec85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->