### PR TITLE
Thread timestamp format

### DIFF
--- a/src/tools/conversations.ts
+++ b/src/tools/conversations.ts
@@ -32,6 +32,7 @@ interface MessageRow {
 
 export interface ThreadGroup {
   thread_ts: string | null;
+  thread_started_at: string;
   channel_id: string;
   messages: Array<{
     id: string;
@@ -239,6 +240,7 @@ export function createConversationSearchTools(context?: ScheduleContext) {
             if (!group) {
               group = {
                 thread_ts: row.slack_thread_ts || row.slack_ts,
+                thread_started_at: formatTimestamp(row.slack_thread_ts || row.slack_ts, context?.timezone),
                 channel_id: row.channel_id,
                 messages: [],
               };
@@ -326,6 +328,7 @@ export function createConversationSearchTools(context?: ScheduleContext) {
                 );
                 const fullThread: ThreadGroup = {
                   thread_ts: thread.thread_ts,
+                  thread_started_at: thread.thread_started_at,
                   channel_id: thread.channel_id,
                   messages: allMessages as ThreadGroup["messages"],
                 };


### PR DESCRIPTION
Adds `thread_started_at` (ISO format) to `search_my_conversations` tool output to provide LLMs with human-readable thread timestamps.

This fixes GitHub issue #500 by preventing LLMs from needing to manually convert raw Slack epoch `thread_ts` values, thus avoiding extra tool calls or incorrect time references. The raw `thread_ts` is preserved for downstream API compatibility.

---
<p><a href="https://cursor.com/agents/bc-3ee5ac1d-6b1a-4d7a-ade9-cfdfdcf61a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ee5ac1d-6b1a-4d7a-ade9-cfdfdcf61a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra output field to `search_my_conversations` thread objects; main risk is minor downstream compatibility for consumers expecting the previous `ThreadGroup` shape.
> 
> **Overview**
> `search_my_conversations` now returns a human-readable, ISO-8601 `thread_started_at` for each thread group (derived from the Slack thread/root timestamp and formatted via `formatTimestamp`, respecting the caller timezone).
> 
> The new field is propagated when building the full thread context response so both summarized threads and expanded context threads include `thread_started_at`, while preserving the existing raw `thread_ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0b2d15a4509df423b350ad15e904daac041cf61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->