### PR TITLE
fix: move dynamic context out of cached system prompt (#445)

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -434,13 +434,6 @@ export async function buildSystemPrompt(
     parts.push(skillIndex);
   }
 
-  // Conversation context (thread or recent channel messages)
-  if (context.threadContext) {
-    const heading = context.isChannelHistory
-      ? `\n## Recent channel context\n\nHere are the recent messages in this channel for context:\n\n${context.threadContext}`
-      : `\n## Recent thread context\n\nHere are the recent messages in this thread for context:\n\n${context.threadContext}`;
-    parts.push(heading);
-  }
 
   return parts.join("\n\n");
 }
@@ -454,12 +447,23 @@ export function buildDynamicContext(context: {
   modelId?: string;
   channelId?: string;
   threadTs?: string;
+  threadContext?: string;
+  isChannelHistory?: boolean;
 }): string {
   const parts: string[] = [];
   parts.push(`Current time: ${getCurrentTimeContext(context.userTimezone)}`);
   if (context.modelId) parts.push(`Active model: \`${context.modelId}\``);
   if (context.channelId) parts.push(`Current channel: ${context.channelId}`);
   if (context.threadTs) parts.push(`Current thread_ts: ${context.threadTs}`);
+
+  // Thread/channel context -- dynamic per conversation, must not be cached
+  if (context.threadContext) {
+    const heading = context.isChannelHistory
+      ? `\n## Recent channel context\n\nHere are the recent messages in this channel for context:\n\n${context.threadContext}`
+      : `\n## Recent thread context\n\nHere are the recent messages in this thread for context:\n\n${context.threadContext}`;
+    parts.push(heading);
+  }
+
   return parts.join('\n');
 }
 

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -279,7 +279,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       );
     }
     const retrievalStart = Date.now();
-    const { systemPrompt, memories, conversations } = await assemblePrompt(
+    const { systemPrompt, memories, conversations, threadContext, isChannelHistory } = await assemblePrompt(
       { ...context, text: messageText },
       conversation,
       client,
@@ -309,6 +309,8 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       teamId,
       recipientUserId: context.userId,
       channelType: context.channelType,
+      threadContext,
+      isChannelHistory,
     });
     const llmMs = Date.now() - llmStart;
 

--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -117,8 +117,6 @@ export async function assemblePrompt(
     channelId: context.channelId,
     threadTs: context.threadTs,
     userTimezone: userProfile?.timezone || undefined,
-    threadContext,
-    isChannelHistory,
     modelId,
   });
 
@@ -129,5 +127,5 @@ export async function assemblePrompt(
     hasThread: !!threadContext,
   });
 
-  return { systemPrompt, memories, conversations, userProfile };
+  return { systemPrompt, memories, conversations, userProfile, threadContext, isChannelHistory };
 }

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -272,6 +272,8 @@ interface RespondOptions {
   files?: FileContentPart[];
   channelId: string;
   threadTs?: string;
+  threadContext?: string;
+  isChannelHistory?: boolean;
   /** Slack team ID — required for chatStream in channels */
   teamId?: string;
   /** Slack user ID of the message author — required for chatStream in channels */
@@ -523,7 +525,7 @@ export async function generateResponse(
     model,
     system: [
       withCacheControl(options.systemPrompt),
-      { role: 'system' as const, content: buildDynamicContext({ channelId: options.channelId, threadTs: options.threadTs, modelId, userTimezone: options.context?.timezone }) },
+      { role: 'system' as const, content: buildDynamicContext({ channelId: options.channelId, threadTs: options.threadTs, modelId, userTimezone: options.context?.timezone, threadContext: options.threadContext, isChannelHistory: options.isChannelHistory }) },
     ],
     tools: createSlackTools(options.slackClient, options.context),
     stopWhen: stepCountIs(STEP_LIMIT),
@@ -999,7 +1001,7 @@ export async function generateResponse(
         model,
         system: [
           withCacheControl(options.systemPrompt),
-          { role: 'system' as const, content: buildDynamicContext({ channelId: options.channelId, threadTs: options.threadTs, modelId, userTimezone: options.context?.timezone }) },
+          { role: 'system' as const, content: buildDynamicContext({ channelId: options.channelId, threadTs: options.threadTs, modelId, userTimezone: options.context?.timezone, threadContext: options.threadContext, isChannelHistory: options.isChannelHistory }) },
         ],
         prompt: retryPrompt,
         abortSignal: retryAbortController.signal,


### PR DESCRIPTION
## Problem

The cached system prompt included per-call dynamic values (channelId, threadTs, modelId, timestamp), making every invocation a cache miss. Cache reads dropped to zero after the dynamic values were introduced.

## Fix

Split into two system messages:
1. **Cached** (existing) -- stable system prompt via `withCacheControl`
2. **Uncached** (new) -- dynamic context via `buildDynamicContext`

Anthropic supports multiple system messages. Only the first one (with `cacheControl: ephemeral`) gets cached. The second one has no cache_control and can change per-call without breaking cache hits.

## Changes
- `src/personality/system-prompt.ts`: Remove dynamic block from `buildSystemPrompt`, add exported `buildDynamicContext` function
- `src/pipeline/respond.ts`: Both call sites updated to pass an array of two system messages

## Diff size
~20 lines changed. Minimal fix.