### PR TITLE
System prompt caching layers

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -165,7 +165,7 @@ export async function executeJob(
       tools: slackTools,
       stopWhen: stepCountIs(HEADLESS_STEP_LIMIT),
       prepareStep: createHeadlessPrepareStep({
-        systemPrompt,
+        stablePrefix: systemPrompt,
         modelId,
         defaultEffort: "medium",
         getEscalationModel,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -219,3 +219,38 @@ export function withCacheControl(systemPrompt: string) {
     providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
   };
 }
+
+/**
+ * Build a multi-breakpoint cached system message array for Anthropic prompt caching.
+ *
+ * Returns 2–3 system messages with cache control on the stable layers:
+ *   1. stablePrefix (cached globally): personality + self-directive + notes-index + skill-index
+ *   2. conversationContext (cached per-thread): channel + user + memories + conversations + thread
+ *   3. dynamicContext (uncached, optional): time, model, channelId, threadTs
+ *
+ * Safe for non-Anthropic models — they ignore providerOptions.anthropic.
+ */
+export function buildCachedSystemMessages(
+  stablePrefix: string,
+  conversationContext: string,
+  dynamicContext?: string,
+) {
+  const messages: Array<{ role: 'system'; content: string; providerOptions?: Record<string, any> }> = [
+    {
+      role: 'system',
+      content: stablePrefix,
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+    },
+  ];
+  if (conversationContext) {
+    messages.push({
+      role: 'system',
+      content: conversationContext,
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+    });
+  }
+  if (dynamicContext) {
+    messages.push({ role: 'system', content: dynamicContext });
+  }
+  return messages;
+}

--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -329,17 +329,35 @@ function formatConversations(conversations: ConversationThread[]): string {
   return `\n## Relevant past conversations\n\nThese are past conversation threads retrieved from your message history. Use them for context if relevant — reference specific things people said.\n\n${formatted}`;
 }
 
+export interface SystemPromptLayers {
+  /** Stable across ALL requests: personality + self-directive + notes-index + skill-index */
+  stablePrefix: string;
+  /** Stable within a conversation thread: channel context + user profile + memories + conversations + thread context */
+  conversationContext: string;
+}
+
 /**
- * Build the full system prompt for an LLM call.
- * Async because it queries the skill index from the database.
+ * Build the system prompt split into two cached layers.
+ *
+ * Layer 1 (stablePrefix): content that is identical across all requests —
+ * personality, self-directive, notes-index, and skill index. Cached globally.
+ *
+ * Layer 2 (conversationContext): content that varies per conversation thread —
+ * channel context, user profile, memories, past conversations, thread context.
+ * Cached per-thread.
+ *
+ * Async because it queries the skill index and notes from the database.
  */
 export async function buildSystemPrompt(
   context: SystemPromptContext,
-): Promise<string> {
-  const parts: string[] = [];
+): Promise<SystemPromptLayers> {
+  const stableParts: string[] = [];
+  const conversationParts: string[] = [];
+
+  // ── Layer 1: Stable prefix ──────────────────────────────────────────
 
   // Core personality (always present)
-  parts.push(PERSONALITY);
+  stableParts.push(PERSONALITY);
 
   // Self-directive: agent's own persistent context, loaded every invocation
   // Hard cap at ~2000 tokens (~8000 chars) to prevent context-window overflow
@@ -361,7 +379,7 @@ export async function buildSystemPrompt(
           limit: SELF_DIRECTIVE_MAX_CHARS,
         });
       }
-      parts.push(
+      stableParts.push(
         `\n## Self-directive\n\nYou wrote and maintain this yourself. It persists across all invocations.\n\n${content}`,
       );
     }
@@ -388,7 +406,7 @@ export async function buildSystemPrompt(
           limit: NOTES_INDEX_MAX_CHARS,
         });
       }
-      parts.push(
+      stableParts.push(
         `\n## Notes index\n\nMaster index of all your notes. Use read_note() to load full content, search_notes() to grep across all notes.\n\n${indexContent}`,
       );
     }
