### PR TITLE
Semantic loop detection

### DIFF
--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -102,7 +102,9 @@ interface TrackedToolCall {
 function normalizeCommand(cmd: string): string {
   return cmd
     .replace(/\\[\r\n]+/g, " ")
-    .replace(/#[^\n]*/g, "")
+    .replace(/(["'])(?:\\[\s\S]|(?!\1).)*\1|#[^\n]*/g, (match) =>
+      match.startsWith("#") ? "" : match,
+    )
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -143,7 +145,7 @@ function normalizeToolArgs(toolName: string, args: unknown): string {
     if (typeof command === "string" && command) return extractCommandFingerprint(command);
   }
   try {
-    return JSON.stringify(args);
+    return JSON.stringify(args) ?? "undefined";
   } catch {
     return String(args);
   }
@@ -320,8 +322,12 @@ export function createPrepareStep(opts: {
           argsHash: hashArgs(args),
         });
 
-        // Semantic circuit breaker tracking
-        const result = resultById.get(tc.toolCallId) ?? toolResults[i];
+        // Semantic circuit breaker tracking — only fall back to index when
+        // the result at that position has no toolCallId (avoiding mis-association
+        // if results arrive in a different order than calls).
+        const resultByIndex = toolResults[i];
+        const result = resultById.get(tc.toolCallId)
+          ?? (resultByIndex && !resultByIndex.toolCallId ? resultByIndex : undefined);
         const output = result?.output ?? result?.result;
         const failed =
           output?.ok === false ||


### PR DESCRIPTION
Implement a circuit breaker for semantic loop detection to catch functionally identical but string-different repeated tool calls and error patterns.

The existing loop detection only caught exact string matches. This PR introduces normalization and fingerprinting for commands and error messages, allowing the system to identify and break out of loops where the agent repeatedly attempts the same action with minor variations or encounters the same underlying error.

---
<p><a href="https://cursor.com/agents/bc-ced89dc3-8e2a-4d0d-a57a-a7b7192fc93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ced89dc3-8e2a-4d0d-a57a-a7b7192fc93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent control-flow by injecting new stop/warning nudges based on semantic tool-call and error similarity, which could alter tool retry behavior and prematurely stop legitimate retries if fingerprinting is too aggressive.
> 
> **Overview**
> Adds a **semantic circuit breaker** to `prepareStep` to detect repeated tool attempts that are functionally the same even when arguments differ superficially.
> 
> The new logic normalizes/fingerprints tool arguments (with special handling for `run_command`/`curl`/`wget`) and error outputs, tracks recent calls/results, and injects either a warning or a hard stop nudge when similar calls or repeated errors cross a threshold (in addition to the existing exact-match loop detection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e32e4e9a5ea843c9c72a2de6adf76d7bee05f62f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->