### PR TITLE
Read_url Cloudflare bypass

### DIFF
--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -12,6 +12,11 @@ function getTavilyClient() {
   return tavily({ apiKey });
 }
 
+// ── Browser Headers ─────────────────────────────────────────────────────────
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
 // ── HTML Stripping ───────────────────────────────────────────────────────────
 
 /** Strip HTML tags and clean up whitespace for readable text extraction. */
@@ -228,7 +233,11 @@ export function createWebTools() {
           for (let r = 0; r < 10; r++) {
             response = await fetch(currentUrl, {
               headers: {
-                "User-Agent": "Mozilla/5.0 (compatible; AuraBot/1.0)",
+                "User-Agent": BROWSER_UA,
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Cache-Control": "no-cache",
               },
               signal: AbortSignal.timeout(10000),
               redirect: "manual",
@@ -251,9 +260,12 @@ export function createWebTools() {
           }
 
           if (!response.ok) {
+            const hint = response.status === 403
+              ? ". This may be Cloudflare bot protection — try using the `browse` tool instead, which uses a real browser."
+              : "";
             return {
               ok: false as const,
-              error: `HTTP ${response.status} ${response.statusText}`,
+              error: `HTTP ${response.status} ${response.statusText}${hint}`,
               url,
             };
           }


### PR DESCRIPTION
Uses realistic browser headers in `read_url` to bypass Cloudflare 403s and improves the error message for 403s.

The previous User-Agent `AuraBot/1.0` was immediately identified as a bot by Cloudflare, leading to 403 Forbidden responses on protected sites. This change makes `read_url` requests appear as a standard browser, increasing the success rate. For cases where 403s still occur, the error message now suggests using the `browse` tool as an alternative.

---
<p><a href="https://cursor.com/agents/bc-3c9c3ca5-4500-4826-8e04-a14f235755f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c9c3ca5-4500-4826-8e04-a14f235755f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts outbound `read_url` request headers and error messaging; main behavioral change is how third-party sites respond (possible different content/encodings).
> 
> **Overview**
> `read_url` now sends more realistic browser request headers (new `BROWSER_UA` plus `Accept`/language/encoding/cache headers) instead of an obvious bot User-Agent to reduce 403s on protected sites.
> 
> When fetch still fails, the error message appends a Cloudflare-specific hint for `403` responses suggesting the `browse` tool as an alternative.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ee0d090c12148e92c92a042737401fa3e9cd08f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->