@@ -396,34 +414,36 @@ export async function buildSystemPrompt(
     logger.warn("Failed to load notes-index note", { error });
   }
 
+  // Skill index (progressive disclosure -- lightweight topic + first line)
+  const skillIndex = await buildSkillIndex();
+  if (skillIndex) {
+    stableParts.push(skillIndex);
+  }
+
+  // ── Layer 2: Conversation context ───────────────────────────────────
+
   // Channel context
   if (context.channelType === "dm") {
-    parts.push(`You're in a private DM. Be conversational and personal.`);
+    conversationParts.push(`You're in a private DM. Be conversational and personal.`);
   } else {
-    parts.push(
+    conversationParts.push(
       `You're in the ${context.channelContext} channel. Respond in-thread. Adapt your tone to the channel.`,
     );
   }
 
   // User profile (if available)
   if (context.userProfile) {
-    parts.push(formatUserProfile(context.userProfile));
+    conversationParts.push(formatUserProfile(context.userProfile));
   }
 
   // Retrieved memories
   if (context.memories.length > 0) {
-    parts.push(formatMemories(context.memories));
+    conversationParts.push(formatMemories(context.memories));
   }
 
   // Retrieved conversation threads
   if (context.conversations && context.conversations.length > 0) {
-    parts.push(formatConversations(context.conversations));
-  }
-
-  // Skill index (progressive disclosure -- lightweight topic + first line)
-  const skillIndex = await buildSkillIndex();
-  if (skillIndex) {
-    parts.push(skillIndex);
+    conversationParts.push(formatConversations(context.conversations));
   }
 
   // Conversation context (thread or recent channel messages)
@@ -431,10 +451,13 @@ export async function buildSystemPrompt(
     const heading = context.isChannelHistory
       ? `\n## Recent channel context\n\nHere are the recent messages in this channel for context:\n\n${context.threadContext}`
       : `\n## Recent thread context\n\nHere are the recent messages in this thread for context:\n\n${context.threadContext}`;
-    parts.push(heading);
+    conversationParts.push(heading);
   }
 
-  return parts.join("\n\n");
+  return {
+    stablePrefix: stableParts.join("\n\n"),
+    conversationContext: conversationParts.join("\n\n"),
+  };
 }
 
 /**

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -304,7 +304,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       );
     }
     const retrievalStart = Date.now();
-    const { systemPrompt, dynamicContext, memories, conversations } = await assemblePrompt(
+    const { stablePrefix, conversationContext, dynamicContext, memories, conversations } = await assemblePrompt(
       { ...context, text: messageText },
       conversation,
       client,
@@ -324,7 +324,8 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     // 5. Call LLM (streams response directly to Slack via chat.update)
     const llmStart = Date.now();
     const response = await generateResponse({
-      systemPrompt,
+      stablePrefix,
+      conversationContext,
       dynamicContext,
       userMessage: messageText,
       slackClient: client,

--- a/src/pipeline/prepare-step.ts
+++ b/src/pipeline/prepare-step.ts
@@ -42,7 +42,8 @@ type PrepareStepFn = (options: {
 export function createPrepareStep(opts: {
   stepLimit?: number;
   warningThreshold?: number;
-  systemPrompt: string;
+  stablePrefix: string;
+  conversationContext?: string;
   dynamicContext?: string;
   defaultEffort?: EffortLevel;
   modelId?: string;
@@ -123,14 +124,17 @@ export function createPrepareStep(opts: {
     }
 
     // --- Step limit warning ---
+    // Concatenates all layers into a single string override. This breaks
+    // cache for the wrap-up step only — acceptable tradeoff since it fires
+    // near the step limit (≥200) and only once per conversation.
     if (stepNumber >= threshold) {
       const wrapUp = WRAP_UP_MESSAGE
         .replace("{stepCount}", String(stepNumber))
         .replace("{limit}", String(limit));
-      systemOverride = opts.systemPrompt
-        + "\n\n"
-        + (opts.dynamicContext ? opts.dynamicContext + "\n\n" : "")
-        + wrapUp;
+      systemOverride = opts.stablePrefix
+        + (opts.conversationContext ? "\n\n" + opts.conversationContext : "")
+        + (opts.dynamicContext ? "\n\n" + opts.dynamicContext : "")
+        + "\n\n" + wrapUp;
       logger.info("prepareStep: injecting wrap-up nudge", {
         stepNumber,
         limit,
@@ -153,7 +157,8 @@ export function createPrepareStep(opts: {
 
 /** Factory for interactive Slack agent prepareStep (250-step limit). */
 export function createInteractivePrepareStep(opts: {
-  systemPrompt: string;
+  stablePrefix: string;
+  conversationContext?: string;
   dynamicContext?: string;
   modelId?: string;
   defaultEffort?: EffortLevel;
@@ -162,7 +167,8 @@ export function createInteractivePrepareStep(opts: {
   return createPrepareStep({
     stepLimit: STEP_LIMIT,
     warningThreshold: WARNING_THRESHOLD,
-    systemPrompt: opts.systemPrompt,
+    stablePrefix: opts.stablePrefix,
+    conversationContext: opts.conversationContext,
     dynamicContext: opts.dynamicContext,
     modelId: opts.modelId,
     defaultEffort: opts.defaultEffort,
@@ -172,7 +178,8 @@ export function createInteractivePrepareStep(opts: {
 
 /** Factory for headless job execution prepareStep (350-step limit). */
 export function createHeadlessPrepareStep(opts: {
-  systemPrompt: string;
+  stablePrefix: string;
+  conversationContext?: string;
   dynamicContext?: string;
   modelId?: string;
   defaultEffort?: EffortLevel;
@@ -181,7 +188,8 @@ export function createHeadlessPrepareStep(opts: {
   return createPrepareStep({
     stepLimit: HEADLESS_STEP_LIMIT,
     warningThreshold: HEADLESS_WARNING_THRESHOLD,
-    systemPrompt: opts.systemPrompt,
+    stablePrefix: opts.stablePrefix,
+    conversationContext: opts.conversationContext,
     dynamicContext: opts.dynamicContext,
     modelId: opts.modelId,
     defaultEffort: opts.defaultEffort,

--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -12,7 +12,10 @@ import { logger } from "../lib/logger.js";
 import { getMainModelId } from "../lib/ai.js";
 
 export interface AssembledPrompt {
-  systemPrompt: string;
+  /** Stable across all requests: personality + self-directive + notes-index + skill-index (cached globally) */
+  stablePrefix: string;
+  /** Stable within a conversation thread: channel + user + memories + conversations + thread (cached per-thread) */
+  conversationContext: string;
   /** Dynamic per-call context (time, model, channel, thread) — passed as a separate uncached system message */
   dynamicContext: string;
   memories: Memory[];
@@ -109,8 +112,8 @@ export async function assemblePrompt(
   // Resolve active model ID for self-awareness in system prompt
   const modelId = await getMainModelId();
 
-  // Build the stable system prompt (async: queries skill index from DB)
-  let systemPrompt = await buildSystemPrompt({
+  // Build the system prompt layers (async: queries skill index from DB)
+  const { stablePrefix, conversationContext } = await buildSystemPrompt({
     memories,
     conversations,
     userProfile,
@@ -151,5 +154,5 @@ If the thread content is sparse, try list_slack_list_items to find the item by m
     hasSlackListItemContext: !!context.slackListItemContext,
   });
 
-  return { systemPrompt, dynamicContext, memories, conversations, userProfile };
+  return { stablePrefix, conversationContext, dynamicContext, memories, conversations, userProfile };
 }

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -1,6 +1,6 @@
 import { streamText, stepCountIs } from "ai";
 import type { WebClient } from "@slack/web-api";
-import { getMainModel, getEscalationModel, withCacheControl } from "../lib/ai.js";
+import { getMainModel, getEscalationModel, buildCachedSystemMessages } from "../lib/ai.js";
 import { createSlackTools } from "../tools/slack.js";
 import type { FileContentPart } from "../lib/files.js";
 import { logger } from "../lib/logger.js";
@@ -122,8 +122,11 @@ function truncate(s: string | undefined, max: number): string | undefined {
 // ── Types ────────────────────────────────────────────────────────────────────
 
 interface RespondOptions {
-  systemPrompt: string;
-  /** Dynamic per-call context (time, model, channel) — passed as uncached second system message */
+  /** Stable across all requests (cached globally) */
+  stablePrefix: string;
+  /** Stable within a conversation thread (cached per-thread) */
+  conversationContext: string;
+  /** Dynamic per-call context (time, model, channel) — passed as uncached system message */
   dynamicContext?: string;
   userMessage: string;
   slackClient: WebClient;
@@ -383,9 +386,11 @@ export async function generateResponse(
   let streamKeepAlive: ReturnType<typeof setInterval> | null = null;
 
   // ── Build stream options ─────────────────────────────────────────────
-  const systemMessages = options.dynamicContext
-    ? [withCacheControl(options.systemPrompt), { role: 'system' as const, content: options.dynamicContext }]
-    : withCacheControl(options.systemPrompt);
+  const systemMessages = buildCachedSystemMessages(
+    options.stablePrefix,
+    options.conversationContext,
+    options.dynamicContext,
+  );
 
   const streamOptions: any = {
     model,
@@ -393,7 +398,8 @@ export async function generateResponse(
     tools: createSlackTools(options.slackClient, options.context),
     stopWhen: stepCountIs(STEP_LIMIT),
     prepareStep: createInteractivePrepareStep({
-      systemPrompt: options.systemPrompt,
+      stablePrefix: options.stablePrefix,
+      conversationContext: options.conversationContext,
       dynamicContext: options.dynamicContext,
       modelId,
       defaultEffort: "medium",
@@ -416,7 +422,7 @@ export async function generateResponse(
     model: model.modelId || "unknown",
     hasFiles,
     toolCount: Object.keys(streamOptions.tools || {}).length,
-    promptLength: options.systemPrompt.length,
+    promptLength: options.stablePrefix.length + options.conversationContext.length,
   });
 
   // ── Stream and send to Slack ────────────────────────────────────────


### PR DESCRIPTION
Implement multi-breakpoint prompt caching to significantly improve Anthropic cache hit rates by splitting the system prompt into three distinct layers.

The previous single-string system prompt with `cacheControl: ephemeral` resulted in ~50% cache misses due to variable content breaking prefix matching. This PR introduces a `stablePrefix` (globally cached), `conversationContext` (per-thread cached), and `dynamicContext` (uncached) to leverage Anthropic's prefix-matched caching more effectively.

---
<p><a href="https://cursor.com/agents/bc-ca731616-0d5b-4024-a1c1-dd0fd312349e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca731616-0d5b-4024-a1c1-dd0fd312349e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core prompt-construction and LLM invocation path (interactive pipeline and headless jobs), so any layering/ordering mistake could change model behavior or degrade context quality. Functional impact is mostly performance/caching, but it affects every request to Anthropic models.
> 
> **Overview**
> Implements multi-layer Anthropic prompt caching by splitting the system prompt into **globally stable** `stablePrefix`, **thread-stable** `conversationContext`, and **per-call** `dynamicContext`, and sending them as multiple `system` messages (via new `buildCachedSystemMessages`).
> 
> Updates prompt assembly and response generation to pass these layers end-to-end (`buildSystemPrompt` now returns layered output; `assemblePrompt`/`runPipeline`/`generateResponse` updated accordingly), and adjusts `prepareStep` factories to accept the layers while only concatenating them for the near-limit wrap-up warning (sacrificing cache only for that step).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a30e1b6a464ca4e8c327bfca3ad8d42c565b4e1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->