### PR TITLE
Prune messages tool calls

### DIFF
--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -139,7 +139,6 @@ export function createPrepareStep(opts: {
 
     const prunedMessages = pruneMessages({
       messages,
-      toolCalls: "before-last-5-messages",
       reasoning: "before-last-message",
     });
 


### PR DESCRIPTION
Remove `toolCalls` pruning from `pruneMessages` to prevent LLM context loss and task loops.

The previous `toolCalls: "before-last-5-messages"` strategy stripped tool results from older messages, causing the LLM to forget prior searches/reads and re-execute them. With a 200K context window, this aggressive pruning is unnecessary and detrimental to task completion, leading to observed looping behavior.

---
<p><a href="https://cursor.com/agents/bc-f9b578bf-a726-40f0-b1ce-dfce23565ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9b578bf-a726-40f0-b1ce-dfce23565ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change to `pruneMessages` that only affects what conversation context is retained between steps, with no auth/data-write surface area.
> 
> **Overview**
> Stops pruning historical tool-call content when preparing step messages by removing `toolCalls: "before-last-5-messages"` from the `pruneMessages` call in `prepare-step.ts`.
> 
> This preserves older tool results/searches in the LLM context to reduce repeated tool execution and looping due to context loss.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faa68e9a2ebebf143fa3458fcaee9cf23032208f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->