### PR TITLE
fix: voice.ts TS errors (safeFetch out of scope, type cast)

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -250,13 +250,13 @@ async function resolvePhoneNumberIdFromCache(
   try {
     const apiKey = process.env.ELEVENLABS_API_KEY;
     if (!apiKey) return null;
-    const res = await safeFetch(
+    const res = await fetch(
       `${ELEVENLABS_API_BASE}/convai/agents?page_size=50`,
-      { headers: { "xi-api-key": apiKey } },
+      { headers: { "xi-api-key": apiKey }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
     );
-    if (res) {
-      const agents: Array<{ phone_numbers?: Array<{ phone_number: string; phone_number_id: string }> }> =
-        (res as { agents?: unknown[] }).agents ?? [];
+    if (res.ok) {
+      const json = (await res.json()) as { agents?: Array<{ phone_numbers?: Array<{ phone_number: string; phone_number_id: string }> }> };
+      const agents = json.agents ?? [];
       for (const agent of agents) {
         const match = (agent.phone_numbers ?? []).find(
           (p) => p.phone_number === fromNumber,


### PR DESCRIPTION
## Problem

PR #442 introduced two TS errors blocking deployment:

```
src/tools/voice.ts(253,23): error TS2304: Cannot find name 'safeFetch'.
src/tools/voice.ts(258,13): error TS2322: Type 'unknown[]' is not assignable to type ...
```

`safeFetch` is a local function inside `getElevenLabsData` -- not accessible outside. The fallback in `resolvePhoneNumberIdFromCache` was calling it outside that scope.

## Fix
- Replace `safeFetch` call with a raw `fetch` + try/catch inline
- Properly type the JSON response with explicit type assertion
- Logic unchanged: still falls back to `/convai/agents` endpoint when `/convai/phone-numbers` is flaky

## Test
- TS build should pass
- Phone number resolution still uses agents endpoint as fallback
