### PR TITLE
Slackbot notification detection

### DIFF
--- a/src/pipeline/context.ts
+++ b/src/pipeline/context.ts
@@ -50,7 +50,7 @@ export interface SlackListItemContext {
   messageTs: string;
   /** Channel where the notification appeared */
   channelId: string;
-  /** Original notification text (e.g. "A comment was added") */
+  /** Original notification text from USLACKBOT (locale-dependent) */
   notificationText: string;
 }
 
@@ -436,24 +436,15 @@ export async function resolveChannelName(
 
 // ── USLACKBOT Notification Detection ─────────────────────────────────────────
 
-const USLACKBOT_NOTIFICATION_PATTERNS = [
-  /^a comment was added$/i,
-  /^a field was updated$/i,
-  /^an item was (created|moved|completed|deleted)$/i,
-  /^a status was changed$/i,
-  /^an item was added$/i,
-  /^a due date was (set|changed|removed)$/i,
-];
-
 /**
- * Detect whether a message is a generic USLACKBOT notification about a Slack
- * List item. These notifications contain minimal text (e.g. "A comment was
- * added") and the message ts doubles as the list item's thread_ts.
+ * Detect whether a message is a USLACKBOT notification about a Slack List item.
+ * Uses sender identity + channel membership instead of brittle text matching,
+ * since Slack localizes notification strings per workspace locale.
  */
 export function isSlackbotListNotification(
   event: SlackEvent,
+  alwaysProcessChannels: Set<string>,
 ): boolean {
   if (!("user" in event) || event.user !== "USLACKBOT") return false;
-  const text = ("text" in event ? event.text || "" : "").trim();
-  return USLACKBOT_NOTIFICATION_PATTERNS.some((p) => p.test(text));
+  return alwaysProcessChannels.has(event.channel);
 }

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -29,6 +29,7 @@ import {
 } from "../users/profiles.js";
 import { downloadEventFiles } from "../lib/files.js";
 import { pauseSandbox } from "../lib/sandbox.js";
+import { getSettingJSON } from "../lib/settings.js";
 import { logger } from "../lib/logger.js";
 import { logError } from "../lib/error-logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
@@ -248,11 +249,13 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     }
 
     // ── USLACKBOT list notification enrichment ───────────────────────────
-    // When USLACKBOT posts a generic notification (e.g. "A comment was
-    // added") in a monitored channel, the LLM gets no useful context.
-    // Detect this and attach metadata so the prompt can guide the LLM to
+    // Any USLACKBOT message in a tracked List channel is a list activity
+    // notification. We attach metadata so the prompt guides the LLM to
     // investigate the actual list item via tools.
-    if (isSlackbotListNotification(event)) {
+    const alwaysProcessChannels = new Set(
+      (await getSettingJSON<string[]>("always_process_channels", [])) ?? [],
+    );
+    if (isSlackbotListNotification(event, alwaysProcessChannels)) {
       context.slackListItemContext = {
         messageTs: context.messageTs,
         channelId: context.channelId,


### PR DESCRIPTION
Remove hardcoded English regex patterns for Slackbot notification detection to improve robustness and internationalization.

The previous implementation relied on brittle, locale-specific regex patterns that would break silently if Slack changed notification wording or if used in non-English workspaces. This PR replaces it with a reliable check based on the sender (`USLACKBOT`) and the channel being a configured "always process" channel.

---
<p><a href="https://cursor.com/agents/bc-3a6ae72f-fdb0-47e5-85c5-4fa92d26fa7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a6ae72f-fdb0-47e5-85c5-4fa92d26fa7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the criteria for when USLACKBOT messages are treated as list notifications, so misconfiguration of `always_process_channels` could cause missed enrichments or unintended processing in those channels.
> 
> **Overview**
> Replaces Slack List USLACKBOT notification detection from hardcoded English regex matching to a *locale-agnostic* check based on `event.user === "USLACKBOT"` and whether the message’s channel is in the configured `always_process_channels` set.
> 
> The pipeline now loads `always_process_channels` via `getSettingJSON` and enriches matching events with `slackListItemContext` metadata (including the original localized notification text) to help downstream prompting/tooling fetch the actual list item context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5047b62a2e7d7b8abf1ecc2711e2aaf3a09b1f2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->