### PR TITLE
Voice note tool

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -403,6 +403,34 @@ export async function resolveUserByName(
 }
 
 /**
+ * Resolve a channel name, user name, or Slack ID to a channel ID.
+ * Handles D-prefixed DM IDs, C/G-prefixed channel IDs, channel names,
+ * and user names (opening a DM if needed). Returns null if unresolvable.
+ */
+export async function resolveSlackDestination(
+  client: WebClient,
+  destination: string,
+): Promise<string | null> {
+  if (/^D[A-Z0-9]+$/.test(destination)) return destination;
+  if (/^[CG][A-Z0-9]+$/.test(destination)) return destination;
+
+  const resolved = await resolveChannelByName(client, destination);
+  if (resolved) return resolved.id;
+
+  try {
+    const user = await resolveUserByName(client, destination);
+    if (user?.id) {
+      const dm = await client.conversations.open({ users: user.id });
+      if (dm.channel?.id) return dm.channel.id;
+    }
+  } catch {
+    // fall through
+  }
+
+  return null;
+}
+
+/**
  * Resolve a Slack user ID to a display name.
  * Caches results for the duration of the invocation.
  */
@@ -2299,31 +2327,12 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
           let channelId: string | undefined;
           if (resolvedChannel) {
-            if (/^D[A-Z0-9]+$/.test(resolvedChannel)) {
-              channelId = resolvedChannel;
-            } else if (/^[CG][A-Z0-9]+$/.test(resolvedChannel)) {
-              channelId = resolvedChannel;
-            } else {
-              const resolved = await resolveChannelByName(client, resolvedChannel);
-              if (resolved) {
-                channelId = resolved.id;
-              } else {
-                try {
-                  const user = await resolveUserByName(client, resolvedChannel);
-                  if (user?.id) {
-                    const dm = await client.conversations.open({ users: user.id });
-                    channelId = dm.channel?.id;
-                  }
-                } catch {
-                  // fall through to error
-                }
-                if (!channelId) {
-                  return {
-                    ok: false,
-                    error: `Could not find channel or user "${resolvedChannel}". Use list_channels to see available channels.`,
-                  };
-                }
-              }
+            channelId = (await resolveSlackDestination(client, resolvedChannel)) ?? undefined;
+            if (!channelId) {
+              return {
+                ok: false,
+                error: `Could not find channel or user "${resolvedChannel}". Use list_channels to see available channels.`,
+              };
             }
           }
 

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -7,7 +7,7 @@ import type { ScheduleContext } from "../db/schema.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
 import type { WebClient } from "@slack/web-api";
-import { resolveChannelByName, resolveUserByName } from "./slack.js";
+import { resolveSlackDestination } from "./slack.js";
 
 // ── Language Config ──────────────────────────────────────────────────────────
 
@@ -702,7 +702,7 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
         }
 
         try {
-          // 1. Resolve channel (same logic as upload_file) — validate before paid API call
+          // 1. Resolve channel — validate before paid API call
           const resolvedChannel = channel ?? context?.channelId;
           const resolvedThreadTs = thread_ts ?? (channel ? undefined : context?.threadTs);
 
@@ -715,32 +715,12 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
             };
           }
 
-          let channelId: string | undefined;
-          if (/^D[A-Z0-9]+$/.test(resolvedChannel)) {
-            channelId = resolvedChannel;
-          } else if (/^[CG][A-Z0-9]+$/.test(resolvedChannel)) {
-            channelId = resolvedChannel;
-          } else {
-            const resolved = await resolveChannelByName(client, resolvedChannel);
-            if (resolved) {
-              channelId = resolved.id;
-            } else {
-              try {
-                const user = await resolveUserByName(client, resolvedChannel);
-                if (user?.id) {
-                  const dm = await client.conversations.open({ users: user.id });
-                  channelId = dm.channel?.id;
-                }
-              } catch {
-                // fall through
-              }
-              if (!channelId) {
-                return {
-                  ok: false,
-                  error: `Could not find channel or user "${resolvedChannel}". Use list_channels to see available channels.`,
-                };
-              }
-            }
+          const channelId = (await resolveSlackDestination(client, resolvedChannel)) ?? undefined;
+          if (!channelId) {
+            return {
+              ok: false,
+              error: `Could not find channel or user "${resolvedChannel}". Use list_channels to see available channels.`,
+            };
           }
 
           // 2. Generate speech via ElevenLabs TTS


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds a new `send_voice_note` tool for text-to-speech generation via ElevenLabs and Slack MP3 upload.

---
<p><a href="https://cursor.com/agents/bc-d617ccc8-af49-41fa-ac5e-b5dea93c0587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d617ccc8-af49-41fa-ac5e-b5dea93c0587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admin-only tool that calls external ElevenLabs TTS and uploads audio to Slack, plus refactors shared destination resolution; failures could impact messaging/file-upload flows and incur API usage.
> 
> **Overview**
> Adds a new admin-only `send_voice_note` tool that generates an MP3 via ElevenLabs TTS from input text and uploads/shares it to Slack (optionally into a thread), with simple rate limiting and DB tracking.
> 
> Introduces `resolveSlackDestination` to consistently resolve channel/user/ID inputs into a Slack channel ID, reusing it in `upload_file`, and updates voice tool wiring (`createVoiceTools` now takes a `WebClient`) while deferring `send_voice_note` in tool discovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55fcdc5c3fc2a2bc4be9a62423b1945461e7047b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->