### PR TITLE
feat: generic credential management in App Home

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import { cronApp } from "./cron/consolidate.js";
 import { heartbeatApp } from "./cron/heartbeat.js";
 import { elevenlabsWebhookApp } from "./webhook/elevenlabs.js";
 import { runPipeline } from "./pipeline/index.js";
-import { publishHomeTab, ACTION_TO_SETTING, CREDENTIAL_ACTIONS, isAdmin, openCredentialModal } from "./slack/home.js";
+import { publishHomeTab, ACTION_TO_SETTING, CREDENTIAL_ACTIONS, isAdmin, openAddCredentialModal, openEditCredentialModal } from "./slack/home.js";
 import { setSetting } from "./lib/settings.js";
 import { logger } from "./lib/logger.js";
 import { recordError } from "./lib/metrics.js";
@@ -354,19 +354,53 @@ app.post("/api/slack/interactions", async (c) => {
         waitUntil(savePromise);
       }
 
-      const credentialKey = CREDENTIAL_ACTIONS[action.action_id];
-      if (credentialKey && payload.trigger_id) {
-        const modalPromise = openCredentialModal(
+      // Generic "Add Credential" button
+      if (action.action_id === "credential_add" && payload.trigger_id) {
+        const addPromise = openAddCredentialModal(
           slackClient,
           payload.trigger_id,
-          credentialKey,
         ).catch((err) => {
-          recordError("interactions.credential_modal", err, {
-            userId,
-            credentialKey,
-          });
+          recordError("interactions.credential_modal", err, { userId });
         });
-        waitUntil(modalPromise);
+        waitUntil(addPromise);
+      }
+
+      // Overflow menu on existing credentials (edit / delete)
+      if (
+        action.action_id?.startsWith("credential_overflow_") &&
+        action.selected_option?.value
+      ) {
+        const [op, ...keyParts] = action.selected_option.value.split(":");
+        const credKey = keyParts.join(":");
+        if (op === "edit" && payload.trigger_id) {
+          const editPromise = openEditCredentialModal(
+            slackClient,
+            payload.trigger_id,
+            credKey,
+          ).catch((err) => {
+            recordError("interactions.credential_modal", err, {
+              userId,
+              credentialKey: credKey,
+            });
+          });
+          waitUntil(editPromise);
+        } else if (op === "delete") {
+          const delPromise = (async () => {
+            try {
+              const { deleteCredential } = await import(
+                "./lib/credentials.js"
+              );
+              await deleteCredential(credKey);
+              await publishHomeTab(slackClient, userId);
+            } catch (err) {
+              recordError("interactions.credential_delete", err, {
+                userId,
+                credentialKey: credKey,
+              });
+            }
+          })();
+          waitUntil(delPromise);
+        }
       }
     }
   }
@@ -375,6 +409,37 @@ app.post("/api/slack/interactions", async (c) => {
     const callbackId = payload.view?.callback_id;
     const userId = payload.user?.id;
 
+    // New credential (name + value from add modal)
+    if (callbackId === "credential_add_submit" && userId && isAdmin(userId)) {
+      const credName =
+        payload.view?.state?.values?.credential_name_block?.credential_name
+          ?.value;
+      const credValue =
+        payload.view?.state?.values?.credential_value_block?.credential_value
+          ?.value;
+
+      if (credName && credValue) {
+        const normalizedKey = credName
+          .toLowerCase()
+          .replace(/[\s-]+/g, "_")
+          .replace(/[^a-z0-9_]/g, "");
+        const addPromise = (async () => {
+          try {
+            const { setCredential } = await import("./lib/credentials.js");
+            await setCredential(normalizedKey, credValue, userId);
+            await publishHomeTab(slackClient, userId);
+          } catch (err) {
+            recordError("interactions.credential_save", err, {
+              userId,
+              credentialKey: normalizedKey,
+            });
+          }
+        })();
+        waitUntil(addPromise);
+      }
+    }
+
+    // Update existing credential
     if (callbackId === "credential_submit" && userId && isAdmin(userId)) {
       const credentialKey = payload.view?.private_metadata;
       const newValue =

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -91,3 +91,38 @@ export function maskCredential(value: string): string {
   if (value.length <= 12) return "••••••••";
   return `${value.slice(0, 8)}...${value.slice(-4)}`;
 }
+
+export async function listCredentials(): Promise<
+  { key: string; maskedValue: string }[]
+> {
+  const { db } = await import("../db/client.js");
+  const { sql } = await import("drizzle-orm");
+
+  try {
+    const rows = await db.execute(
+      sql\`SELECT key, value FROM settings WHERE key LIKE 'credential:%' ORDER BY key\`,
+    );
+    return rows.rows.map((row: any) => {
+      const key = (row.key as string).replace("credential:", "");
+      let masked = "••••••••";
+      try {
+        const plain = decryptCredential(row.value as string);
+        masked = maskCredential(plain);
+      } catch {}
+      return { key, maskedValue: masked };
+    });
+  } catch (error) {
+    logger.error("Failed to list credentials", { error });
+    return [];
+  }
+}
+
+export async function deleteCredential(key: string): Promise<void> {
+  const { db } = await import("../db/client.js");
+  const { sql } = await import("drizzle-orm");
+  await db.execute(
+    sql\`DELETE FROM settings WHERE key = \${"credential:" + key}\`,
+  );
+  logger.info("Credential deleted", { key });
+}
+

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -2,7 +2,6 @@ import type { WebClient } from "@slack/web-api";
 import { getAllSettings } from "../lib/settings.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
-import { getCredential, maskCredential } from "../lib/credentials.js";
 
 // ── Model Catalog ────────────────────────────────────────────────────────────
 
@@ -52,26 +51,13 @@ const DEFAULTS: Record<string, string> = {
   model_embedding: process.env.MODEL_EMBEDDING || "openai/text-embedding-3-small",
 };
 
-// ── Credential Definitions ───────────────────────────────────────────────────
+// ── Credentials (generic, dynamic) ──────────────────────────────────────────
 
-interface CredentialDef {
-  key: string;
-  label: string;
-  description: string;
-}
+// No hardcoded credential list. All credentials are discovered from the DB.
+// Admins can add any credential via App Home -- it gets AES-256-GCM encrypted.
 
-const CREDENTIALS: CredentialDef[] = [
-  {
-    key: "github_token",
-    label: "GitHub Token",
-    description: "For issues, PRs, and code access",
-  },
-];
-
-/** Map credential button action IDs to credential keys */
-export const CREDENTIAL_ACTIONS: Record<string, string> = {
-  credential_edit_github_token: "github_token",
-};
+/** Legacy export -- no longer statically populated, kept for app.ts compat */
+export const CREDENTIAL_ACTIONS: Record<string, string> = {};
 
 // ── Block Kit Helpers ────────────────────────────────────────────────────────
 
@@ -109,6 +95,9 @@ function buildDropdown(
 }
 
 async function buildCredentialBlocks(): Promise<any[]> {
+  const { listCredentials } = await import("../lib/credentials.js");
+  const credentials = await listCredentials();
+
   const blocks: any[] = [
     { type: "divider" },
     {
@@ -120,64 +109,104 @@ async function buildCredentialBlocks(): Promise<any[]> {
       elements: [
         {
           type: "mrkdwn",
-          text: "Encrypted and stored in the database. Values are never logged or displayed in full.",
+          text: "Encrypted at rest with AES-256-GCM. Values are never logged or displayed in full.",
         },
       ],
     },
   ];
 
-  for (const cred of CREDENTIALS) {
-    const value = await getCredential(cred.key);
-    const status = value ? `\`${maskCredential(value)}\`` : "_not set_";
-
+  for (const cred of credentials) {
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${cred.label}*  —  ${cred.description}\nCurrent: ${status}`,
+        text: `*${cred.key}*\nCurrent: \`${cred.maskedValue}\``,
       },
       accessory: {
-        type: "button",
-        text: { type: "plain_text", text: value ? "Update" : "Set" },
-        action_id: `credential_edit_${cred.key}`,
+        type: "overflow",
+        action_id: `credential_overflow_${cred.key}`,
+        options: [
+          {
+            text: { type: "plain_text", text: "Update" },
+            value: `edit:${cred.key}`,
+          },
+          {
+            text: { type: "plain_text", text: "Delete" },
+            value: `delete:${cred.key}`,
+          },
+        ],
       },
     });
   }
+
+  if (credentials.length === 0) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "_No credentials stored yet._",
+      },
+    });
+  }
+
+  blocks.push({
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Add Credential" },
+        action_id: "credential_add",
+        style: "primary",
+      },
+    ],
+  });
 
   return blocks;
 }
 
 /**
- * Open a modal for editing a credential value.
+ * Open a modal for adding a new credential (name + value).
  */
