### PR TITLE
ElevenLabs agent pattern

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -379,7 +379,9 @@ export function createVoiceTools(context?: ScheduleContext): Record<string, any>
         const resolvedName = person_name || "Unknown";
         const langConfig = getLanguageConfig(language || DEFAULT_LANGUAGE);
 
-        const dynamicVars: Record<string, string> = {};
+        const dynamicVars: Record<string, string> = {
+          direction: "outbound",
+        };
         if (resolvedName && resolvedName !== "Unknown") {
           dynamicVars.person_name = resolvedName;
         }


### PR DESCRIPTION
Implement the `place_call` generic agent pattern to send all ElevenLabs configuration at runtime.

This PR removes hardcoded fallback values, eliminates language auto-detection, simplifies the outbound call payload, and adds explicit environment variable validation, aligning the tool with a thin wrapper approach for ElevenLabs.

---
<p><a href="https://cursor.com/agents/bc-fa5f9db6-1d3c-4c24-ae30-068a85eea795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa5f9db6-1d3c-4c24-ae30-068a85eea795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes call initiation behavior by removing hardcoded fallbacks and language auto-detection, and by altering the outbound payload/dynamic variables; misconfigured env vars or expectations about language/variables could cause call failures or different agent behavior.
> 
> **Overview**
> Updates `place_call` in `src/tools/voice.ts` to act as a thinner ElevenLabs wrapper: removes hardcoded default `agent_id`/`from_number`/`voice_id` fallbacks and adds explicit runtime validation for required env vars/inputs.
> 
> Removes phone-based language auto-detection and simplifies the outbound call payload by only sending `direction` plus optional `person_name` dynamic variables, while always setting agent `language` via `conversation_config_override` and conditionally overriding the agent `prompt`/TTS `voice_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eec8a8b783233440876384b23fc8220c73721d21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->