### PR TITLE
Tool definition migration

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -33,7 +33,7 @@ export function getSlackMeta(t: unknown): SlackToolMetadata | undefined {
 
 /**
  * Wrapper around AI SDK's tool() that co-locates Slack card metadata with the
- * tool definition. The optional `slack` field is attached directly to the
+ * tool definition. The required `slack` field is attached directly to the
  * returned tool object so respond.ts can read it at runtime without maintaining
  * separate switch blocks.
  *
@@ -55,7 +55,7 @@ export function defineTool<TInput, TOutput>(config: {
   description: string;
   inputSchema: ZodType<TInput, any, any>;
   execute: (input: TInput) => PromiseLike<TOutput>;
-  slack?: SlackToolMetadata<TInput, TOutput>;
+  slack: SlackToolMetadata<TInput, TOutput>;
   toModelOutput?: Tool<TInput, TOutput>["toModelOutput"];
 }) {
   const { slack, ...toolConfig } = config;
@@ -64,10 +64,8 @@ export function defineTool<TInput, TOutput>(config: {
   const t = tool<TInput, TOutput>(
     toolConfig as unknown as Tool<TInput, TOutput>,
   );
-  if (slack) {
-    (t as any).slack = slack;
-  }
+  (t as any).slack = slack;
   return t as Tool<TInput, TOutput> & {
-    slack?: SlackToolMetadata<TInput, TOutput>;
+    slack: SlackToolMetadata<TInput, TOutput>;
   };
 }

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -42,28 +42,18 @@ function truncateToBytes(s: string, maxBytes: number): string {
   return buf.subarray(0, end).toString("utf8") + "…";
 }
 
-/** Serialize tool output with per-tool truncation. */
-function serializeToolOutput(toolName: string, output: any): string {
+/** Serialize tool output with generic truncation (cap large row arrays). */
+function serializeToolOutput(_toolName: string, output: any): string {
   if (output == null) return "";
   if (typeof output !== "object") return String(output);
 
-  switch (toolName) {
-    case "execute_query": {
-      if (output.rows && Array.isArray(output.rows)) {
-        const capped = { ...output, rows: output.rows.slice(0, 50) };
-        if (output.rows.length > 50) capped._truncated = true;
-        return truncateToBytes(JSON.stringify(capped), 3000);
-      }
-      return truncateToBytes(JSON.stringify(output), 3000);
-    }
-    case "run_command":
-      return truncateToBytes(JSON.stringify(output), 2000);
-    case "web_search":
-    case "read_url":
-      return truncateToBytes(JSON.stringify(output), 2000);
-    default:
-      return truncateToBytes(JSON.stringify(output), 1500);
+  // Cap large row-like arrays to keep metadata size manageable
+  if (output.rows && Array.isArray(output.rows) && output.rows.length > 50) {
+    const capped = { ...output, rows: output.rows.slice(0, 50), _truncated: true };
+    return truncateToBytes(JSON.stringify(capped), 2000);
   }
+
+  return truncateToBytes(JSON.stringify(output), 2000);
 }
 
 /** Build Slack message metadata from accumulated tool call records. */


### PR DESCRIPTION
Completes the `defineTool()` migration by making `slack` metadata required and removing the last hardcoded tool-name strings from `respond.ts`.

While most tools were already migrated to `defineTool()`, this PR finishes the job by enforcing the `.slack` metadata field as required in `src/lib/tool.ts` and eliminating the last remaining hardcoded tool-name logic in `src/pipeline/respond.ts`. This centralizes tool output serialization and ensures all future tools declare their Slack card metadata upfront.

---
<p><a href="https://cursor.com/agents/bc-35bcb435-a411-4647-9660-6a9e99f9bfad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35bcb435-a411-4647-9660-6a9e99f9bfad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enforces required `slack` metadata on all `defineTool()` tools (compile-time breaking) and changes how tool outputs are truncated for Slack metadata, which could affect downstream rendering/diagnostics if assumptions about output size/shape differ.
> 
> **Overview**
> Completes the `defineTool()` migration by making `slack` card metadata **required** in `defineTool()` and always attaching it to the returned tool object (no optional/conditional `.slack`).
> 
> Removes hardcoded tool-name branches in `respond.ts` for tool output serialization, switching to a single generic truncation path that caps large `rows` arrays (50) and truncates JSON to a fixed budget.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a40955b4be4fa1e5be86ca7af4623b1ead236945. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->