### PR TITLE
fix: upload_file description — warn that username opens new DM, not current thread

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -2278,7 +2278,7 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
 
     upload_file: defineTool({
       description:
-        "Upload a file to Slack, optionally sharing to a channel or thread. Two modes: (1) Pass `content` for text files (CSV, JSON, code) — inline string. (2) Pass `file_path` for binary files (images, audio, PDFs) — reads the file from the sandbox filesystem. Exactly one of `content` or `file_path` must be provided. The channel parameter accepts any Slack destination: channel name ('general'), channel ID ('C0BNVKS77'), DM channel ID ('D0AF1K2EBH8'), group DM ID ('G01234'), or a username/display name ('Joan') to open a DM. Use thread_ts to post into a specific thread (including Slack List item comment threads).",
+        "Upload a file to Slack, optionally sharing to a channel or thread. Two modes: (1) Pass `content` for text files (CSV, JSON, code) — inline string. (2) Pass `file_path` for binary files (images, audio, PDFs) — reads the file from the sandbox filesystem. Exactly one of `content` or `file_path` must be provided. The channel parameter accepts any Slack destination: channel name ('general'), channel ID ('C0BNVKS77'), DM channel ID ('D0AF1K2EBH8'), group DM ID ('G01234'), or a username/display name ('Joan') to open a DM. Use thread_ts to post into a specific thread (including Slack List item comment threads). IMPORTANT: If you are currently in a thread and want to share a file there, pass the channel ID (not a username) plus thread_ts. Passing a username always opens a new DM conversation, even if you're already in a DM thread with that person.",
       inputSchema: z.object({
         content: z
           .string()


### PR DESCRIPTION
## Problem

When `upload_file` is called with a username (e.g. `'Joan'`) while already in a thread, the file lands in a fresh top-level DM instead of the current conversation. Nothing in the description warned about this.

## Fix

Added an **IMPORTANT** callout to the tool description:

> If you are currently in a thread and want to share a file there, pass the channel ID (not a username) plus thread_ts. Passing a username always opens a new DM conversation, even if you're already in a DM thread with that person.

## Why this matters

The LLM reads tool descriptions at call time. Making the behavior explicit prevents the mistake from repeating.

Fixes: the upload-lands-in-wrong-place bug seen in the logo generation session (2026-03-07).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change to the `upload_file` tool description with no runtime or API behavior modifications.
> 
> **Overview**
> Updates the `upload_file` tool description in `src/tools/slack.ts` with an **IMPORTANT** callout explaining that providing a username as `channel` will open a *new* DM, and that posting a file into the *current thread* requires using the channel ID plus `thread_ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b75f277b279e7b4eb9bd5cb9de465f87802f2309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->