### PR TITLE
Tool I/O context truncation

### DIFF
--- a/src/pipeline/slack-context.ts
+++ b/src/pipeline/slack-context.ts
@@ -264,10 +264,15 @@ export async function fetchConversationContext(
 // ── Formatting ───────────────────────────────────────────────────────────────
 
 /** Format rich tool I/O records into a structured block for context. */
-function formatToolIO(records: ToolIORecord[]): string {
+function formatToolIO(records: ToolIORecord[], isOld = false): string {
+  const trunc = (s: string, max: number) =>
+    s.length > max ? s.slice(0, max) + "..." : s;
+
   const parts = records.map((r) => {
     const error = r.is_error ? " [ERROR]" : "";
-    return `  - ${r.name}${error}\n    Input: ${r.input}\n    Output: ${r.output}`;
+    const inputStr = isOld ? trunc(String(r.input ?? ""), 500) : String(r.input ?? "");
+    const outputStr = isOld ? trunc(String(r.output ?? ""), 500) : String(r.output ?? "");
+    return `  - ${r.name}${error}\n    Input: ${inputStr}\n    Output: ${outputStr}`;
   });
   return `\n[Tool I/O]\n${parts.join("\n")}`;
 }
@@ -287,10 +292,10 @@ function formatToolCalls(toolCalls: ToolCallSummary[]): string {
 }
 
 /** Format a single message, preferring rich tool I/O over task_card summaries. */
-function formatMessage(m: SlackThreadMessage, timezone?: string): string {
+function formatMessage(m: SlackThreadMessage, timezone?: string, isOld = false): string {
   const time = formatTimestamp(m.ts, timezone);
   const base = `[${time}] ${m.displayName}: ${m.text}`;
-  if (m.toolIO?.length) return base + formatToolIO(m.toolIO);
+  if (m.toolIO?.length) return base + formatToolIO(m.toolIO, isOld);
   if (m.toolCalls?.length) return base + formatToolCalls(m.toolCalls);
   return base;
 }
@@ -311,6 +316,8 @@ export function formatConversationContext(
   includeChannelFallback: boolean = true,
   timezone?: string,
 ): string | undefined {
+  const RECENT_TOOL_IO_COUNT = 10;
+
   // Prefer thread context if available
   if (conversation.thread && conversation.thread.length > 0) {
     // Cap thread context to avoid inflating the system prompt for long threads.
@@ -322,7 +329,10 @@ export function formatConversationContext(
         ? thread
         : [thread[0], ...thread.slice(-MAX_THREAD_MESSAGES + 1)];
     const threadFormatted = capped
-      .map((m) => formatMessage(m, timezone))
+      .map((m, i) => {
+        const isOld = i < capped.length - RECENT_TOOL_IO_COUNT;
+        return formatMessage(m, timezone, isOld);
+      })
       .join("\n\n");
 
     // Include channel messages posted before the thread root for broader context.
@@ -339,7 +349,7 @@ export function formatConversationContext(
 
     if (surrounding.length > 0) {
       const channelFormatted = surrounding
-        .map((m) => formatMessage(m, timezone))
+        .map((m) => formatMessage(m, timezone, true))
         .join("\n\n");
       return (
         "Channel messages near the thread (for context):\n\n" +
@@ -354,8 +364,12 @@ export function formatConversationContext(
 
   // Fall back to recent channel/DM messages only when appropriate
   if (includeChannelFallback && conversation.recentMessages.length > 0) {
-    const formatted = conversation.recentMessages
-      .map((m) => formatMessage(m, timezone))
+    const msgs = conversation.recentMessages;
+    const formatted = msgs
+      .map((m, i) => {
+        const isOld = i < msgs.length - RECENT_TOOL_IO_COUNT;
+        return formatMessage(m, timezone, isOld);
+      })
       .join("\n\n");
     return formatted;
   }


### PR DESCRIPTION
Implement position-aware tool I/O truncation to save tokens by keeping recent messages full and truncating older ones.

This PR modifies `formatToolIO`, `formatMessage`, and `formatConversationContext` to ensure that tool I/O for the last 10 messages in a conversation remains untruncated, while older messages (11+) have their tool I/O capped at 500 characters. This prevents injecting large amounts of stale data into the context window without impacting recent, relevant tool interactions.

---
<p><a href="https://cursor.com/agents/bc-42e50903-4c26-4745-ab10-162c2fa7a921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e50903-4c26-4745-ab10-162c2fa7a921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to prompt/context formatting and truncation logic; main risk is accidentally dropping needed older tool details or off-by-one behavior in what counts as “recent”.
> 
> **Overview**
> Reduces system-prompt token usage by making Slack conversation context *position-aware* when rendering rich tool input/output.
> 
> `formatConversationContext` now treats only the most recent 10 messages as “full fidelity”; older messages (and surrounding pre-thread channel context) are marked `isOld`, and `formatToolIO` truncates each tool `input`/`output` field to 500 chars for those older messages while leaving recent tool I/O unmodified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb65d5a19b417918e9d184c0c6e6387e93ea6b1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->