### PR TITLE
Anthropic context integration bugs

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -194,10 +194,16 @@ export function buildContextManagement() {
         type: "compact_20260112" as const,
         trigger: { type: "input_tokens" as const, value: 80000 },
         instructions:
-          "Preserve: current task state and goal, key decisions made, error patterns found, " +
-          "file paths being investigated, user preferences learned, thread context (channel, thread_ts), " +
-          "and any data/metrics discovered. Drop: verbatim tool outputs that have been summarized, " +
-          "intermediate failed attempts, redundant search results.",
+          "CRITICAL — preserve in this exact priority order:\n" +
+          "1. The user's MOST RECENT request/question — quote it verbatim if short\n" +
+          "2. What you are currently doing to address that request and your next planned step\n" +
+          "3. What you have already tried and the outcome (succeeded/failed/partial)\n" +
+          "4. Key findings, data, metrics, or file paths discovered so far\n" +
+          "5. Error patterns found and things that did NOT work (to avoid repeating them)\n" +
+          "6. Thread context (channel, thread_ts) and user preferences learned\n" +
+          "Drop: verbatim tool outputs that have been summarized, " +
+          "intermediate failed attempts where the outcome is already captured above, " +
+          "redundant search results, and any earlier conversation topics that are no longer relevant.",
       },
     ],
   };

--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -14,6 +14,62 @@ const WRAP_UP_MESSAGE =
   "Start wrapping up — summarize your findings and post results now. " +
   "Do not start new investigations or long tool chains.";
 
