### PR TITLE
Sandbox GCS mount

### DIFF
--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -180,13 +180,16 @@ export async function getOrCreateSandbox(): Promise<any> {
 
       cachedSandbox = sandbox;
       logger.info("E2B sandbox resumed", { sandboxId: savedId });
-      await setupSandboxFilesystem(sandbox, envs);
-      return sandbox;
     } catch (error: any) {
       logger.warn("Failed to resume sandbox, creating new one", {
         savedId,
         error: error.message,
       });
+    }
+
+    if (cachedSandbox) {
+      await setupSandboxFilesystem(cachedSandbox, envs);
+      return cachedSandbox;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Auto-mount GCS bucket `gs://aura-files` in sandboxes to ensure persistence across creation and resumption.

This PR addresses issue #564 by automatically installing `gcsfuse` and mounting `gs://aura-files` at `/mnt/aura-files` when a new sandbox is created or an existing one is resumed, as the mount does not survive sandbox resets.

---
<p><a href="https://cursor.com/agents/bc-b17411c9-3570-4dec-a883-171c0d67cfbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b17411c9-3570-4dec-a883-171c0d67cfbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->