### PR TITLE
Binary model output helper

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -71,3 +71,54 @@ export function defineTool<TInput, TOutput>(config: {
     slack?: SlackToolMetadata<TInput, TOutput>;
   };
 }
+
+/**
+ * Build a toModelOutput result for tools that return binary content (images, PDFs, etc).
+ * Converts base64 strings into native AI SDK content parts so the LLM can see the file.
+ */
+export function binaryToModelOutput(opts: {
+  base64: string;
+  mimeType: string;
+  filename?: string;
+  meta?: Record<string, unknown>;
+}): {
+  type: "content";
+  value: Array<
+    | { type: "text"; text: string }
+    | { type: "image-data"; data: string; mediaType: string }
+    | { type: "file-data"; data: string; mediaType: string; filename?: string }
+  >;
+} {
+  const parts: Array<
+    | { type: "text"; text: string }
+    | { type: "image-data"; data: string; mediaType: string }
+    | { type: "file-data"; data: string; mediaType: string; filename?: string }
+  > = [];
+
+  if (opts.meta && Object.keys(opts.meta).length > 0) {
+    parts.push({
+      type: "text",
+      text: JSON.stringify({
+        ...opts.meta,
+        note: "Binary content attached as native file below",
+      }),
+    });
+  }
+
+  if (opts.mimeType?.startsWith("image/")) {
+    parts.push({
+      type: "image-data",
+      data: opts.base64,
+      mediaType: opts.mimeType,
+    });
+  } else {
+    parts.push({
+      type: "file-data",
+      data: opts.base64,
+      mediaType: opts.mimeType || "application/octet-stream",
+      filename: opts.filename,
+    });
+  }
+
+  return { type: "content", value: parts };
+}

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -1,4 +1,4 @@
-import { defineTool } from "../lib/tool.js";
+import { defineTool, binaryToModelOutput } from "../lib/tool.js";
 import { z } from "zod";
 import {
   createSession,
@@ -329,28 +329,15 @@ export function createBrowserTools(context?: ScheduleContext): Record<string, an
           }
         }
       },
-      toModelOutput({ output }: { output: unknown }) {
+      toModelOutput({ output }: { output: any }) {
         if (!output || typeof output !== "object") {
-          return { type: "text", value: JSON.stringify(output) };
+          return { type: "text" as const, value: JSON.stringify(output) };
         }
-
         const { screenshot_base64, ...rest } = output as Record<string, unknown>;
-        const parts: Array<
-          | { type: "text"; text: string }
-          | { type: "image-data"; data: string; mediaType: string }
-        > = [];
-
-        parts.push({ type: "text", text: JSON.stringify(rest) });
-
         if (screenshot_base64 && typeof screenshot_base64 === "string") {
-          parts.push({
-            type: "image-data",
-            data: screenshot_base64,
-            mediaType: "image/png",
-          });
+          return binaryToModelOutput({ base64: screenshot_base64, mimeType: "image/png", meta: rest });
         }
-
-        return { type: "content", value: parts };
+        return { type: "json" as const, value: output };
       },
       slack: { status: "Browsing...", detail: (i) => i.url ?? "running code" },
     }),

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineTool } from "../lib/tool.js";
+import { defineTool, binaryToModelOutput } from "../lib/tool.js";
 import { logger } from "../lib/logger.js";
 import { isTextMimeType } from "../lib/files.js";
 
@@ -246,51 +246,11 @@ export function createDriveTools() {
         }
       },
       toModelOutput({ output }: { output: any }) {
-        if (!output || typeof output !== "object" || !output.ok) {
+        if (!output?.ok || output.encoding !== "base64" || !output.content) {
           return { type: "json" as const, value: output };
         }
-
-        if (output.encoding === "base64" && output.content) {
-          const { content, ...meta } = output;
-          const parts: Array<
-            | { type: "text"; text: string }
-            | { type: "image-data"; data: string; mediaType: string }
-            | {
-                type: "file-data";
-                data: string;
-                mediaType: string;
-                filename?: string;
-              }
-          > = [];
-
-          parts.push({
-            type: "text",
-            text: JSON.stringify({
-              ...meta,
-              encoding: "base64",
-              note: "Binary content attached as native file below",
-            }),
-          });
-
-          if (output.mimeType?.startsWith("image/")) {
-            parts.push({
-              type: "image-data",
-              data: content,
-              mediaType: output.mimeType,
-            });
-          } else {
-            parts.push({
-              type: "file-data",
-              data: content,
-              mediaType: output.mimeType || "application/octet-stream",
-              filename: output.name,
-            });
-          }
-
-          return { type: "content" as const, value: parts };
-        }
-
-        return { type: "json" as const, value: output };
+        const { content, ...meta } = output;
+        return binaryToModelOutput({ base64: content, mimeType: output.mimeType, filename: output.name, meta });
       },
       slack: {
         status: "Reading file from Drive...",

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { WebClient } from "@slack/web-api";
 import { logger } from "../lib/logger.js";
-import { defineTool } from "../lib/tool.js";
+import { defineTool, binaryToModelOutput } from "../lib/tool.js";
 import { isAdmin } from "../lib/permissions.js";
 import { createNoteTools } from "./notes.js";
 import { createJobTools } from "./jobs.js";
@@ -2495,51 +2495,11 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
         }
       },
       toModelOutput({ output }: { output: any }) {
-        if (
-          !output ||
-          typeof output !== "object" ||
-          !output.ok ||
-          !output.content_base64
-        ) {
+        if (!output?.ok || !output.content_base64) {
           return { type: "json" as const, value: output };
         }
-
         const { content_base64, ...meta } = output;
-        const parts: Array<
-          | { type: "text"; text: string }
-          | { type: "image-data"; data: string; mediaType: string }
-          | {
-              type: "file-data";
-              data: string;
-              mediaType: string;
-              filename?: string;
-            }
-        > = [];
-
-        parts.push({
-          type: "text",
-          text: JSON.stringify({
-            ...meta,
-            note: "Binary content attached as native file below",
-          }),
-        });
-
-        if (output.mimetype?.startsWith("image/")) {
-          parts.push({
-            type: "image-data",
-            data: content_base64,
-            mediaType: output.mimetype,
-          });
-        } else {
-          parts.push({
-            type: "file-data",
-            data: content_base64,
-            mediaType: output.mimetype || "application/octet-stream",
-            filename: output.filename,
-          });
-        }
-
-        return { type: "content" as const, value: parts };
+        return binaryToModelOutput({ base64: content_base64, mimeType: output.mimetype, filename: output.filename, meta });
       },
       slack: { status: "Downloading file...", detail: (i) => i.file_id },
     }),


### PR DESCRIPTION
Deduplicate `toModelOutput` implementations across three tools by extracting a shared `binaryToModelOutput` helper.

---
<p><a href="https://cursor.com/agents/bc-839cdff0-94f3-4f78-9da1-65d110bf275a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-839cdff0-94f3-4f78-9da1-65d110bf275a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly deduplicates tool output formatting; minor behavior changes in `browse` output types could affect consumers expecting the prior `content` shape when no screenshot is present.
> 
> **Overview**
> Adds a shared `binaryToModelOutput` helper in `src/lib/tool.ts` to convert base64 binary results into native AI SDK `content` parts (image/file + optional metadata text).
> 
> Refactors `browse`, `read_drive_file`, and `download_slack_file` `toModelOutput` implementations to use this helper, standardizing how binary outputs are attached and simplifying the conditional logic; `browse` now returns `json` when no screenshot is present instead of always returning a `content` array.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60bb1c36a0d327231020c46615e0945c81375733. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->