### PR TITLE
Recurring job cancellation race

### DIFF
--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -72,7 +72,7 @@ export async function executeJob(
   const claimed = await db
     .update(jobs)
     .set({ status: "running", updatedAt: new Date() })
-    .where(and(eq(jobs.id, jobId), eq(jobs.status, "pending")))
+    .where(and(eq(jobs.id, jobId), eq(jobs.status, "pending"), eq(jobs.enabled, 1)))
     .returning({ id: jobs.id });
 
   if (claimed.length === 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Close a TOCTOU race in recurring job cancellation by ensuring only enabled jobs can be atomically claimed for execution.

When `cancel_job` disables a recurring job, there's a race condition where the `executeJob` function might still claim and execute it if the job was disabled after being loaded into memory but before the atomic claim. This fix adds a check for `jobs.enabled = 1` to the atomic claim's WHERE clause, preventing disabled jobs from being executed.

---
<p><a href="https://cursor.com/agents/bc-84f5479d-1e3d-4205-864d-52a8b2b8cc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84f5479d-1e3d-4205-864d-52a8b2b8cc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->