### PR TITLE
Tool slack metadata co-location

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -1,0 +1,72 @@
+import { tool, type Tool } from "ai";
+import type { ZodType } from "zod";
+
+// ── Slack Card Metadata ──────────────────────────────────────────────────────
+// Co-located with tool definitions via defineTool() so that Slack card behavior
+// (spinner label, input summary, output summary, URL citations) stays in sync
+// with the tool itself instead of drifting in separate switch blocks.
+
+export interface SlackToolMetadata<TInput = any, TOutput = any> {
+  /** Spinner label shown while tool is running, e.g. "Searching the web..." */
+  status: string;
+  /** Extract a short detail from input args for the in-progress card */
+  detail?: (input: TInput) => string | undefined;
+  /** Extract a short summary from result for the completed card */
+  output?: (result: TOutput) => string | undefined;
+  /** Extract URL citations for web tool cards */
+  sources?: (
+    result: TOutput,
+  ) => Array<{ type: "url"; url: string; text: string }> | undefined;
+}
+
+/**
+ * Retrieve the Slack card metadata from a tool, if it was created with
+ * defineTool(). Returns undefined for tools created with the standard
+ * AI SDK tool() helper.
+ */
+export function getSlackMeta(t: unknown): SlackToolMetadata | undefined {
+  if (t && typeof t === "object" && "slack" in t) {
+    return (t as { slack: SlackToolMetadata }).slack;
+  }
+  return undefined;
+}
+
+/**
+ * Wrapper around AI SDK's tool() that co-locates Slack card metadata with the
+ * tool definition. The optional `slack` field is attached directly to the
+ * returned tool object so respond.ts can read it at runtime without maintaining
+ * separate switch blocks.
+ *
+ * Usage:
+ * ```ts
+ * const myTool = defineTool({
+ *   description: "...",
+ *   inputSchema: z.object({ query: z.string() }),
+ *   execute: async ({ query }) => ({ ok: true, results: [] }),
+ *   slack: {
+ *     status: "Searching...",
+ *     detail: (input) => input.query,
+ *     output: (result) => `${result.results.length} results`,
+ *   },
+ * });
+ * ```
+ */
+export function defineTool<TInput, TOutput>(config: {
+  description: string;
+  inputSchema: ZodType<TInput, any, any>;
+  execute: (input: TInput) => PromiseLike<TOutput>;
+  slack?: SlackToolMetadata<TInput, TOutput>;
+}) {
+  const { slack, ...toolConfig } = config;
+  // The spread loses the generic relationship between TInput/TOutput and the
+  // Tool intersection type, so we go through `unknown` to satisfy the compiler.
+  const t = tool<TInput, TOutput>(
+    toolConfig as unknown as Tool<TInput, TOutput>,
+  );
+  if (slack) {
+    (t as any).slack = slack;
+  }
+  return t as Tool<TInput, TOutput> & {
+    slack?: SlackToolMetadata<TInput, TOutput>;
+  };
+}

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -9,6 +9,7 @@ import { formatForSlack } from "../lib/format.js";
 import { TABLE_BLOCK_KEY } from "../tools/table.js";
 import { safePostMessage, isChannelTypeNotSupported, isInvalidBlocks, isMsgTooLong } from "../lib/slack-messaging.js";
 import { createInteractivePrepareStep, STEP_LIMIT } from "./prepare-step.js";
+import { getSlackMeta } from "../lib/tool.js";
 
 // ── Tool I/O Persistence ─────────────────────────────────────────────────────
 // Accumulated during streaming and attached as invisible Slack message metadata
