### PR TITLE
fix: remove thread_ts from dynamic context (duplicate message bug)

### DIFF
--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -451,6 +451,5 @@ export function buildDynamicContext(context: {
   let s = `## Current context\n\n${getCurrentTimeContext(context.userTimezone)}`;
   if (context.modelId) s += `\nActive model: \`${context.modelId}\``;
   if (context.channelId) s += `\nCurrent channel: ${context.channelId}`;
-  if (context.threadTs) s += `\nCurrent thread_ts: ${context.threadTs}`;
   return s;
 }


### PR DESCRIPTION
## Problem

`buildDynamicContext` was emitting `Current thread_ts: <ts>` into the second system message (the uncached dynamic block). The model read this and called `send_thread_reply` explicitly — while the streaming pipeline ALSO posted the final response to the thread. Result: duplicate messages ~24ms apart, one plain and one with interactive elements.

Visible in #cost_infra and any channel thread where Aura was responding.

## Root cause

Commit that added the dynamic context split (#417 area) emitted `threadTs` as an instruction-like line. The model interpreted it as "you should reply in this thread" rather than as metadata.

Thread routing is purely internal pipeline infrastructure. The model doesn't need to know its own thread_ts.

## Fix

One line deletion: remove the `if (context.threadTs) s += `\nCurrent thread_ts: ${context.threadTs}`` line from `buildDynamicContext`.

The `threadTs` parameter remains in the function signature (callers still pass it) but it's no longer emitted to the string.