### PR TITLE
Tool I/O truncation

### DIFF
--- a/src/pipeline/slack-context.ts
+++ b/src/pipeline/slack-context.ts
@@ -265,9 +265,14 @@ export async function fetchConversationContext(
 
 /** Format rich tool I/O records into a structured block for context. */
 function formatToolIO(records: ToolIORecord[]): string {
+  const trunc = (s: string, max: number) =>
+    s.length > max ? s.slice(0, max) + "..." : s;
+
   const parts = records.map((r) => {
     const error = r.is_error ? " [ERROR]" : "";
-    return `  - ${r.name}${error}\n    Input: ${r.input}\n    Output: ${r.output}`;
+    const inputStr = trunc(String(r.input ?? ""), 200);
+    const outputStr = trunc(String(r.output ?? ""), r.is_error ? 500 : 200);
+    return `  - ${r.name}${error}\n    Input: ${inputStr}\n    Output: ${outputStr}`;
   });
   return `\n[Tool I/O]\n${parts.join("\n")}`;
 }


### PR DESCRIPTION
Truncate tool I/O in thread history to reduce context bloat caused by large tool outputs.

---
<p><a href="https://cursor.com/agents/bc-557744d0-fac4-4965-b05d-1d3bf770a3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557744d0-fac4-4965-b05d-1d3bf770a3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized formatting change; main risk is losing useful debugging context due to truncation or slightly altering prompt contents.
> 
> **Overview**
> Reduces Slack thread context bloat by truncating rich `toolIO` entries when formatting conversation history.
> 
> `formatToolIO` now caps `Input` at 200 chars and `Output` at 200 chars (or 500 chars when `is_error`), instead of inlining full tool payloads into the prompt context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d40d1a7f7ccb486821c9e4a83f535930fb0e26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->