### PR TITLE
Tool definition migration

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -33,7 +33,7 @@ export function getSlackMeta(t: unknown): SlackToolMetadata | undefined {
 
 /**
  * Wrapper around AI SDK's tool() that co-locates Slack card metadata with the
- * tool definition. The optional `slack` field is attached directly to the
+ * tool definition. The required `slack` field is attached directly to the
  * returned tool object so respond.ts can read it at runtime without maintaining
  * separate switch blocks.
  *
@@ -55,7 +55,7 @@ export function defineTool<TInput, TOutput>(config: {
   description: string;
   inputSchema: ZodType<TInput, any, any>;
   execute: (input: TInput) => PromiseLike<TOutput>;
-  slack?: SlackToolMetadata<TInput, TOutput>;
+  slack: SlackToolMetadata<TInput, TOutput>;
   toModelOutput?: Tool<TInput, TOutput>["toModelOutput"];
 }) {
   const { slack, ...toolConfig } = config;
@@ -64,10 +64,8 @@ export function defineTool<TInput, TOutput>(config: {
   const t = tool<TInput, TOutput>(
     toolConfig as unknown as Tool<TInput, TOutput>,
   );
-  if (slack) {
-    (t as any).slack = slack;
-  }
+  (t as any).slack = slack;
   return t as Tool<TInput, TOutput> & {
-    slack?: SlackToolMetadata<TInput, TOutput>;
+    slack: SlackToolMetadata<TInput, TOutput>;
   };
 }


### PR DESCRIPTION
Make the `.slack` field required for `defineTool()` to enforce Slack card metadata declaration for all tools.

This completes the migration outlined in issue #452 by ensuring that all future tools will have their Slack card metadata defined at creation time, preventing compile-time errors if omitted.

---
<p><a href="https://cursor.com/agents/bc-a489b64d-9bf7-4f91-861e-85b2b36141eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a489b64d-9bf7-4f91-861e-85b2b36141eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

