### PR TITLE
People notes field

### DIFF
--- a/drizzle/0024_add_people_notes.sql
+++ b/drizzle/0024_add_people_notes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE people ADD COLUMN notes TEXT;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1772707200000,
       "tag": "0023_add_pg_trgm_extension",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1772793600000,
+      "tag": "0024_add_people_notes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -168,6 +168,7 @@ export const people = pgTable(
     preferredLanguage: text("preferred_language"),
     birthdate: date("birthdate", { mode: "date" }),
     managerId: uuid("manager_id").references((): any => people.id),
+    notes: text("notes"),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },

--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -26,6 +26,7 @@ interface RawPersonRow {
   preferred_language: string | null;
   birthdate: string | null;
   manager_id: string | null;
+  notes: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -40,6 +41,7 @@ function mapRawPerson(row: RawPersonRow): typeof people.$inferSelect {
     preferredLanguage: row.preferred_language,
     birthdate: row.birthdate ? new Date(row.birthdate) : null,
     managerId: row.manager_id,
+    notes: row.notes,
     createdAt: new Date(row.created_at),
     updatedAt: new Date(row.updated_at),
   };
@@ -55,6 +57,7 @@ interface PersonResult {
   birthdate: string | null;
   manager_id: string | null;
   manager_name: string | null;
+  notes: string | null;
   addresses: { id: string; channel: string; value: string; is_primary: boolean }[];
   stats: {
     workspace_messages: number;
@@ -132,6 +135,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
     birthdate: person.birthdate ? person.birthdate.toISOString().split("T")[0] : null,
     manager_id: person.managerId,
     manager_name: managerName,
+    notes: person.notes,
     addresses: addrs.map((a) => ({
       id: a.id,
       channel: a.channel,
@@ -186,7 +190,7 @@ export function createPeopleTools(context?: ScheduleContext) {
     get_person: defineTool({
       description:
         "Look up a person in the people database by name, Slack user ID (e.g. 'U0678NQJ2'), or email address. " +
-        "Returns structured profile data including job title, gender, preferred language, birthdate, manager, " +
+        "Returns structured profile data including job title, gender, preferred language, birthdate, manager, notes/context, " +
         "all known addresses (email, phone, slack), and Slack activity stats (workspace_messages, aura_dm_messages, last_activity, last_aura_dm). " +
         "Use this before update_person to confirm identity. For ambiguous name searches, returns up to 3 fuzzy matches.",
       inputSchema: z.object({
@@ -230,7 +234,7 @@ export function createPeopleTools(context?: ScheduleContext) {
     update_person: defineTool({
       description:
         "Update a person's profile in the people database. Identify the person by person_id (UUID) or query (fuzzy name/Slack ID/email lookup — must resolve to exactly 1 person). " +
-        "Can update fields (display_name, job_title, gender, preferred_language, birthdate, manager_id), " +
+        "Can update fields (display_name, job_title, gender, preferred_language, birthdate, manager_id, notes), " +
         "add or remove addresses, and use phone/email shorthands to upsert primary contact info. " +
         "Always use get_person first to verify identity before updating.",
       inputSchema: z.object({
@@ -259,6 +263,10 @@ export function createPeopleTools(context?: ScheduleContext) {
               .string()
               .optional()
               .describe("UUID or name to fuzzy-resolve"),
+            notes: z
+              .string()
+              .optional()
+              .describe("Free-text notes/context about this person"),
             phone: z
               .string()
               .regex(E164_RE, "Must be E.164 format, e.g. +14155551234")
@@ -348,6 +356,8 @@ export function createPeopleTools(context?: ScheduleContext) {
                 updateSet.managerId = (mgrMatches[0] as any).id;
               }
             }
+
+            if (fields.notes !== undefined) updateSet.notes = fields.notes;
 
             if (fields.phone !== undefined) {
               await upsertPrimaryAddress(resolvedId, "phone", fields.phone.toLowerCase());


### PR DESCRIPTION
Add a `notes` TEXT field to the `people` table and wire it through the people tools to implement issue #553.

---
<p><a href="https://cursor.com/agents/bc-efe9b57e-876f-4a3c-b6c8-bc53de8af22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efe9b57e-876f-4a3c-b6c8-bc53de8af22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a nullable `notes` column and threads it through existing read/update tooling without changing identifiers or query logic.
> 
> **Overview**
> Adds a new nullable `notes` field to the `people` table via a Drizzle migration and updates the Drizzle schema to include it.
> 
> Wires `notes` through the people tools so `get_person` returns it and `update_person` can accept and persist free-text notes/context as part of profile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f657e52cdde03c5ed1d8e1ede1434e50f5cf0330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->