### PR TITLE
Message stats detail

### DIFF
--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, sql, count } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { defineTool } from "../lib/tool.js";
 import { logger } from "../lib/logger.js";
 import { db } from "../db/client.js";
@@ -57,11 +57,10 @@ interface PersonResult {
   manager_name: string | null;
   addresses: { id: string; channel: string; value: string; is_primary: boolean }[];
   stats: {
-    message_count: number;
     workspace_messages: number;
-    dm_messages: number;
-    last_interaction: string | null;
-    last_dm_interaction: string | null;
+    aura_dm_messages: number;
+    last_activity: string | null;
+    last_aura_dm: string | null;
     profile_created: string | null;
   };
 }
@@ -87,11 +86,10 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
     managerName = mgr?.displayName ?? null;
   }
 
-  let messageCount = 0;
   let workspaceMessages = 0;
-  let dmMessages = 0;
-  let lastInteraction: string | null = null;
-  let lastDmInteraction: string | null = null;
+  let auraDmMessages = 0;
+  let lastActivity: string | null = null;
+  let lastAuraDm: string | null = null;
   let profileCreated: string | null = null;
 
   if (person.slackUserId) {
@@ -109,20 +107,18 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
 
       const [msgStats] = await db
         .select({
-          count: count(),
           lastTs: sql<string>`max(${messages.createdAt})`,
           workspaceMessages: sql<number>`count(*) filter (where ${messages.channelType} != 'dm')`,
-          dmMessages: sql<number>`count(*) filter (where ${messages.channelType} = 'dm')`,
-          lastDmInteraction: sql<string>`max(${messages.createdAt}) filter (where ${messages.channelType} = 'dm')`,
+          auraDmMessages: sql<number>`count(*) filter (where ${messages.channelType} = 'dm')`,
+          lastAuraDm: sql<string>`max(${messages.createdAt}) filter (where ${messages.channelType} = 'dm')`,
         })
         .from(messages)
         .where(eq(messages.userId, profile.slackUserId));
 
-      messageCount = msgStats?.count ?? 0;
       workspaceMessages = Number(msgStats?.workspaceMessages ?? 0);
-      dmMessages = Number(msgStats?.dmMessages ?? 0);
-      lastInteraction = msgStats?.lastTs ?? null;
-      lastDmInteraction = msgStats?.lastDmInteraction ?? null;
+      auraDmMessages = Number(msgStats?.auraDmMessages ?? 0);
+      lastActivity = msgStats?.lastTs ?? null;
+      lastAuraDm = msgStats?.lastAuraDm ?? null;
     }
   }
 
@@ -143,11 +139,10 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
       is_primary: a.isPrimary,
     })),
     stats: {
-      message_count: messageCount,
       workspace_messages: workspaceMessages,
-      dm_messages: dmMessages,
-      last_interaction: lastInteraction,
-      last_dm_interaction: lastDmInteraction,
+      aura_dm_messages: auraDmMessages,
+      last_activity: lastActivity,
+      last_aura_dm: lastAuraDm,
       profile_created: profileCreated,
     },
   };
@@ -192,7 +187,7 @@ export function createPeopleTools(context?: ScheduleContext) {
       description:
         "Look up a person in the people database by name, Slack user ID (e.g. 'U0678NQJ2'), or email address. " +
         "Returns structured profile data including job title, gender, preferred language, birthdate, manager, " +
-        "all known addresses (email, phone, slack), and Slack activity stats (message count, last interaction). " +
+        "all known addresses (email, phone, slack), and Slack activity stats (workspace_messages, aura_dm_messages, last_activity, last_aura_dm). " +
         "Use this before update_person to confirm identity. For ambiguous name searches, returns up to 3 fuzzy matches.",
       inputSchema: z.object({
         query: z


### PR DESCRIPTION
Splits the `message_count` stat into `workspace_messages`, `dm_messages`, and `last_dm_interaction` to provide more granular user activity insights, fixing #550.

---
<p><a href="https://cursor.com/agents/bc-e35b808a-359f-4433-9c5b-448c43d086f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e35b808a-359f-4433-9c5b-448c43d086f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of `get_person`/`update_person` returned `stats` (renaming/removing fields), which may break any downstream consumers expecting the old `message_count`/`last_interaction` keys.
> 
> **Overview**
> **Adds more granular Slack activity stats to `get_person` results.** The previous `stats.message_count` and `stats.last_interaction` fields are replaced with `workspace_messages`, `aura_dm_messages`, `last_activity`, and `last_aura_dm`.
> 
> Message stats computation in `enrichPerson` is updated to use SQL `FILTER` aggregates to separately count DM vs non-DM messages and track the latest overall activity timestamp and latest DM timestamp, and the tool description text is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f86b9eadb4541cd300e014b99b42b606d2ee104b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->