### PR TITLE
chore: add content:index scripts to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "db:studio": "drizzle-kit studio",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
-    "test": "vitest run"
+    "test": "vitest run",
+    "content:index": "tsx scripts/index-content.ts",
+    "content:index:no-embeddings": "tsx scripts/index-content.ts --skip-embeddings"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.46",


### PR DESCRIPTION
Ported from ef87 branch. Adds `content:index` and `content:index:no-embeddings` scripts to root package.json for convenient content indexing.

Targets #609 (7848 branch).