### PR TITLE
fix: resolve phone number ID from agents endpoint (fallback for flaky phone-numbers API)

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -235,13 +235,40 @@ async function resolvePhoneNumberIdFromCache(
   fromNumber: string | undefined,
 ): Promise<string | null> {
   if (!fromNumber) return null;
+
+  // First try: use cached phones list (populated from /convai/phone-numbers, may be [])
   try {
     const data = await getElevenLabsData();
     const match = data.phones.find((p) => p.phone_number === fromNumber);
-    return match?.phone_number_id ?? null;
+    if (match?.phone_number_id) return match.phone_number_id;
   } catch {
-    return null;
+    // fall through
   }
+
+  // Second try: search phone numbers embedded in each agent config via /convai/agents
+  // This endpoint is more reliable than /convai/phone-numbers
+  try {
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+    if (!apiKey) return null;
+    const res = await safeFetch(
+      `${ELEVENLABS_API_BASE}/convai/agents?page_size=50`,
+      { headers: { "xi-api-key": apiKey } },
+    );
+    if (res) {
+      const agents: Array<{ phone_numbers?: Array<{ phone_number: string; phone_number_id: string }> }> =
+        (res as { agents?: unknown[] }).agents ?? [];
+      for (const agent of agents) {
+        const match = (agent.phone_numbers ?? []).find(
+          (p) => p.phone_number === fromNumber,
+        );
+        if (match?.phone_number_id) return match.phone_number_id;
+      }
+    }
+  } catch {
+    // no match found
+  }
+
+  return null;
 }
 
 // ── Tool Definitions ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When `make_call` is called with an explicit `from_number`, the resolution chain is:

1. `resolvePhoneNumberIdFromCache` → calls `getElevenLabsData()` → hits `/convai/phone-numbers` (flaky endpoint, often times out) → returns `phones: []` → no match → returns `null`
2. `resolvePhoneNumberIdFromConfig` → only checks the *requesting agent's own* `phone_numbers` array → empty for Sales Booking agent → returns `undefined`
3. Falls back to `DEFAULT_FROM_NUMBER` (US number) even when Swiss number was explicitly requested

This caused two bugs:
- Wrong phone number used (US instead of Swiss)
- Instant hang-up when voice override was also blocked

## Fix

Added a second fallback in `resolvePhoneNumberIdFromCache`: when `/convai/phone-numbers` is flaky, fall back to fetching `/convai/agents` (the **reliable** endpoint) and search each agent's embedded `phone_numbers` array.

This way any phone number can be resolved regardless of which agent it's assigned to, and without depending on the flaky `/convai/phone-numbers` endpoint.

## Key insight

ElevenLabs allows any phone number to be used with any agent on outbound calls (1:1 assignment in the dashboard is only for inbound routing defaults). The code now correctly resolves cross-agent phone number lookups.