### PR TITLE
Email embeddings tool removal

### DIFF
--- a/src/tools/email-sync.ts
+++ b/src/tools/email-sync.ts
@@ -722,59 +722,5 @@ export function createEmailSyncTools(
       },
       slack: { status: "Searching emails...", detail: (i) => i.query },
     }),
-
-    backfill_email_embeddings: defineTool({
-      description:
-        "Backfill vector embeddings for all email threads that don't have one yet. This enables semantic search on historical emails. May take a while for large mailboxes. Admin-only.",
-      inputSchema: z.object({
-        user_name: z
-          .string()
-          .describe(
-            "Display name, username, or user ID of the Gmail account owner",
-          ),
-      }),
-      execute: async ({ user_name }) => {
-        if (!isAdmin(context?.userId)) {
-          return {
-            ok: false as const,
-            error: "This tool is restricted to admin users only.",
-          };
-        }
-
-        try {
-          const user = await resolveUserByName(client, user_name);
-          if (!user) {
-            return {
-              ok: false as const,
-              error: `Could not resolve user '${user_name}'.`,
-            };
-          }
-
-          const { backfillEmailEmbeddings } = await import(
-            "../lib/email-sync.js"
-          );
-          const result = await backfillEmailEmbeddings(user.id);
-
-          return {
-            ok: true as const,
-            ...result,
-            message: `Backfilled ${result.embedded} thread embeddings (${result.errors} errors)`,
-          };
-        } catch (error: any) {
-          logger.error("backfill_email_embeddings tool failed", {
-            userName: user_name,
-            error: error.message,
-          });
-          return {
-            ok: false as const,
-            error: `Backfill failed: ${error.message}`,
-          };
-        }
-      },
-      slack: {
-        status: "Backfilling email embeddings...",
-        detail: (i) => i.user_name,
-      },
-    }),
   };
 }


### PR DESCRIPTION
Remove the `backfill_email_embeddings` tool to prevent system prompt pollution and improve reliability.

---
<p><a href="https://cursor.com/agents/bc-53c55263-1269-45c2-af96-776a8a8be71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53c55263-1269-45c2-af96-776a8a8be71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that only removes an admin-only tool entry point; primary impact is operational (you can no longer trigger embedding backfills via tools), not core email sync behavior.
> 
> **Overview**
> Removes the admin-only `backfill_email_embeddings` tool from `src/tools/email-sync.ts`, eliminating the tool-accessible entry point for batch backfilling missing email thread embeddings.
> 
> This leaves embedding/backfill implementation untouched but prevents invoking it through the tools interface (reducing tool surface area and potential prompt/tool noise).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7af680c2167a21af8b833d23c17d2a43b4ecddc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->