### PR TITLE
fix: credentials UI — hide type label, white + icon, show access list (#604)

### DIFF
--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -1,9 +1,10 @@
-import { eq, and, or, isNull, sql } from "drizzle-orm";
+import { eq, and, or, isNull, inArray, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import {
   credentials,
   credentialGrants,
   credentialAuditLog,
+  userProfiles,
   type Credential,
 } from "../db/schema.js";
 import { encryptCredential, decryptCredential } from "./credentials.js";
@@ -374,6 +375,40 @@ export async function listApiCredentials(
     ...owned.map((r) => ({ ...r, permission: "owner" as const })),
     ...granted.map((r) => ({ ...r, permission: r.permission as "read" | "write" | "admin" })),
   ];
+}
+
+export async function listGrantsForCredentials(
+  credentialIds: string[],
+): Promise<
+  Array<{
+    credentialId: string;
+    granteeId: string;
+    permission: string;
+    displayName: string | null;
+  }>
+> {
+  if (credentialIds.length === 0) return [];
+
+  const grants = await db
+    .select({
+      credentialId: credentialGrants.credentialId,
+      granteeId: credentialGrants.granteeId,
+      permission: credentialGrants.permission,
+      displayName: userProfiles.displayName,
+    })
+    .from(credentialGrants)
+    .leftJoin(
+      userProfiles,
+      eq(credentialGrants.granteeId, userProfiles.slackUserId),
+    )
+    .where(
+      and(
+        inArray(credentialGrants.credentialId, credentialIds),
+        isNull(credentialGrants.revokedAt),
+      ),
+    );
+
+  return grants;
 }
 
 export async function deleteApiCredential(

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -5,6 +5,7 @@ import { logger } from "../lib/logger.js";
 import { getCredential, maskCredential } from "../lib/credentials.js";
 import {
   listApiCredentials,
+  listGrantsForCredentials,
 } from "../lib/api-credentials.js";
 
 // ── Model Catalog ────────────────────────────────────────────────────────────
@@ -175,7 +176,7 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
       elements: [
         {
           type: "button",
-          text: { type: "plain_text", text: "➕ Add Credential" },
+          text: { type: "plain_text", text: "+ Add Credential", emoji: true },
           action_id: "api_credential_add",
           style: "primary",
         },
@@ -194,11 +195,24 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
     return blocks;
   }
 
+  const ownedCredIds = creds
+    .filter((c) => c.owner_id === userId)
+    .map((c) => c.id);
+  const allGrants = await listGrantsForCredentials(ownedCredIds);
+  const grantsByCredId = new Map<
+    string,
+    Array<{ granteeId: string; permission: string; displayName: string | null }>
+  >();
+  for (const g of allGrants) {
+    const list = grantsByCredId.get(g.credentialId) ?? [];
+    list.push(g);
+    grantsByCredId.set(g.credentialId, list);
+  }
+
   for (const cred of creds) {
     const isOwner = cred.owner_id === userId;
     const source = isOwner ? "yours" : `shared by <@${cred.owner_id}>`;
     const permLabel = isOwner ? "owner" : cred.permission;
-    const typeBadge = cred.type !== "token" ? ` (${cred.type})` : "";
 
     let expiryText = "";
     if (cred.expires_at) {
@@ -228,11 +242,26 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
       );
     }
 
+    const grants = grantsByCredId.get(cred.id) ?? [];
+    const actionCount = overflowOptions.length;
+    const maxAccessEntries = 5 - actionCount;
+
+    for (const grant of grants.slice(0, maxAccessEntries)) {
+      const label = grant.displayName ?? grant.granteeId;
+      overflowOptions.push({
+        text: {
+          type: "plain_text",
+          text: `👤 ${label} (${grant.permission})`,
+        },
+        value: `api_credential_access_${cred.id}_${grant.granteeId}`,
+      });
+    }
+
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${cred.name}*${typeBadge}  ·  _${source}_ (${permLabel})${expiryText}`,
+        text: `*${cred.name}*  ·  _${source}_ (${permLabel})${expiryText}`,
       },
       accessory: {
         type: "overflow",


### PR DESCRIPTION
## Changes

Three UI improvements to the App Home credentials section:

1. **Removed type suffix** — `airbyte_cloud (oauth_client)` → `airbyte_cloud`. Internal type label was noise.
2. **White + icon** — Replaced `➕` emoji with plain `+` so it renders white on the green primary button.
3. **Access list in overflow menu** — Each credential overflow now shows users with access (`👤 Name (permission)`), respecting Slack 5-option limit.

New `listGrantsForCredentials()` batch function fetches active grants with display names via LEFT JOIN on `userProfiles`.

Closes #604