### PR TITLE
fix: outbound calls should wait for human to speak first

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -522,7 +522,6 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
             dynamic_variables: dynamicVars,
             conversation_config_override: {
               agent: {
-                first_message: resolvedFirstMessage,
                 language: langConfig.languageCode,
               },
               ...(resolvedVoiceId


### PR DESCRIPTION
## Problem

When initiating an outbound call, the agent was speaking first (injecting `first_message` into the override). This is wrong for outbound -- the agent should ring, the human picks up and speaks, then the agent responds.

## Fix

Remove `first_message` from the `conversation_config_override` on outbound calls. The agent's default `first_message` is already empty at the agent level, so omitting the override lets it stay silent until the human speaks.

## Change

1 line deleted from `src/tools/voice.ts`.