### PR TITLE
Job API OAuth exchange

### DIFF
--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -288,10 +288,9 @@ async function exchangeOAuthToken(
 }
 
 /**
- * Retrieve a credential for a scheduled job. Returns raw decrypted value.
- * NOTE: Does not auto-exchange oauth_client tokens — jobs get raw client_id/client_secret JSON.
- * This is intentional: jobs may need different exchange flows or caching strategies.
- * Use getApiCredentialWithType for interactive tool calls that need auto-exchange.
+ * Retrieve a credential for a scheduled job. Returns the usable secret value.
+ * For oauth_client credentials with a tokenUrl, automatically exchanges
+ * client_id/client_secret for an access_token via the token endpoint.
  */
 export async function getJobApiCredential(
   name: string,
@@ -326,7 +325,27 @@ export async function getJobApiCredential(
   }
 
   await audit(cred.id, name, `job:${jobId}`, "use", `creator:${creatorId}`);
-  return decryptCredential(cred.value);
+  const decrypted = decryptCredential(cred.value);
+
+  if (cred.type === "oauth_client" && cred.tokenUrl) {
+    let parsed: { client_id: string; client_secret: string };
+    try {
+      parsed = JSON.parse(decrypted);
+    } catch {
+      throw new Error(`oauth_client credential "${name}" has invalid JSON value`);
+    }
+    if (!parsed.client_id || !parsed.client_secret) {
+      throw new Error(`oauth_client credential "${name}" missing client_id or client_secret`);
+    }
+    const tokenResponse = await exchangeOAuthToken(
+      cred.tokenUrl,
+      parsed.client_id,
+      parsed.client_secret,
+    );
+    return tokenResponse.access_token;
+  }
+
+  return decrypted;
 }
 
 export async function listApiCredentials(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add OAuth token exchange to `getJobApiCredential` to support OAuth client credentials for job API access.

---
<p><a href="https://cursor.com/agents/bc-fcbb69d6-c9a9-4e4e-8dec-fa735809cab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbb69d6-c9a9-4e4e-8dec-fa735809cab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->