### PR TITLE
Streaming markdown tables

### DIFF
--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -619,7 +619,9 @@ export async function generateResponse(
               currentStreamLength += preToolFlush.length;
               await tryStreamAppend({ markdown_text: preToolFlush });
             }
-            if (!streamingFailed) {
+            if (streamingFailed) {
+              fallbackStartIdx = streamedRawIdx;
+            } else {
               streamedRawIdx = accumulatedText.length;
             }
           }
@@ -779,6 +781,9 @@ export async function generateResponse(
     if (finalTableFlush && !streamingFailed) {
       currentStreamLength += finalTableFlush.length;
       await tryStreamAppend({ markdown_text: finalTableFlush });
+      if (streamingFailed) {
+        fallbackStartIdx = streamedRawIdx;
+      }
     }
 
     // ── Finalize ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Buffer markdown tables in the streaming path before flushing to Slack.

The streaming path in `src/pipeline/respond.ts` was sending raw markdown tables directly to Slack, causing them to render as broken `| col | col |` text. This PR introduces a line buffer to detect and wrap multi-line tables in triple backticks, ensuring correct rendering in streaming conversations.

---
<p><a href="https://cursor.com/agents/bc-6b233a97-0c7a-4f45-88f7-efc9235d6184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b233a97-0c7a-4f45-88f7-efc9235d6184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Slack streaming text path to buffer and reformat table-like output, which could affect message chunking/continuations and fallback boundaries if edge cases are missed. Impact is limited to response rendering and streaming reliability, with no auth or data-model changes.
> 
> **Overview**
> Improves Slack `chatStream` rendering by buffering streamed lines that look like markdown tables (lines starting with `|`) and emitting them only once the table is complete, wrapping multi-row tables in triple-backtick code fences.
> 
> Updates streaming bookkeeping to track the last successfully streamed raw index (`streamedRawIdx`) and uses it for `postMessage` fallback boundaries, and forces buffered table content to flush before tool cards and at end-of-stream.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ac54a77e44eb1a931188977ea8266ed25953c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->