### PR TITLE
Loop detection circuit breaker

### DIFF
--- a/src/pipeline/__tests__/circuit-breaker.test.ts
+++ b/src/pipeline/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Standalone test for circuit breaker logic.
+ * Run: npx tsx src/pipeline/__tests__/circuit-breaker.test.ts
+ */
+import {
+  normalizeCommand,
+  extractEndpoints,
+  detectCircuitBreaker,
+  type CommandFailureRecord,
+} from "../circuit-breaker.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, name: string) {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    failed++;
+    console.error(`  ✗ ${name}`);
+  }
+}
+
+// ── normalizeCommand ─────────────────────────────────────────────────────────
+
+console.log("\nnormalizeCommand:");
+
+assert(
+  normalizeCommand("curl https://api.example.com # retry 1") ===
+    normalizeCommand("curl https://api.example.com # retry 2"),
+  "strips trailing comments",
+);
+
+assert(
+  normalizeCommand("curl   https://api.example.com") ===
+    normalizeCommand("curl https://api.example.com"),
+  "collapses whitespace",
+);
+
+assert(
+  normalizeCommand("echo 'hello # world'") === "echo 'hello # world'",
+  "preserves # inside single quotes",
+);
+
+assert(
+  normalizeCommand('echo "hello # world"') === 'echo "hello # world"',
+  "preserves # inside double quotes",
+);
+
+assert(
+  normalizeCommand("# full comment line\ncurl https://example.com") ===
+    "curl https://example.com",
+  "strips full comment lines",
+);
+
+assert(
+  normalizeCommand("curl \\\n  https://api.example.com \\\n  -H 'Auth: x' # attempt 1") ===
+    normalizeCommand("curl \\\n  https://api.example.com \\\n  -H 'Auth: x' # attempt 5"),
+  "multiline commands with different comments normalize equally",
+);
+
+// ── extractEndpoints ─────────────────────────────────────────────────────────
+
+console.log("\nextractEndpoints:");
+
+assert(
+  extractEndpoints("curl https://api.elevenlabs.io/v1/text-to-speech")[0] ===
+    "https://api.elevenlabs.io/v1/text-to-speech",
+  "extracts simple URL",
+);
+
+assert(
+  extractEndpoints("curl 'https://api.example.com/v1/users?page=1&limit=10'")[0] ===
+    "https://api.example.com/v1/users",
+  "strips query parameters from endpoint",
+);
+
+assert(
+  extractEndpoints("echo no urls here").length === 0,
+  "returns empty array when no URLs",
+);
+
+assert(
+  extractEndpoints(
+    "curl https://api.a.com/v1 && curl https://api.b.com/v2",
+  ).length === 2,
+  "extracts multiple URLs",
+);
+
+// ── detectCircuitBreaker ─────────────────────────────────────────────────────
+
+console.log("\ndetectCircuitBreaker:");
+
+assert(
+  !detectCircuitBreaker([]).triggered,
+  "no trigger on empty failures",
+);
+
+assert(
+  !detectCircuitBreaker([
+    { normalizedCommand: "curl https://x.com", endpoints: ["https://x.com"] },
+    { normalizedCommand: "curl https://x.com", endpoints: ["https://x.com"] },
+  ]).triggered,
+  "no trigger below threshold (2 failures)",
+);
+
+// Test case from the issue: 4 consecutive failures with same URL, different comments
+const elevenLabsFailures: CommandFailureRecord[] = [
+  {
+    normalizedCommand: normalizeCommand(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx' # attempt 1",
+    ),
+    endpoints: extractEndpoints(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx'",
+    ),
+  },
+  {
+    normalizedCommand: normalizeCommand(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx' # retry attempt 2",
+    ),
+    endpoints: extractEndpoints(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx'",
+    ),
+  },
+  {
+    normalizedCommand: normalizeCommand(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx' # third try",
+    ),
+    endpoints: extractEndpoints(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx'",
+    ),
+  },
+  {
+    normalizedCommand: normalizeCommand(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx' # last attempt",
+    ),
+    endpoints: extractEndpoints(
+      "curl -X POST https://api.elevenlabs.io/v1/text-to-speech -H 'xi-api-key: xxx'",
+    ),
+  },
+];
+
+const result3 = detectCircuitBreaker(elevenLabsFailures.slice(0, 3));
+assert(
+  result3.triggered,
+  "triggers after 3rd failure with same endpoint (ElevenLabs scenario)",
+);
+assert(
+  result3.message!.includes("CIRCUIT BREAKER"),
+  "message contains CIRCUIT BREAKER label",
+);
+
+const result4 = detectCircuitBreaker(elevenLabsFailures);
+assert(
+  result4.triggered,
+  "triggers after 4th failure with same endpoint",
+);
+
+// Similar commands (same normalized, different comments)
+assert(
+  detectCircuitBreaker(elevenLabsFailures).message!.includes(
+    "semantically identical",
+  ),
+  "identifies semantically identical commands (same normalized form)",
+);
+
+// Different commands but same endpoint
+const sameEndpointDiffCommands: CommandFailureRecord[] = [
+  {
+    normalizedCommand: "curl -X GET https://api.elevenlabs.io/v1/voices",
+    endpoints: ["https://api.elevenlabs.io/v1/voices"],
+  },
+  {
+    normalizedCommand: "curl -X POST https://api.elevenlabs.io/v1/voices -d '{}'",
+    endpoints: ["https://api.elevenlabs.io/v1/voices"],
+  },
+  {
+    normalizedCommand: "wget https://api.elevenlabs.io/v1/voices",
+    endpoints: ["https://api.elevenlabs.io/v1/voices"],
+  },
+];
+
+const endpointResult = detectCircuitBreaker(sameEndpointDiffCommands);
+assert(
+  endpointResult.triggered,
+  "triggers on same endpoint with different commands",
+);
+assert(
+  endpointResult.message!.includes("api.elevenlabs.io"),
+  "message mentions the failing endpoint",
+);
+
+// General consecutive failures (different commands, different endpoints)
+const generalFailures: CommandFailureRecord[] = [
+  {
+    normalizedCommand: "apt-get install foo",
+    endpoints: [],
+  },
+  {
+    normalizedCommand: "pip install bar",
+    endpoints: [],
+  },
+  {
+    normalizedCommand: "npm install baz",
+    endpoints: [],
+  },
+];
+
+const generalResult = detectCircuitBreaker(generalFailures);
+assert(
+  generalResult.triggered,
+  "triggers on 3 consecutive failures even with different commands",
+);
+assert(
+  generalResult.message!.includes("consecutive run_command"),
+  "uses general failure message for diverse commands",
+);
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/src/pipeline/circuit-breaker.ts
+++ b/src/pipeline/circuit-breaker.ts
@@ -1,0 +1,108 @@
+/**
+ * Circuit breaker for detecting semantic repetition in run_command tool calls.
+ *
+ * Catches "same purpose, same failure" patterns by:
+ * 1. Normalizing shell commands (stripping comments, collapsing whitespace)
+ * 2. Tracking consecutive run_command failures
+ * 3. Detecting repeated API endpoint URLs across failures
+ */
+
+const CIRCUIT_BREAKER_THRESHOLD = 3;
+
+const CIRCUIT_BREAKER_FAILURE =
+  "CIRCUIT BREAKER: {count} consecutive run_command calls have failed. " +
+  "Stop retrying — the command is not working. Analyze the error output, " +
+  "report the failure to the user, and suggest a different approach. " +
+  "Do NOT retry the same or similar command.";
+
+const CIRCUIT_BREAKER_SIMILAR =
+  "CIRCUIT BREAKER: You are retrying semantically identical commands " +
+  "(differing only in comments or whitespace) that keep failing. " +
+  "STOP immediately. The command does not work. Report the failure to the user.";
+
+const CIRCUIT_BREAKER_ENDPOINT =
+  "CIRCUIT BREAKER: The API endpoint {endpoint} has failed in {count} " +
+  "consecutive commands. It is likely down, rate-limited, or the request " +
+  "is malformed. STOP calling this endpoint. Report the failure to the user.";
+
+export interface CommandFailureRecord {
+  normalizedCommand: string;
+  endpoints: string[];
+}
+
+/**
+ * Normalize a shell command for semantic comparison.
+ * Strips shell comments (respecting quotes), collapses whitespace, trims.
+ */
+export function normalizeCommand(cmd: string): string {
+  return cmd
+    .split("\n")
+    .map((line) => {
+      let result = "";
+      let inSingle = false;
+      let inDouble = false;
+      for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (ch === "'" && !inDouble) inSingle = !inSingle;
+        else if (ch === '"' && !inSingle) inDouble = !inDouble;
+        else if (ch === "#" && !inSingle && !inDouble) break;
+        result += ch;
+      }
+      return result;
+    })
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Extract API endpoint URLs from a shell command.
+ * Returns normalized endpoints (origin + pathname, no query/fragment).
+ */
+export function extractEndpoints(cmd: string): string[] {
+  const urlRegex = /https?:\/\/[^\s'"\\)}>]+/gi;
+  const matches = cmd.match(urlRegex) || [];
+  const endpoints = new Set<string>();
+  for (const url of matches) {
+    try {
+      const u = new URL(url);
+      endpoints.add(u.origin + u.pathname);
+    } catch {
+      endpoints.add(url);
+    }
+  }
+  return [...endpoints];
+}
+
+export function detectCircuitBreaker(failures: CommandFailureRecord[]): {
+  triggered: boolean;
+  message?: string;
+} {
+  if (failures.length < CIRCUIT_BREAKER_THRESHOLD) {
+    return { triggered: false };
+  }
+
+  const recent = failures.slice(-CIRCUIT_BREAKER_THRESHOLD);
+
+  const lastNormalized = recent[recent.length - 1].normalizedCommand;
+  if (lastNormalized && recent.every((f) => f.normalizedCommand === lastNormalized)) {
+    return { triggered: true, message: CIRCUIT_BREAKER_SIMILAR };
+  }
+
+  const lastEndpoints = recent[recent.length - 1].endpoints;
+  for (const ep of lastEndpoints) {
+    if (recent.every((f) => f.endpoints.includes(ep))) {
+      return {
+        triggered: true,
+        message: CIRCUIT_BREAKER_ENDPOINT
+          .replace("{endpoint}", ep)
+          .replace("{count}", String(recent.length)),
+      };
+    }
+  }
+
+  return {
+    triggered: true,
+    message: CIRCUIT_BREAKER_FAILURE.replace("{count}", String(failures.length)),
+  };
+}

--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -3,6 +3,12 @@ import type { LanguageModel, ModelMessage } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
 import { supportsEffort, isAnthropicModel, buildContextManagement } from "../lib/ai.js";
 import { logger } from "../lib/logger.js";
+import {
+  normalizeCommand,
+  extractEndpoints,
+  detectCircuitBreaker,
+  type CommandFailureRecord,
+} from "./circuit-breaker.js";
 
 export const STEP_LIMIT = 250;
 export const HEADLESS_STEP_LIMIT = 350;
@@ -38,8 +44,14 @@ interface ToolCallSignature {
   argsHash: string;
 }
 
-function hashArgs(args: unknown): string {
+function hashArgs(toolName: string, args: unknown): string {
   try {
+    if (toolName === "run_command" && typeof args === "object" && args !== null) {
+      const { command, ...rest } = args as Record<string, unknown>;
+      if (typeof command === "string") {
+        return JSON.stringify({ command: normalizeCommand(command), ...rest });
+      }
+    }
     return JSON.stringify(args);
   } catch {
     return String(args);
@@ -113,6 +125,7 @@ export function createPrepareStep(opts: {
   let escalatedModel: { modelId: string; model: LanguageModel } | null = null;
   let failureCount = 0;
   const recentToolCalls: ToolCallSignature[] = [];
+  const consecutiveCommandFailures: CommandFailureRecord[] = [];
 
   return async ({ stepNumber, steps, messages }) => {
     let systemOverride: string | undefined;
@@ -133,9 +146,10 @@ export function createPrepareStep(opts: {
     // --- Loop detection: track recent tool calls and detect repetition ---
     if (lastStep?.toolCalls && Array.isArray(lastStep.toolCalls)) {
       for (const tc of lastStep.toolCalls) {
+        const toolName = tc.toolName ?? tc.name ?? "unknown";
         recentToolCalls.push({
-          name: tc.toolName ?? tc.name ?? "unknown",
-          argsHash: hashArgs(tc.input ?? tc.args),
+          name: toolName,
+          argsHash: hashArgs(toolName, tc.input ?? tc.args),
         });
       }
       while (recentToolCalls.length > LOOP_WINDOW) {
@@ -143,7 +157,49 @@ export function createPrepareStep(opts: {
       }
     }
 
+    // --- Circuit breaker: track consecutive run_command failures ---
+    if (lastStep?.toolCalls && Array.isArray(lastStep.toolCalls)) {
+      const toolResults: any[] = lastStep.toolResults ?? [];
+      let hadRunCommand = false;
+      let anyRunCommandSucceeded = false;
+
+      for (const tc of lastStep.toolCalls) {
+        const toolName = tc.toolName ?? tc.name ?? "unknown";
+        if (toolName !== "run_command") continue;
+
+        hadRunCommand = true;
+        const args = tc.input ?? tc.args;
+        const command: string = (typeof args === "object" && args !== null)
+          ? (args as Record<string, unknown>).command as string ?? ""
+          : "";
+
+        const result = toolResults.find(
+          (r: any) => r.toolCallId === tc.toolCallId,
+        );
+        const output = result?.output;
+        const isFailed =
+          output?.ok === false ||
+          output?.error != null ||
+          (output?.exit_code != null && output.exit_code !== 0);
+
+        if (isFailed) {
+          consecutiveCommandFailures.push({
+            normalizedCommand: normalizeCommand(command),
+            endpoints: extractEndpoints(command),
+          });
+        } else {
+          anyRunCommandSucceeded = true;
+        }
+      }
+
+      if (hadRunCommand && anyRunCommandSucceeded) {
+        consecutiveCommandFailures.length = 0;
+      }
+    }
+
     const loopResult = detectLoop(recentToolCalls);
+    const circuitBreakerResult = detectCircuitBreaker(consecutiveCommandFailures);
+
     let loopNudge: string | undefined;
     if (loopResult.looping) {
       if (loopResult.count >= LOOP_STOP_THRESHOLD) {
@@ -164,6 +220,15 @@ export function createPrepareStep(opts: {
           repeatCount: loopResult.count,
         });
       }
+    }
+
+    let circuitBreakerNudge: string | undefined;
+    if (circuitBreakerResult.triggered) {
+      circuitBreakerNudge = circuitBreakerResult.message;
+      logger.warn("prepareStep: circuit breaker triggered", {
+        stepNumber,
+        consecutiveFailures: consecutiveCommandFailures.length,
+      });
     }
 
     // --- Effort escalation (only for models supporting Anthropic `effort` param) ---
@@ -227,8 +292,12 @@ export function createPrepareStep(opts: {
       modelOverride = escalatedModel.model;
     }
 
-    // --- Step limit warning and loop detection nudges ---
+    // --- Step limit warning, loop detection, and circuit breaker nudges ---
     const nudges: string[] = [];
+
+    if (circuitBreakerNudge) {
+      nudges.push(circuitBreakerNudge);
+    }
 
     if (loopNudge) {
       nudges.push(loopNudge);


### PR DESCRIPTION
Add a circuit breaker to loop detection to catch semantic repetition of failing `run_command` calls, preventing infinite retries of external API calls that fail with slight command variations.

This addresses scenarios where the LLM retries the same failing API call repeatedly with minor command differences (e.g., comments or whitespace), which the previous string-identical loop detection missed. The circuit breaker normalizes commands, extracts API endpoints, and tracks consecutive failures to identify semantically identical failing operations.

---
<p><a href="https://cursor.com/agents/bc-1dac5b58-a973-45fa-ad60-030911beca17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dac5b58-a973-45fa-ad60-030911beca17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

