### PR TITLE
Make_call tool name

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2951,7 +2951,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     // Browser
     "browse", "download_slack_file",
     // Voice / Calls
-    "list_voice_agents", "make_call", "send_sms",
+    "list_voice_agents", "place_call", "send_sms",
     // Directory / Contacts
     "lookup_workspace_user", "list_workspace_users", "lookup_contact",
     // Checkpoint

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -197,7 +197,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
     tools.list_voice_agents = defineTool({
       description:
         "List available ElevenLabs voice agents, phone numbers, and voices. " +
-        "Call this BEFORE make_call when the user asks to call with a specific agent, " +
+        "Call this BEFORE place_call when the user asks to call with a specific agent, " +
         "voice, or phone number so you can resolve names to IDs. " +
         "Results are cached for 10 minutes. Admin-only.",
       inputSchema: z.object({}),
@@ -245,12 +245,12 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
       slack: { status: "Listing voice agents..." },
     });
 
-    // ── make_call ───────────────────────────────────────────────────
+    // ── place_call ───────────────────────────────────────────────────
     const DEFAULT_AGENT_ID = process.env.ELEVENLABS_AGENT_ID ?? "agent_9301kj9tjcqaermrz71vvr0fpv4v";
     const DEFAULT_FROM_NUMBER = process.env.ELEVENLABS_FROM_NUMBER ?? "+14158860211";
     const DEFAULT_VOICE_ID = process.env.ELEVENLABS_VOICE_ID ?? "upcns7xCtWHwsgL2HKV5";
 
-    tools.make_call = defineTool({
+    tools.place_call = defineTool({
       description:
         "Initiate an outbound phone call via ElevenLabs + Twilio. " +
         "Use list_voice_agents first to discover available agents/phones/voices, " +
@@ -428,7 +428,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
 
           if (!callResponse.ok) {
             const errorText = await callResponse.text();
-            logger.error("make_call ElevenLabs API error", {
+            logger.error("place_call ElevenLabs API error", {
               statusCode: callResponse.status,
               body: errorText.substring(0, 500),
             });
@@ -445,7 +445,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
             };
           } catch (parseError: any) {
             try { await callResponse.body?.cancel(); } catch {}
-            logger.error("make_call response JSON parse failed (call may have been placed)", {
+            logger.error("place_call response JSON parse failed (call may have been placed)", {
               error: parseError.message,
               to: toNumber,
             });
@@ -478,18 +478,18 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
                 })
                 .onConflictDoNothing({ target: voiceCalls.conversationId });
             } catch (dbError: any) {
-              logger.error("make_call DB insert failed (call was placed)", {
+              logger.error("place_call DB insert failed (call was placed)", {
                 error: dbError.message,
                 conversationId,
               });
             }
           } else {
-            logger.warn("make_call: no conversation_id returned, skipping DB insert", {
+            logger.warn("place_call: no conversation_id returned, skipping DB insert", {
               to: toNumber,
             });
           }
 
-          logger.info("make_call tool called", {
+          logger.info("place_call tool called", {
             to: toNumber,
             person: resolvedName,
             agentId: resolvedAgentId,
@@ -503,7 +503,7 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
             ...(trackingWarning ? { warning: trackingWarning } : {}),
           };
         } catch (error: any) {
-          logger.error("make_call tool failed", { error: error.message });
+          logger.error("place_call tool failed", { error: error.message });
           return {
             ok: false,
             error: `Failed to initiate call: ${error.message}`,


### PR DESCRIPTION
Rename the `make_call` tool to `place_call` across the codebase.

---
<p><a href="https://cursor.com/agents/bc-f5fd32b3-7c09-4804-b164-5255004f6721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5fd32b3-7c09-4804-b164-5255004f6721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a broad tool rename that can break callers relying on the old `make_call` name (e.g., prompts, integrations, or tests), even though the underlying call logic is unchanged.
> 
> **Overview**
> Renames the outbound calling tool from `make_call` to `place_call` and updates related user-facing guidance/logging to match.
> 
> Updates Slack tool deferral/discovery (`DEFERRED_TOOLS` in `src/tools/slack.ts`) and the voice tools export (`src/tools/voice.ts`) so the system advertises/uses `place_call` instead of `make_call`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0a5745782d13ad22c6f7e39eb6230d0bce6ca70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->