### PR TITLE
Markdown table prettification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "e2b": "^2.12.1",
         "google-auth-library": "^10.5.0",
         "hono": "^4.11.9",
+        "markdown-table-prettify": "^3.7.0",
         "playwright-core": "^1.58.2",
         "turndown": "^7.2.2",
         "zod": "^3.24.4"
@@ -2638,6 +2639,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/markdown-table-prettify": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/markdown-table-prettify/-/markdown-table-prettify-3.7.0.tgz",
+      "integrity": "sha512-woZ1X+u0HsTygXL5kcptMSDwnjU//3UKTOH6fGdaABSSLOxTdWjr2P6i7dVrru5t/pxyEOT48/skv/8m8/VqdA==",
+      "license": "MIT",
+      "bin": {
+        "markdown-table-prettify": "cli/index.js"
+      },
+      "engines": {
+        "vscode": "^1.103.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "e2b": "^2.12.1",
     "google-auth-library": "^10.5.0",
     "hono": "^4.11.9",
+    "markdown-table-prettify": "^3.7.0",
     "playwright-core": "^1.58.2",
     "turndown": "^7.2.2",
     "zod": "^3.24.4"

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,12 @@
+import { CliPrettify } from "markdown-table-prettify";
+
+/** Prettify a markdown table (align columns) and wrap in triple-backtick fences. */
+export function prettifyAndWrapTable(tableLines: string[]): string {
+  const raw = tableLines.join("").trimEnd();
+  const prettified = CliPrettify.prettify(raw);
+  return "```\n" + prettified + "\n```\n";
+}
+
 /**
  * Convert LLM markdown to Slack mrkdwn.
  * Handles bold, italic, and heading syntax differences while preserving
@@ -22,7 +31,8 @@ export function formatForSlack(text: string): string {
   // Runs AFTER code-block protection, so tables already inside ``` are safe.
   // A "table" = 2+ consecutive lines starting with |
   result = result.replace(/((?:^[ \t]*\|.*\n?){2,})/gm, (table) => {
-    return "```\n" + table.trimEnd() + "\n```";
+    const prettified = CliPrettify.prettify(table.trimEnd());
+    return "```\n" + prettified + "\n```";
   });
 
   // Headers → bold (### heading, ## heading, # heading)

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -5,7 +5,7 @@ import { createSlackTools } from "../tools/slack.js";
 import type { FileContentPart } from "../lib/files.js";
 import { logger } from "../lib/logger.js";
 import { logError } from "../lib/error-logger.js";
-import { formatForSlack } from "../lib/format.js";
+import { formatForSlack, prettifyAndWrapTable } from "../lib/format.js";
 import { TABLE_BLOCK_KEY } from "../tools/table.js";
 import { safePostMessage, isChannelTypeNotSupported, isInvalidBlocks, isMsgTooLong } from "../lib/slack-messaging.js";
 import { createInteractivePrepareStep, STEP_LIMIT } from "./prepare-step.js";
@@ -451,7 +451,7 @@ export async function generateResponse(
       } else {
         if (tableBuffer.length > 0) {
           output += tableBuffer.length >= 2
-            ? "```\n" + tableBuffer.join("").trimEnd() + "\n```\n"
+            ? prettifyAndWrapTable(tableBuffer)
             : tableBuffer.join("");
           tableBuffer = [];
         }
@@ -465,7 +465,7 @@ export async function generateResponse(
         lineCarry = "";
       } else if (tableBuffer.length > 0 && !lineCarry.trimStart().startsWith("|")) {
         output += tableBuffer.length >= 2
-          ? "```\n" + tableBuffer.join("").trimEnd() + "\n```\n"
+          ? prettifyAndWrapTable(tableBuffer)
           : tableBuffer.join("");
         tableBuffer = [];
         output += lineCarry;
@@ -485,7 +485,7 @@ export async function generateResponse(
       } else {
         if (tableBuffer.length > 0) {
           output += tableBuffer.length >= 2
-            ? "```\n" + tableBuffer.join("").trimEnd() + "\n```\n"
+            ? prettifyAndWrapTable(tableBuffer)
             : tableBuffer.join("");
           tableBuffer = [];
         }
@@ -495,7 +495,7 @@ export async function generateResponse(
     }
     if (tableBuffer.length > 0) {
       output += tableBuffer.length >= 2
-        ? "```\n" + tableBuffer.join("").trimEnd() + "\n```\n"
+        ? prettifyAndWrapTable(tableBuffer)
         : tableBuffer.join("");
       tableBuffer = [];
     }

--- a/src/types/markdown-table-prettify.d.ts
+++ b/src/types/markdown-table-prettify.d.ts
@@ -1,0 +1,5 @@
+declare module "markdown-table-prettify" {
+  export class CliPrettify {
+    static prettify(markdown: string): string;
+  }
+}


### PR DESCRIPTION
Prettify markdown tables in Slack messages by aligning columns to improve readability, fixing #511.

---
<p><a href="https://cursor.com/agents/bc-894547b0-5e80-4e99-a961-2d61ef4b0268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-894547b0-5e80-4e99-a961-2d61ef4b0268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: output-only formatting change for Slack messages plus a new dependency; main potential issues are unexpected table formatting or performance on very large tables.
> 
> **Overview**
> Slack message rendering now **prettifies Markdown tables** by aligning columns before wrapping them in triple-backtick code fences.
> 
> This introduces `markdown-table-prettify`, adds a small helper (`prettifyAndWrapTable`) used both in `formatForSlack` and the streaming table-buffer path in `respond.ts`, and includes a local `.d.ts` shim for the new module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d37a363a977e73be74af6201740543793cae7da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->