### PR TITLE
Upload file input schema

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2311,7 +2311,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
       }),
       execute: async ({ content, file_path, filename, channel, title, thread_ts }) => {
         const resolvedChannel = channel ?? context?.channelId;
-        const resolvedThreadTs = thread_ts ?? (channel ? undefined : context?.threadTs);
+        const resolvedThreadTs = thread_ts ?? (!channel || channel === context?.channelId ? context?.threadTs : undefined);
 
         try {
           if (content === undefined && !file_path) {


### PR DESCRIPTION
Redesign `upload_file` tool input to support binary files via `file_path` from the sandbox.

The previous `content` parameter with base64 encoding for binary files was fundamentally broken for files over ~50KB due to silent truncation by LLM tool parameters, rendering it unusable for images, audio, and PDFs. This change introduces a `file_path` parameter to read binary content directly from the sandbox filesystem.

---
<p><a href="https://cursor.com/agents/bc-20d6f184-e717-42be-a77b-f6ce5e21e8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d6f184-e717-42be-a77b-f6ce5e21e8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `upload_file` tool contract and adds sandbox filesystem reads gated by admin checks, which could affect existing callers and introduces a new access path to local files.
> 
> **Overview**
> Updates the Slack `upload_file` tool to support binary uploads by reading from the sandbox filesystem via a new `file_path` parameter, instead of base64-encoding binary data in `content`.
> 
> The tool schema now enforces **exactly one of** `content` (text) or `file_path` (binary), removes the `is_binary` flag, and adds validation plus an admin-only authorization check before reading sandbox files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72abe5a426ca679b68efcb05290a357268f1c3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->