### PR TITLE
fix: wrap bare markdown tables in code blocks in formatForSlack

### DIFF
--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -18,6 +18,13 @@ export function formatForSlack(text: string): string {
     return `\x00INLINE${inlineCode.length - 1}\x00`;
   });
 
+  // Wrap bare markdown tables in code blocks so they render as monospace in Slack.
+  // Runs AFTER code-block protection, so tables already inside ``` are safe.
+  // A "table" = 2+ consecutive lines starting with |
+  result = result.replace(/((?:^[ \t]*\|.*\n?){2,})/gm, (table) => {
+    return "```\n" + table.trimEnd() + "\n```";
+  });
+
   // Headers → bold (### heading, ## heading, # heading)
   // Strip inline bold/emphasis markers within headers since the whole header becomes bold
   result = result.replace(/^#{1,6}\s+(.+)$/gm, (_, content) => {


### PR DESCRIPTION
## Problem

Markdown tables (`| col | col |`) render as broken text in Slack -- mrkdwn has no table primitive. Despite prompt instructions to use `draw_table` or triple backticks, the LLM still occasionally outputs raw markdown tables.

## Fix

Add a 7-line regex in `formatForSlack()` that detects bare markdown tables (2+ consecutive lines starting with `|`) and wraps them in triple backticks. This runs after code-block protection, so tables already inside fenced blocks are not double-wrapped.

**Before:** `| Name | Age |\n| --- | --- |\n| Joan | 30 |` → broken text in Slack
**After:** same content wrapped in ```...``` → clean monospace rendering

## Why this beats prompt engineering

We've tried prompt rules multiple times. The LLM still produces raw tables ~10% of the time. A programmatic safety net catches every case.

## Scope

One file: `src/lib/format.ts` — 7 lines added.