-export async function openCredentialModal(
+export async function openAddCredentialModal(
   client: WebClient,
   triggerId: string,
-  credentialKey: string,
 ): Promise<void> {
-  const cred = CREDENTIALS.find((c) => c.key === credentialKey);
-  if (!cred) return;
-
   await client.views.open({
     trigger_id: triggerId,
     view: {
       type: "modal",
-      callback_id: "credential_submit",
-      private_metadata: credentialKey,
-      title: { type: "plain_text", text: `Update ${cred.label}` },
+      callback_id: "credential_add_submit",
+      title: { type: "plain_text", text: "Add Credential" },
       submit: { type: "plain_text", text: "Save" },
       close: { type: "plain_text", text: "Cancel" },
       blocks: [
         {
           type: "input",
-          block_id: "credential_input_block",
-          label: { type: "plain_text", text: cred.label },
+          block_id: "credential_name_block",
+          label: { type: "plain_text", text: "Credential Name" },
+          element: {
+            type: "plain_text_input",
+            action_id: "credential_name",
+            placeholder: {
+              type: "plain_text",
+              text: "e.g. airbyte_api_token, close_ch_key, meta_ads",
+            },
+          },
+          hint: {
+            type: "plain_text",
+            text: "Lowercase with underscores. This is the key used to retrieve the credential.",
+          },
+        },
+        {
+          type: "input",
+          block_id: "credential_value_block",
+          label: { type: "plain_text", text: "Value" },
           element: {
             type: "plain_text_input",
             action_id: "credential_value",
             placeholder: {
               type: "plain_text",
-              text: "Paste the new token here",
+              text: "Paste the token or secret here",
             },
           },
         },
@@ -186,7 +215,52 @@ export async function openCredentialModal(
           elements: [
             {
               type: "mrkdwn",
-              text: `This will replace the current ${cred.label}. The value is encrypted at rest with AES-256-GCM.`,
+              text: "Encrypted with AES-256-GCM before storage. Never displayed in full.",
+            },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+/**
+ * Open a modal for updating an existing credential (value only).
+ */
+export async function openEditCredentialModal(
+  client: WebClient,
+  triggerId: string,
+  credentialKey: string,
+): Promise<void> {
+  await client.views.open({
+    trigger_id: triggerId,
+    view: {
+      type: "modal",
+      callback_id: "credential_submit",
+      private_metadata: credentialKey,
+      title: { type: "plain_text", text: `Update: ${credentialKey}` },
+      submit: { type: "plain_text", text: "Save" },
+      close: { type: "plain_text", text: "Cancel" },
+      blocks: [
+        {
+          type: "input",
+          block_id: "credential_input_block",
+          label: { type: "plain_text", text: credentialKey },
+          element: {
+            type: "plain_text_input",
+            action_id: "credential_value",
+            placeholder: {
+              type: "plain_text",
+              text: "Paste the new value here",
+            },
+          },
+        },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `Replaces the current value for *${credentialKey}*. Encrypted at rest.`,
             },
           ],
         },


### PR DESCRIPTION
## What
Replace hardcoded credential list with a fully generic system. Admins type any name + value, it gets encrypted and stored. No code changes needed to add new credentials.

## Why
Jonas needs to store an Airbyte API token. Currently adding a new credential requires editing home.ts to add it to the CREDENTIALS array. This should be self-service.

## How
**App Home UI:**
- 'Add Credential' button opens a modal with Name + Value fields
- Each credential shows with an overflow menu: Update / Delete
- Credentials discovered dynamically from DB (settings table, credential: prefix)
- Keys auto-normalized: lowercase, underscores, alphanumeric only

**credentials.ts:**
- listCredentials() -- scan DB for all credential:* entries, decrypt, mask
- deleteCredential(key) -- remove a credential

**app.ts:**
- credential_add action -> opens add modal
- credential_overflow_{key} action -> edit or delete
- credential_add_submit callback -> normalize key, encrypt, store
- Existing credential_submit callback unchanged (handles updates)

**Security:**
- Same AES-256-GCM encryption as before
- Admin-only (both UI rendering and action handlers)
- Values never logged or displayed in full
- Backward compatible: existing github_token credential + env fallbacks still work

Closes part of #571