### PR TITLE
Dropped messages summary

### DIFF
--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -84,7 +84,7 @@ export async function assemblePrompt(
   // would have no conversation context despite the shouldRespond gate seeing it.
   const useChannelFallback =
     context.isDm || !!context.threadTs || conversation.auraRecentlyActive;
-  const threadContext = formatConversationContext(
+  const threadContext = await formatConversationContext(
     conversation,
     useChannelFallback,
     userProfile?.timezone || undefined,

--- a/src/pipeline/slack-context.ts
+++ b/src/pipeline/slack-context.ts
@@ -311,29 +311,61 @@ function formatMessage(m: SlackThreadMessage, timezone?: string, isOld = false):
  *   messages, false for non-threaded channel messages (to avoid mislabeling
  *   unrelated channel history as "thread context" in the system prompt).
  */
-export function formatConversationContext(
+export async function formatConversationContext(
   conversation: ConversationContext,
   includeChannelFallback: boolean = true,
   timezone?: string,
-): string | undefined {
+): Promise<string | undefined> {
   const RECENT_TOOL_IO_COUNT = 10;
 
   // Prefer thread context if available
   if (conversation.thread && conversation.thread.length > 0) {
-    // Cap thread context to avoid inflating the system prompt for long threads.
-    // Keep the parent message (first) plus the most recent messages.
     const MAX_THREAD_MESSAGES = 50;
     const thread = conversation.thread;
-    const capped =
-      thread.length <= MAX_THREAD_MESSAGES
-        ? thread
-        : [thread[0], ...thread.slice(-MAX_THREAD_MESSAGES + 1)];
-    const threadFormatted = capped
-      .map((m, i) => {
-        const isOld = i < capped.length - RECENT_TOOL_IO_COUNT;
-        return formatMessage(m, timezone, isOld);
-      })
-      .join("\n\n");
+
+    let threadFormatted: string;
+
+    if (thread.length <= MAX_THREAD_MESSAGES) {
+      threadFormatted = thread
+        .map((m, i) => {
+          const isOld = i < thread.length - RECENT_TOOL_IO_COUNT;
+          return formatMessage(m, timezone, isOld);
+        })
+        .join("\n\n");
+    } else {
+      const droppedMessages = thread.slice(1, thread.length - (MAX_THREAD_MESSAGES - 2));
+      const recentMessages = thread.slice(-(MAX_THREAD_MESSAGES - 2));
+
+      let summaryEntry: string;
+      try {
+        const { getFastModel } = await import("../lib/ai.js");
+        const { generateText } = await import("ai");
+        const fastModel = await getFastModel();
+
+        const droppedText = droppedMessages
+          .map((m) => `${m.displayName}: ${m.text.slice(0, 200)}`)
+          .join("\n");
+
+        const { text: summary } = await generateText({
+          model: fastModel,
+          prompt: `These are messages from an ongoing conversation (${droppedMessages.length} messages). Summarize the key decisions, facts, tasks completed/merged, and open threads in 3-5 sentences. Focus on: what was decided, what was built or merged, what tasks were assigned, what is still pending.\n\nMessages:\n${droppedText.slice(0, 8000)}`,
+          maxOutputTokens: 200,
+        });
+
+        summaryEntry = `[Context: ${droppedMessages.length} earlier messages summarized: ${summary.trim()}]`;
+      } catch {
+        summaryEntry = `[${droppedMessages.length} earlier messages not shown]`;
+      }
+
+      const parts: string[] = [];
+      parts.push(formatMessage(thread[0], timezone, true));
+      parts.push(summaryEntry);
+      recentMessages.forEach((m, i) => {
+        const isOld = i < recentMessages.length - RECENT_TOOL_IO_COUNT;
+        parts.push(formatMessage(m, timezone, isOld));
+      });
+      threadFormatted = parts.join("\n\n");
+    }
 
     // Include channel messages posted before the thread root for broader context.
     // recentMessages are in chronological order (oldest-first after the reverse


### PR DESCRIPTION
Summarize dropped thread messages in `formatConversationContext` to prevent loss of context in long conversations.

Previously, `formatConversationContext` silently dropped messages in threads longer than 50, leading to critical context loss for Aura. This change introduces an LLM-generated summary of these dropped messages, injecting it into the conversation context.

---
<p><a href="https://cursor.com/agents/bc-1a832c80-0899-4d67-ba4f-056745f05f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a832c80-0899-4d67-ba4f-056745f05f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an extra LLM call during prompt assembly for long threads, which can impact latency/cost and adds a new failure mode (handled via fallback placeholder).
> 
> **Overview**
> Prevents silent context loss in long Slack threads by inserting an LLM-generated summary of *dropped* messages into the formatted conversation context when a thread exceeds 50 messages.
> 
> This makes `formatConversationContext` async and updates prompt assembly to `await` it; the summarization uses the configured `getFastModel()` via `ai.generateText`, and falls back to a placeholder if summarization fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44cf35acefcbdc35fe1aaf0de4007dd8af93d3c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->