### PR TITLE
Outbound call dynamic variables

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -451,8 +451,10 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
           agentConfig.conversation_config?.agent?.dynamic_variables
             ?.dynamic_variable_placeholders ?? {};
 
+        const excludedVars = new Set(["call_context", "call_opener"]);
         const missingVars: string[] = [];
         for (const key of Object.keys(placeholders)) {
+          if (excludedVars.has(key)) continue;
           if (dynamicVars[key] === undefined) {
             const defaultVal = placeholders[key];
             if (


### PR DESCRIPTION
Align `make_call` tool behavior with sandbox calls by preventing the agent from speaking first and cleaning up related dead code.

The `call_opener` dynamic variable was inadvertently triggering the agent to speak first in outbound calls. This PR removes `call_opener` and `call_context` from the dynamic variables passed to the agent, ensuring the agent waits silently for human input, consistent with direct sandbox calls. It also removes associated dead code from `LanguageConfig` and the `make_call` tool schema.

---
<p><a href="https://cursor.com/agents/bc-dd2d8cf9-2b6b-4955-83d4-db953dbc40dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd2d8cf9-2b6b-4955-83d4-db953dbc40dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized behavior change to outbound call initiation; main risk is altered agent prompting if downstream agent configs expect `call_context`/`call_opener` at call start.
> 
> **Overview**
> Adjusts `make_call` outbound behavior to **match ElevenLabs sandbox calls** by no longer passing `call_context`/`call_opener` dynamic variables that caused the agent to speak immediately.
> 
> Removes the `opener` input from the tool schema and deletes the now-dead language greeting/template fields (`COMPANY_NAME`, `firstMessage`, `defaultOpener`), while updating dynamic-variable validation to ignore excluded placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee0048aada869480801edb38754da1983d548c18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->