@@ -672,9 +673,10 @@ export async function generateResponse(
         }
 
         case "tool-call": {
-          const title = TOOL_STATUS[chunk.toolName] || "Working on it...";
+          const slackMeta = getSlackMeta(streamOptions.tools[chunk.toolName]);
+          const title = slackMeta?.status ?? TOOL_STATUS[chunk.toolName] ?? "Working on it...";
           const inputArgs = (chunk as any).input ?? {};
-          const details = getToolDetails(chunk.toolName, inputArgs);
+          const details = slackMeta?.detail?.(inputArgs) ?? getToolDetails(chunk.toolName, inputArgs);
           const toolCallPayload = {
             chunks: [{
               type: "task_update",
@@ -716,7 +718,8 @@ export async function generateResponse(
         }
 
         case "tool-result": {
-          const title = TOOL_STATUS[chunk.toolName] || "Done";
+          const resultSlackMeta = getSlackMeta(streamOptions.tools[chunk.toolName]);
+          const title = resultSlackMeta?.status ?? TOOL_STATUS[chunk.toolName] ?? "Done";
           const output = chunk.output;
           const isError = output && typeof output === "object" &&
             "ok" in output && output.ok === false;
@@ -729,8 +732,8 @@ export async function generateResponse(
             pendingTableBlock = output[TABLE_BLOCK_KEY] as Record<string, any>;
           }
 
-          const taskOutput = getToolOutput(chunk.toolName, output);
-          const sources = getToolSources(chunk.toolName, output);
+          const taskOutput = resultSlackMeta?.output?.(output) ?? getToolOutput(chunk.toolName, output);
+          const sources = resultSlackMeta?.sources?.(output) ?? getToolSources(chunk.toolName, output);
 
           const toolResultPayload = {
             chunks: [{
@@ -775,7 +778,8 @@ export async function generateResponse(
         case "tool-error": {
           const errToolName = (chunk as any).toolName;
           const errToolCallId = (chunk as any).toolCallId;
-          const title = TOOL_STATUS[errToolName] || "Failed";
+          const errSlackMeta = getSlackMeta(streamOptions.tools[errToolName]);
+          const title = errSlackMeta?.status ?? TOOL_STATUS[errToolName] ?? "Failed";
           const err = (chunk as any).error;
           const errorMsg = err instanceof Error ? err.message : String(err);
           const toolErrorPayload = {

--- a/src/tools/bigquery.ts
+++ b/src/tools/bigquery.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { logger } from "../lib/logger.js";
 import { formatTimestamp } from "../lib/temporal.js";
 import { getBigQueryClient } from "../lib/bigquery.js";
+import { defineTool } from "../lib/tool.js";
 import type { ScheduleContext } from "../db/schema.js";
 
 /**
@@ -300,7 +301,7 @@ export function createBigQueryTools(context?: ScheduleContext) {
       },
     }),
 
-    execute_query: tool({
+    execute_query: defineTool({
       description:
         "Run a read-only SQL query against BigQuery. Only SELECT/WITH queries are allowed — DML/DDL is blocked. Uses standard SQL (not legacy). Has a 1 GB scan limit to prevent runaway costs. Use LIMIT for large result sets to keep responses manageable. Read the 'data-warehouse-map' note before re-exploring from scratch.",
       inputSchema: z.object({
@@ -404,6 +405,18 @@ export function createBigQueryTools(context?: ScheduleContext) {
             error: `Query failed: ${error.message}`,
           };
         }
+      },
+      slack: {
+        status: "Running a SQL query...",
+        detail: (input) =>
+          input.sql.length <= 120
+            ? input.sql
+            : input.sql.slice(0, 119) + "…",
+        output: (result) => {
+          if ("error" in result && typeof result.error === "string") return result.error;
+          if ("total_rows" in result) return `${result.total_rows ?? 0} rows`;
+          return undefined;
+        },
       },
     }),
   };

--- a/src/tools/sandbox.ts
+++ b/src/tools/sandbox.ts
@@ -1,4 +1,3 @@
-import { tool } from "ai";
 import { z } from "zod";
 import {
   getOrCreateSandbox,
@@ -8,6 +7,7 @@ import {
 } from "../lib/sandbox.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
+import { defineTool } from "../lib/tool.js";
 import type { ScheduleContext } from "../db/schema.js";
 
 /**
@@ -18,7 +18,7 @@ import type { ScheduleContext } from "../db/schema.js";
  */
 export function createSandboxTools(context?: ScheduleContext) {
   return {
-    run_command: tool({
+    run_command: defineTool({
       description:
         "Execute a shell command in a sandboxed Linux VM. This is the universal primitive for computation: file ops, git, code execution (node, python), search (rg, grep), data processing (curl, jq), and self-modification via Claude Code (claude). Pre-installed: git, node, python, gh, gcloud, vercel CLI, ripgrep, curl, jq, claude. Install more with apt-get or pip. The sandbox persists between conversations — files and state are preserved across messages. Output is truncated; use head, tail, grep to filter. Break complex tasks into smaller commands. For complex workflows, check your skill notes first. Use higher timeouts (up to 750s) for long-running agent commands like Claude Code — the 750s ceiling leaves a 50s buffer before the Vercel function timeout at 800s.",
       inputSchema: z.object({
@@ -128,6 +128,27 @@ export function createSandboxTools(context?: ScheduleContext) {
             error: `Command execution failed: ${error.message}`,
           };
         }
+      },
+      slack: {
+        status: "Running a command in the sandbox...",
+        detail: (input) =>
+          input.command.length <= 120
+            ? input.command
+            : input.command.slice(0, 119) + "…",
+        output: (result) => {
+          if ("ok" in result && !result.ok) return result.error;
+          if (!("exit_code" in result)) return undefined;
+          const r = result as { exit_code: number; stdout?: string; stderr?: string };
+          if (r.exit_code === 0) return undefined;
+          const stderr = typeof r.stderr === "string" ? r.stderr.trim() : "";
+          const stdout = typeof r.stdout === "string" ? r.stdout.trim() : "";
+          const detail = stderr || stdout;
+          if (detail) {
+            const truncated = detail.length <= 180 ? detail : detail.slice(0, 179) + "…";
+            return `Exit code ${r.exit_code}: ${truncated}`;
+          }
+          return `Exit code ${r.exit_code}`;
+        },
       },
     }),
   };

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -1,8 +1,8 @@
-import { tool } from "ai";
 import { z } from "zod";
 import { tavily } from "@tavily/core";
 import { lookup } from "node:dns/promises";
 import { logger } from "../lib/logger.js";
+import { defineTool } from "../lib/tool.js";
 
 // ── Tavily Client ────────────────────────────────────────────────────────────
 
@@ -106,7 +106,7 @@ async function isPrivateUrl(url: string): Promise<boolean> {
  */
 export function createWebTools() {
   return {
-    web_search: tool({
+    web_search: defineTool({
       description:
         "Search the web for current information, documentation, news, or anything outside the Slack workspace. Don't search the web for things you can find in the workspace — use search_messages or read_channel_history instead. Requires TAVILY_API_KEY.",
       inputSchema: z.object({
@@ -124,7 +124,7 @@ export function createWebTools() {
         const tvly = getTavilyClient();
         if (!tvly) {
           return {
-            ok: false,
+            ok: false as const,
             error: "Web search is not available. TAVILY_API_KEY is not configured.",
           };
         }
@@ -148,7 +148,7 @@ export function createWebTools() {
           });
 
           return {
-            ok: true,
+            ok: true as const,
             query,
             answer: response.answer || null,
             results,
@@ -160,14 +160,27 @@ export function createWebTools() {
             error: error.message,
           });
           return {
-            ok: false,
+            ok: false as const,
             error: `Web search failed: ${error.message}`,
           };
         }
       },
+      slack: {
+        status: "Searching the web...",
+        detail: (input) => input.query,
+        output: (result) => "ok" in result && result.ok ? `${result.count ?? 0} results` : result.error,
+        sources: (result) => {
+          if (!("ok" in result) || !result.ok || !Array.isArray(result.results)) return undefined;
+          return result.results.slice(0, 3).map((r) => ({
+            type: "url" as const,
+            url: r.url,
+            text: r.title || r.url,
+          }));
+        },
+      },
     }),
 
-    read_url: tool({
+    read_url: defineTool({
       description:
         "Fetch a URL and extract its readable text content. Use when someone pastes a link and asks 'what does this say?' or 'can you read this?', or to check if a site is up. For simple text extraction, prefer this over browse. If TAVILY_API_KEY is configured, uses Tavily extract for cleaner results; otherwise falls back to basic HTML stripping.",
       inputSchema: z.object({
@@ -182,7 +195,7 @@ export function createWebTools() {
           if (await isPrivateUrl(url)) {
             logger.warn("read_url SSRF blocked", { url });
             return {
-              ok: false,
+              ok: false as const,
               error: "Blocked: URL resolves to a private/internal network address",
               url,
             };
@@ -198,10 +211,10 @@ export function createWebTools() {
                 const content = (result.rawContent || "").substring(0, 4000);
                 logger.info("read_url tool called (tavily)", { url, contentLength: content.length });
                 return {
-                  ok: true,
+                  ok: true as const,
                   url,
                   content,
-                  source: "tavily",
+                  source: "tavily" as const,
                 };
               }
             } catch {
@@ -227,7 +240,7 @@ export function createWebTools() {
               if (await isPrivateUrl(currentUrl)) {
                 logger.warn("read_url SSRF blocked (redirect)", { url, redirectTo: currentUrl });
                 return {
-                  ok: false,
+                  ok: false as const,
                   error: "Blocked: redirect resolves to a private/internal network address",
                   url,
                 };
@@ -239,7 +252,7 @@ export function createWebTools() {
 
           if (!response.ok) {
             return {
-              ok: false,
+              ok: false as const,
               error: `HTTP ${response.status} ${response.statusText}`,
               url,
             };
@@ -260,24 +273,41 @@ export function createWebTools() {
           logger.info("read_url tool called (fetch)", { url, contentLength: content.length });
 
           return {
-            ok: true,
+            ok: true as const,
             url,
             content,
-            source: "fetch",
+            source: "fetch" as const,
           };
         } catch (error: any) {
           logger.error("read_url tool failed", { url, error: error.message });
 
           if (error.name === "TimeoutError" || error.name === "AbortError") {
-            return { ok: false, error: `Request timed out after 10 seconds`, url };
+            return { ok: false as const, error: `Request timed out after 10 seconds`, url };
           }
 
           return {
-            ok: false,
+            ok: false as const,
             error: `Failed to read URL: ${error.message}`,
             url,
           };
         }
+      },
+      slack: {
+        status: "Reading a link...",
+        detail: (input) => input.url,
+        output: (result) => {
+          if ("ok" in result && !result.ok) return result.error;
+          return undefined;
+        },
+        sources: (result) => {
+          if (!("ok" in result) || !result.ok || !("url" in result)) return undefined;
+          const url = (result as { url: string }).url;
+          try {
+            return [{ type: "url" as const, url, text: new URL(url).hostname }];
+          } catch {
+            return [{ type: "url" as const, url, text: url }];
+          }
+        },
       },
     }),
   };


### PR DESCRIPTION
Implements `defineTool()` to co-locate Slack card metadata with tool definitions, centralizing configuration and preventing drift.

This PR introduces `defineTool()` in `src/lib/tool.ts`, updates `src/pipeline/respond.ts` to use the new metadata with backward compatibility, and migrates `web_search`, `read_url`, `run_command`, and `execute_query` as proof of concept.

---
<p><a href="https://cursor.com/agents/bc-eaf704fa-f2e2-4a96-9461-546c92831bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaf704fa-f2e2-4a96-9461-546c92831bb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Slack tool task cards derive titles/details/outputs/sources at runtime; incorrect metadata wiring or typing could degrade streaming UX but doesn’t alter core auth/data flows.
> 
> **Overview**
> Introduces `defineTool()`/`getSlackMeta()` (`src/lib/tool.ts`) to attach optional Slack task-card metadata (status, input detail, output summary, URL sources) directly onto AI SDK tool objects.
> 
> Updates `respond.ts` to prefer per-tool attached metadata when rendering `tool-call`/`tool-result`/`tool-error` task updates, with fallback to the existing `TOOL_STATUS`/`getToolDetails`/`getToolOutput`/`getToolSources` logic for tools not yet migrated.
> 
> Migrates `web_search`, `read_url`, `run_command`, and BigQuery `execute_query` to `defineTool()` and adds tailored Slack card summaries/citations; also tightens some tool return types using `ok: true/false as const` for better type discrimination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b15cb7813323518f79cc5456d471250c129b5eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->