### PR TITLE
Effort cascade refinements

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -165,6 +165,15 @@ export function supportsEffort(modelId: string): boolean {
 }
 
 /**
+ * Check if a model is known to actively use the effort parameter.
+ * Only these models should use effort-based escalation (max out effort before
+ * switching models). Other models fall back to failure-count-based escalation.
+ */
+export function supportsEffortEscalation(modelId: string): boolean {
+  return /claude-(?:opus-4-[56]|sonnet-4-6)/.test(modelId);
+}
+
+/**
  * Get the escalation model for automatic model escalation.
  * Used when the default model is struggling — prepareStep can swap to this mid-conversation.
  * Priority: DB setting > env var > default (Opus 4.6)

--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
-import { supportsEffort } from "../lib/ai.js";
+import { supportsEffort, supportsEffortEscalation } from "../lib/ai.js";
 import { logger } from "../lib/logger.js";
 
 export const STEP_LIMIT = 250;
@@ -47,6 +47,7 @@ export function createPrepareStep(opts: {
   const limit = opts.stepLimit ?? STEP_LIMIT;
   const threshold = opts.warningThreshold ?? WARNING_THRESHOLD;
   const isAnthropic = opts.modelId ? supportsEffort(opts.modelId) : false;
+  const useEffortEscalation = opts.modelId ? supportsEffortEscalation(opts.modelId) : false;
   let currentEffort: EffortLevel = opts.defaultEffort ?? "medium";
   let hasEscalatedModel = false;
   let escalatedModel: { modelId: string; model: LanguageModel } | null = null;
@@ -91,9 +92,9 @@ export function createPrepareStep(opts: {
     }
 
     // --- Model escalation: persistent failures → escalation model ---
-    // For effort-supporting models: escalate after reaching max effort and still failing.
+    // For models with native effort support: escalate after reaching max effort and still failing.
     // For other models: escalate after 3+ cumulative tool failures.
-    const readyToEscalateModel = isAnthropic
+    const readyToEscalateModel = useEffortEscalation
       ? (currentEffort === "high" && hadToolFailure)
       : (failureCount >= 3);
 


### PR DESCRIPTION
Refine AI effort cascade logic for forward compatibility and add clarity to `providerOptions` handling.

The `supportsEffort` function was updated to be more general (`modelId.includes("anthropic/") && modelId.includes("claude")`) instead of a narrow regex. This ensures that new Claude models supporting the `effort` parameter will automatically benefit from the cascade without requiring code changes, leveraging the Anthropic API's behavior of silently ignoring unknown parameters. The comment in `prepare-step.ts` clarifies a design choice related to the AI SDK's state management.

---
<p><a href="https://cursor.com/agents/bc-7af69092-f909-4b8f-85eb-b6c375aae680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7af69092-f909-4b8f-85eb-b6c375aae680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect runtime model selection/escalation logic; misclassification could cause earlier/later escalation or send `effort` to more models, though Anthropic ignores unsupported params.
> 
> **Overview**
> Improves Anthropic `effort` handling by broadening `supportsEffort` to match any gateway Claude model (forward-compatible as unsupported params are ignored) and adding `supportsEffortEscalation` to restrict *effort-based model escalation* to a known-safe subset (Opus 4.5/4.6 and Sonnet 4.6).
> 
> Updates `prepareStep` so it always re-sends `providerOptions.anthropic.effort` each step (since the SDK doesn’t persist provider options) and switches model-escalation gating from “any effort-supporting model” to the new `supportsEffortEscalation` check; all other models continue using failure-count-based escalation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00ecd6a15098f3bee3a0da361282f2e519a1f090. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->