### PR TITLE
fix: reduce list_voice_agents fetch timeout 15s to 5s

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -115,7 +115,7 @@ interface ElevenLabsCacheData {
 let elevenLabsCache: ElevenLabsCacheData | null = null;
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
-const FETCH_TIMEOUT_MS = 15_000;
+const FETCH_TIMEOUT_MS = 5_000;
 
 async function getElevenLabsData(): Promise<ElevenLabsCacheData> {
   // Return fresh cache if available


### PR DESCRIPTION
## Problem
The `/convai/phone-numbers` endpoint hangs 8s+ during ElevenLabs instability. With `FETCH_TIMEOUT_MS = 15_000`, safeFetch blocks for 15s before returning null. The AI SDK kills the tool call before that fires, so the tool errors even when agents + voices are fine.

## Fix
Drop timeout to 5s. Agents respond in ~100ms, voices in under 5s even on slow days. Phones fail fast and gracefully degrade to empty array.

Fixes the tool-level timeout seen after merging #436.