+// ── Loop Detection ───────────────────────────────────────────────────────────
+
+const LOOP_WINDOW = 8;
+const LOOP_WARN_THRESHOLD = 3;
+const LOOP_STOP_THRESHOLD = 5;
+
+const LOOP_WARNING =
+  "WARNING: You appear to be in a loop — you've made the same tool call " +
+  "with the same arguments {count} times in the last {window} steps. " +
+  "STOP repeating this call. Re-read the user's most recent message, " +
+  "reconsider your approach, and either try a different strategy or " +
+  "summarize what you've found so far and respond to the user.";
+
+const LOOP_FORCE_STOP =
+  "CRITICAL: You are stuck in an infinite loop — the same tool call has " +
+  "repeated {count} times. You MUST stop calling tools immediately. " +
+  "Summarize whatever you have and respond to the user NOW. " +
+  "Do NOT make any more tool calls.";
+
+interface ToolCallSignature {
+  name: string;
+  argsHash: string;
+}
+
+function hashArgs(args: unknown): string {
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return String(args);
+  }
+}
+
+function detectLoop(history: ToolCallSignature[]): {
+  looping: boolean;
+  count: number;
+  toolName?: string;
+} {
+  if (history.length < LOOP_WARN_THRESHOLD) return { looping: false, count: 0 };
+
+  const last = history[history.length - 1];
+  let count = 0;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].name === last.name && history[i].argsHash === last.argsHash) {
+      count++;
+    } else {
+      break;
+    }
+  }
+
+  if (count >= LOOP_WARN_THRESHOLD) {
+    return { looping: true, count, toolName: last.name };
+  }
+
+  return { looping: false, count };
+}
+
 export type EffortLevel = "low" | "medium" | "high";
 
 type PrepareStepResult = {
@@ -56,6 +112,7 @@ export function createPrepareStep(opts: {
   let hasEscalatedModel = false;
   let escalatedModel: { modelId: string; model: LanguageModel } | null = null;
   let failureCount = 0;
+  const recentToolCalls: ToolCallSignature[] = [];
 
   return async ({ stepNumber, steps, messages }) => {
     let systemOverride: string | undefined;
@@ -72,6 +129,42 @@ export function createPrepareStep(opts: {
     ) ?? false;
 
     if (hadToolFailure) failureCount++;
+
+    // --- Loop detection: track recent tool calls and detect repetition ---
+    if (lastStep?.toolCalls && Array.isArray(lastStep.toolCalls)) {
+      for (const tc of lastStep.toolCalls) {
+        recentToolCalls.push({
+          name: tc.toolName ?? tc.name ?? "unknown",
+          argsHash: hashArgs(tc.input ?? tc.args),
+        });
+      }
+      while (recentToolCalls.length > LOOP_WINDOW) {
+        recentToolCalls.shift();
+      }
+    }
+
+    const loopResult = detectLoop(recentToolCalls);
+    let loopNudge: string | undefined;
+    if (loopResult.looping) {
+      if (loopResult.count >= LOOP_STOP_THRESHOLD) {
+        loopNudge = LOOP_FORCE_STOP
+          .replace("{count}", String(loopResult.count));
+        logger.warn("prepareStep: loop detected — force stop", {
+          stepNumber,
+          toolName: loopResult.toolName,
+          repeatCount: loopResult.count,
+        });
+      } else {
+        loopNudge = LOOP_WARNING
+          .replace("{count}", String(loopResult.count))
+          .replace("{window}", String(LOOP_WINDOW));
+        logger.warn("prepareStep: loop detected — warning injected", {
+          stepNumber,
+          toolName: loopResult.toolName,
+          repeatCount: loopResult.count,
+        });
+      }
+    }
 
     // --- Effort escalation (only for models supporting Anthropic `effort` param) ---
     if (hasEffortSupport) {
@@ -134,17 +227,29 @@ export function createPrepareStep(opts: {
       modelOverride = escalatedModel.model;
     }
 
-    // --- Step limit warning (existing behavior) ---
+    // --- Step limit warning and loop detection nudges ---
+    const nudges: string[] = [];
+
+    if (loopNudge) {
+      nudges.push(loopNudge);
+    }
+
     if (stepNumber >= threshold) {
-      const nudge = WRAP_UP_MESSAGE
+      const wrapUp = WRAP_UP_MESSAGE
         .replace("{stepCount}", String(stepNumber))
         .replace("{limit}", String(limit));
-
-      systemOverride = opts.systemPrompt + "\n\n" + (opts.dynamicContext ? opts.dynamicContext + "\n\n" : "") + nudge;
+      nudges.push(wrapUp);
       logger.info("prepareStep: injecting wrap-up nudge", {
         stepNumber,
         limit,
       });
+    }
+
+    if (nudges.length > 0) {
+      systemOverride = opts.systemPrompt
+        + "\n\n"
+        + (opts.dynamicContext ? opts.dynamicContext + "\n\n" : "")
+        + nudges.join("\n\n");
     }
 
     const prunedMessages = pruneMessages({

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -428,6 +428,12 @@ export async function generateResponse(
   const pendingToolInputs = new Map<string, { name: string; input: string }>();
   let continuationCount = 0;
 
+  // Track compaction block IDs so their text-deltas are filtered from Slack output.
+  // When Anthropic context management fires compaction, it emits text-start with
+  // providerMetadata.anthropic.type === "compaction", followed by text-deltas
+  // containing the compaction summary — internal context, not user-facing.
+  const compactionBlockIds = new Set<string>();
+
   async function splitToNewStream(): Promise<boolean> {
     if (streamingFailed || continuationCount >= MAX_CONTINUATIONS) {
       if (continuationCount >= MAX_CONTINUATIONS) {
@@ -472,7 +478,26 @@ export async function generateResponse(
       resetTimer();
 
       switch (chunk.type) {
+        case "text-start": {
+          const anthropicMeta = (chunk as any).providerMetadata?.anthropic;
+          if (anthropicMeta?.type === "compaction") {
+            compactionBlockIds.add((chunk as any).id);
+            logger.info("Compaction block detected, filtering from Slack output", {
+              blockId: (chunk as any).id,
+            });
+          }
+          break;
+        }
+
+        case "text-end": {
+          compactionBlockIds.delete((chunk as any).id);
+          break;
+        }
+
         case "text-delta": {
+          if (compactionBlockIds.has((chunk as any).id)) {
+            break;
+          }
           accumulatedText += chunk.text;
           let remaining = chunk.text;
 


### PR DESCRIPTION
Fixes two bugs in Anthropic context management by filtering compaction output from Slack and adding loop detection for tool calls.

Anthropic's context compaction was leaking internal summaries to users in Slack and causing the agent to enter infinite loops of repeating tool calls due to loss of context. This PR addresses both issues by filtering the compaction output from the Slack stream and implementing a loop detection mechanism with improved compaction instructions to better preserve task context.

---
<p><a href="https://cursor.com/agents/bc-f5c24206-e4a2-4390-adc5-c3e7663d515a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5c24206-e4a2-4390-adc5-c3e7663d515a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core response streaming and step orchestration; while straightforward, mistakes could suppress valid output or inject overly aggressive system nudges, impacting user-visible behavior.
> 
> **Overview**
> Prevents Anthropic context compaction summaries from leaking into Slack by tracking `compaction` text blocks in the stream and filtering their `text-delta` output.
> 
> Adds tool-call loop detection in `prepareStep`: records recent tool call signatures and injects escalating system nudges (warning → force-stop) when identical calls repeat, alongside the existing step-limit wrap-up message.
> 
> Tightens Anthropic compaction `instructions` to more reliably preserve the most recent user request and current task state during summarization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af549ca0f758cf10caef7d35849d4f9579200fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->