### PR TITLE
Slack metadata requirement

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -33,7 +33,7 @@ export function getSlackMeta(t: unknown): SlackToolMetadata | undefined {
 
 /**
  * Wrapper around AI SDK's tool() that co-locates Slack card metadata with the
- * tool definition. The optional `slack` field is attached directly to the
+ * tool definition. The required `slack` field is attached directly to the
  * returned tool object so respond.ts can read it at runtime without maintaining
  * separate switch blocks.
  *
@@ -55,7 +55,7 @@ export function defineTool<TInput, TOutput>(config: {
   description: string;
   inputSchema: ZodType<TInput, any, any>;
   execute: (input: TInput) => PromiseLike<TOutput>;
-  slack?: SlackToolMetadata<TInput, TOutput>;
+  slack: SlackToolMetadata<TInput, TOutput>;
   toModelOutput?: Tool<TInput, TOutput>["toModelOutput"];
 }) {
   const { slack, ...toolConfig } = config;
@@ -64,10 +64,8 @@ export function defineTool<TInput, TOutput>(config: {
   const t = tool<TInput, TOutput>(
     toolConfig as unknown as Tool<TInput, TOutput>,
   );
-  if (slack) {
-    (t as any).slack = slack;
-  }
+  (t as any).slack = slack;
   return t as Tool<TInput, TOutput> & {
-    slack?: SlackToolMetadata<TInput, TOutput>;
+    slack: SlackToolMetadata<TInput, TOutput>;
   };
 }


### PR DESCRIPTION
Require `slack` metadata in `defineTool()` as the final step for issue #452.

---
<p><a href="https://cursor.com/agents/bc-2f6e0272-ed9d-406a-b63a-e369ecb9e596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f6e0272-ed9d-406a-b63a-e369ecb9e596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized TypeScript API tightening that mainly affects compile-time; runtime behavior only changes by always attaching `slack` metadata to tools created via `defineTool()`.
> 
> **Overview**
> Makes `slack` card metadata **required** for `defineTool()` and updates its return type accordingly (no more optional `slack`).
> 
> Removes the conditional attachment of metadata and always assigns `(t as any).slack = slack`, ensuring `respond.ts` can consistently read Slack card info from tools at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4a1faa6d8c19f378467d4a56042293fec1bd33e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->