### PR TITLE
chore: remove hardcoded RealAdvisor refs (pre-open-source cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ dist/
 apps/web/node_modules/
 apps/web/.next/
 apps/web/next-env.d.ts
+
+# Additional env files (prevent accidental secret commits)
+.env.prod
+.env.staging
+.env.development

--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -166,7 +166,7 @@ Understanding this helps you set realistic expectations, debug failures, and rea
 
 **Heartbeat:** Every 30 minutes. One-shots fire at scheduled time. Recurring jobs evaluate cron + frequency limits. Each execution gets up to 350 tool calls. Scheduling granularity is ~30 minutes. Failed jobs retry 3x with 30-min backoff, then escalate via DM.
 
-**Codebase:** Your source is at github.com/realadvisor/aura. You have Claude Code (\`claude\`) in your sandbox for exploration, review, and code changes. Always create PRs on branches, never push to main. For prompt changes, flag as "self-edit" and explain reasoning.
+**Codebase:** Your source is at github.com/AuraHQ-ai/aura. You have Claude Code (\`claude\`) in your sandbox for exploration, review, and code changes. Always create PRs on branches, never push to main. For prompt changes, flag as "self-edit" and explain reasoning.
 
 **Limits:** You can't access authenticated external APIs directly from runtime. But you can run code, shell commands, and CLI tools in the sandbox, and search the web / read URLs.
 

--- a/src/tools/cursor-agent.ts
+++ b/src/tools/cursor-agent.ts
@@ -7,7 +7,7 @@ import type { ScheduleContext } from "../db/schema.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
 
-const DEFAULT_REPO = "realadvisor/aura";
+const DEFAULT_REPO = process.env.DEFAULT_GITHUB_REPO ?? "AuraHQ-ai/aura";
 
 /**
  * Create Cursor Cloud Agent tools for the AI SDK.
@@ -50,7 +50,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
           .string()
           .optional()
           .describe(
-            "GitHub repository in owner/repo format, e.g. 'realadvisor/realadvisor'. Defaults to 'realadvisor/aura'",
+            "GitHub repository in owner/repo format, e.g. 'realadvisor/realadvisor'. Defaults to 'AuraHQ-ai/aura'",
           ),
       }),
       execute: async ({ issue_description, branch_prefix, ref, key_files, repository }) => {


### PR DESCRIPTION
Pre-open-source cleanup. Removes hardcoded references that would confuse anyone deploying their own Aura instance.

## Changes

- **`src/tools/cursor-agent.ts`** -- `DEFAULT_REPO` now reads from `DEFAULT_GITHUB_REPO` env var (fallback: `AuraHQ-ai/aura`)
- **`src/personality/system-prompt.ts`** -- update github URL from `realadvisor/aura` → `AuraHQ-ai/aura`
- **`.gitignore`** -- add `.env.prod`, `.env.staging`, `.env.development` to prevent another accidental secret commit (this was how the Cohere key leaked into history)

## What's NOT changed

- `src/lib/gmail.ts` -- already uses `process.env.AURA_EMAIL_ADDRESS`
- `src/lib/contact-lookup.ts` -- already uses `process.env.GCP_PROJECT_ID`
- Blog/docs content mentioning "realadvisor" -- those are intentional storytelling

## Next step

BFG history scrub to remove the `.env.prod` commit (`e0ccd51`) before making the repo public.