### PR TITLE
Anthropic deferred tool search

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { WebClient } from "@slack/web-api";
+import { anthropic as anthropicProvider } from "@ai-sdk/anthropic";
 import { logger } from "../lib/logger.js";
 import { isAdmin } from "../lib/permissions.js";
 import { createNoteTools } from "./notes.js";
@@ -508,7 +509,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     return result;
   }
 
-  return {
+  const tools: Record<string, any> = {
     list_channels: tool({
       description:
         "List Slack channels that Aura is currently a member of (names, topics, member count). Important: this only shows channels Aura has already joined, NOT all public channels in the workspace. Many public channels exist that aren't listed here. To find or join others, use search_channels to fuzzy-search by name, or join_channel with the exact channel name.",
@@ -2888,4 +2889,55 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     // ── Voice & SMS Tools (ElevenLabs + Twilio) ─────────────────────
     ...createVoiceTools(context),
   };
+
+  // ── Anthropic Tool Discovery ──────────────────────────────────────
+  // Mark infrequently-used tools as deferred so their schemas aren't
+  // sent upfront. Claude discovers them via toolSearch when needed.
+  // Non-Anthropic providers simply ignore providerOptions.anthropic.
+  const DEFERRED_TOOLS = new Set([
+    // BigQuery / Data
+    "list_datasets", "list_tables", "inspect_table", "execute_query",
+    // Google Sheets
+    "read_google_sheet",
+    // Calendar
+    "check_calendar", "create_event", "update_event", "delete_event", "find_available_slot",
+    // Canvas
+    "read_canvas", "create_canvas", "edit_canvas", "delete_canvas", "share_canvas", "list_canvases",
+    // Slack Lists
+    "list_slack_list_items", "get_slack_list_item", "create_slack_list_item", "update_slack_list_item", "delete_slack_list_item",
+    // Email (Aura's own inbox)
+    "read_emails", "read_email", "send_email", "reply_to_email",
+    // Email triage (per-user Gmail)
+    "sync_emails", "email_digest", "update_email_thread",
+    "read_user_emails", "read_user_email",
+    "generate_gmail_auth_url", "create_gmail_draft", "list_gmail_drafts", "delete_gmail_draft",
+    // Dev / Code
+    "run_command", "dispatch_headless", "read_job_trace",
+    "dispatch_cursor_agent", "check_cursor_agent", "followup_cursor_agent",
+    "stop_cursor_agent", "get_cursor_conversation", "list_cursor_agents",
+    // Browser
+    "browse", "download_slack_file",
+    // Voice / Calls
+    "list_voice_agents", "make_call", "send_sms",
+    // Directory / Contacts
+    "lookup_workspace_user", "list_workspace_users", "lookup_contact",
+    // Checkpoint
+    "checkpoint_plan",
+    // Subagent
+    "run_subagent",
+  ]);
+
+  const deferOpts = { anthropic: { deferLoading: true } };
+  for (const name of DEFERRED_TOOLS) {
+    if (name in tools) {
+      tools[name] = { ...tools[name], providerOptions: deferOpts };
+    }
+  }
+
+  // Provider-defined tool that lets Claude discover deferred tools mid-conversation.
+  // Non-Anthropic providers ignore provider-defined tools.
+  // Claude uses BM25 search over deferred tool names/descriptions to find them.
+  tools.toolSearch = anthropicProvider.tools.toolSearchBm25_20251119();
+
+  return tools;
 }


### PR DESCRIPTION
Enable native Anthropic tool discovery by marking ~47 tools as `deferLoading: true` and adding the `toolSearchBm25_20251119` tool.

This optimizes the initial prompt size for Anthropic models by deferring less-used tool schemas, allowing them to be discovered dynamically mid-conversation. All changes are centralized in `src/tools/slack.ts`.

---
<p><a href="https://cursor.com/agents/bc-20966ad2-6a20-44c1-902b-97786565bf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20966ad2-6a20-44c1-902b-97786565bf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tool schemas are advertised/loaded for Anthropic models, which can impact tool availability and behavior if deferred tool names drift or discovery fails; scope is localized to `createSlackTools`.
> 
> **Overview**
> Adds Anthropic-native tool discovery by **deferring schema loading** for a curated set of infrequently-used Slack tools via `providerOptions: { anthropic: { deferLoading: true } }`, reducing the initial tool payload sent to Claude.
> 
> Also registers Anthropic’s provider-defined `toolSearchBm25_20251119` as `tools.toolSearch`, allowing Claude to search and load deferred tools on demand; non-Anthropic providers ignore these options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4058a5392d4c5b12df04ac00fd86cfe3935ac711. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->