### PR TITLE
AI model beta flag

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -3,7 +3,7 @@ import { generateText, stepCountIs } from "ai";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "../db/schema.js";
-import { getMainModel, getEscalationModel, withCacheControl, isAnthropicModel } from "../lib/ai.js";
+import { getMainModel, getEscalationModel, withCacheControl } from "../lib/ai.js";
 import { createSlackTools } from "../tools/slack.js";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
@@ -158,20 +158,11 @@ export async function executeJob(
       threadTs: job.threadTs || undefined,
     });
 
-    let tools: Record<string, any> = slackTools;
-    if (isAnthropicModel(modelId)) {
-      const { anthropic: anthropicProvider } = await import("@ai-sdk/anthropic");
-      tools = {
-        ...tools,
-        toolSearchBm25_20251119: anthropicProvider.tools.toolSearchBm25_20251119(),
-      };
-    }
-
     const generateResult = await generateText({
       model,
       system: withCacheControl(systemPrompt),
       prompt,
-      tools,
+      tools: slackTools,
       stopWhen: stepCountIs(HEADLESS_STEP_LIMIT),
       prepareStep: createHeadlessPrepareStep({
         systemPrompt,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -172,18 +172,18 @@ export function supportsEffort(modelId: string): boolean {
 
 /**
  * Build Anthropic context management configuration.
- * Combines three strategies:
+ * Combines two strategies:
  * 1. Clear old tool uses at 60K tokens (keep last 5)
- * 2. Clear old thinking turns (keep last 3)
- * 3. Compact (summarize) at 80K tokens
+ * 2. Compact (summarize) at 80K tokens
+ *
+ * Note: clear_thinking_20251015 is omitted because it requires `thinking`
+ * to be explicitly enabled or adaptive. We use `effort` instead, which
+ * doesn't satisfy that requirement and causes 400 errors across all
+ * gateway providers.
  */
 export function buildContextManagement() {
   return {
     edits: [
-      {
-        type: "clear_thinking_20251015" as const,
-        keep: { type: "thinking_turns" as const, value: 3 },
-      },
       {
         type: "clear_tool_uses_20250919" as const,
         trigger: { type: "input_tokens" as const, value: 60000 },

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -402,15 +402,6 @@ export async function generateResponse(
     abortSignal: abortController.signal,
   };
 
-  // Only inject toolSearchBm25 for direct Anthropic — Vertex/Bedrock don't support the beta flag
-  if (isAnthropicModel(modelId)) {
-    const { anthropic: anthropicProvider } = await import("@ai-sdk/anthropic");
-    streamOptions.tools = {
-      ...streamOptions.tools,
-      toolSearchBm25_20251119: anthropicProvider.tools.toolSearchBm25_20251119(),
-    };
-  }
-
   if (hasFiles) {
     const content: any[] = [
       { type: "text", text: options.userMessage },


### PR DESCRIPTION
Fixes "invalid beta flag" error by adjusting context management and removing an incompatible beta tool flag.

The production error was due to two issues:
1. The `clear_thinking_20251015` context management strategy required `thinking` to be enabled, which was not the case, causing Anthropic direct provider failures.
2. The `toolSearchBm25_20251119` tool injected an `advanced-tool-use-2025-11-20` beta header that was incompatible with Vertex and Bedrock fallback providers, leading to failures across the gateway routing chain. This PR removes the problematic context strategy and the incompatible beta tool flag.

---
<p><a href="https://cursor.com/agents/bc-7a2d0b4a-8d54-401b-8b14-cd8fff51e9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a2d0b4a-8d54-401b-8b14-cd8fff51e9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core LLM invocation paths (streaming responses and cron job execution), so regressions could reduce tool capability or alter long-context behavior, but the change is narrowly scoped to removing incompatible provider options.
> 
> **Overview**
> Fixes production "invalid beta flag" failures by removing Anthropic-specific beta features that break gateway routing.
> 
> Headless job execution and interactive responses no longer inject the Anthropic `toolSearchBm25_20251119` tool (and its beta header); they now use only the standard Slack tool set.
> 
> Anthropic `contextManagement` is simplified to drop the `clear_thinking_20251015` edit, leaving tool-use clearing and compaction to avoid 400s when `thinking` isn’t enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccf0afca4308e8558f370c325c2f508922393955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->