### PR TITLE
Core tables workspace ID

### DIFF
--- a/drizzle/0033_add_workspace_id.sql
+++ b/drizzle/0033_add_workspace_id.sql
@@ -1,0 +1,180 @@
+-- Migration: Add workspace_id to all core tables for multi-tenant support.
+-- Strategy: add nullable → backfill → set NOT NULL with default → update indexes.
+
+-- ── messages ────────────────────────────────────────────────────────────────
+ALTER TABLE "messages" ADD COLUMN "workspace_id" text;
+UPDATE "messages" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "messages" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "messages" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "messages_slack_ts_idx";
+CREATE UNIQUE INDEX "messages_workspace_slack_ts_idx" ON "messages" ("workspace_id", "slack_ts");
+CREATE INDEX "messages_workspace_id_idx" ON "messages" ("workspace_id");
+
+-- ── memories ────────────────────────────────────────────────────────────────
+ALTER TABLE "memories" ADD COLUMN "workspace_id" text;
+UPDATE "memories" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "memories" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "memories" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+CREATE INDEX "memories_workspace_id_idx" ON "memories" ("workspace_id");
+
+-- ── user_profiles ───────────────────────────────────────────────────────────
+ALTER TABLE "user_profiles" ADD COLUMN "workspace_id" text;
+UPDATE "user_profiles" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "user_profiles" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "user_profiles" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "user_profiles_slack_user_id_idx";
+CREATE UNIQUE INDEX "user_profiles_workspace_slack_user_id_idx" ON "user_profiles" ("workspace_id", "slack_user_id");
+CREATE INDEX "user_profiles_workspace_id_idx" ON "user_profiles" ("workspace_id");
+
+-- ── people ──────────────────────────────────────────────────────────────────
+ALTER TABLE "people" ADD COLUMN "workspace_id" text;
+UPDATE "people" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "people" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "people" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "people_slack_user_id_idx";
+CREATE UNIQUE INDEX "people_workspace_slack_user_id_idx" ON "people" ("workspace_id", "slack_user_id") WHERE slack_user_id IS NOT NULL;
+CREATE INDEX "people_workspace_id_idx" ON "people" ("workspace_id");
+
+-- ── addresses ───────────────────────────────────────────────────────────────
+ALTER TABLE "addresses" ADD COLUMN "workspace_id" text;
+UPDATE "addresses" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "addresses" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "addresses" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "addresses_channel_value_idx";
+CREATE UNIQUE INDEX "addresses_workspace_channel_value_idx" ON "addresses" ("workspace_id", "channel", "value");
+CREATE INDEX "addresses_workspace_id_idx" ON "addresses" ("workspace_id");
+
+-- ── channels ────────────────────────────────────────────────────────────────
+ALTER TABLE "channels" ADD COLUMN "workspace_id" text;
+UPDATE "channels" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "channels" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "channels" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "channels_slack_channel_id_idx";
+CREATE UNIQUE INDEX "channels_workspace_slack_channel_id_idx" ON "channels" ("workspace_id", "slack_channel_id");
+CREATE INDEX "channels_workspace_id_idx" ON "channels" ("workspace_id");
+
+-- ── settings (PK change: key → workspace_id + key) ─────────────────────────
+ALTER TABLE "settings" ADD COLUMN "workspace_id" text;
+UPDATE "settings" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "settings" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "settings" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+ALTER TABLE "settings" DROP CONSTRAINT "settings_pkey";
+ALTER TABLE "settings" ADD CONSTRAINT "settings_pkey" PRIMARY KEY ("workspace_id", "key");
+
+-- ── notes ───────────────────────────────────────────────────────────────────
+ALTER TABLE "notes" ADD COLUMN "workspace_id" text;
+UPDATE "notes" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "notes" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "notes" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "notes_topic_idx";
+CREATE UNIQUE INDEX "notes_workspace_topic_idx" ON "notes" ("workspace_id", "topic");
+CREATE INDEX "notes_workspace_id_idx" ON "notes" ("workspace_id");
+
+-- ── resources ───────────────────────────────────────────────────────────────
+ALTER TABLE "resources" ADD COLUMN "workspace_id" text;
+UPDATE "resources" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "resources" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "resources" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "resources_url_idx";
+CREATE UNIQUE INDEX "resources_workspace_url_idx" ON "resources" ("workspace_id", "url");
+CREATE INDEX "resources_workspace_id_idx" ON "resources" ("workspace_id");
+
+-- ── jobs ────────────────────────────────────────────────────────────────────
+ALTER TABLE "jobs" ADD COLUMN "workspace_id" text;
+UPDATE "jobs" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "jobs" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "jobs" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "jobs_name_idx";
+CREATE UNIQUE INDEX "jobs_workspace_name_idx" ON "jobs" ("workspace_id", "name");
+CREATE INDEX "jobs_workspace_id_idx" ON "jobs" ("workspace_id");
+
+-- ── job_executions ──────────────────────────────────────────────────────────
+ALTER TABLE "job_executions" ADD COLUMN "workspace_id" text;
+UPDATE "job_executions" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "job_executions" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "job_executions" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+CREATE INDEX "job_executions_workspace_id_idx" ON "job_executions" ("workspace_id");
+
+-- ── event_locks ─────────────────────────────────────────────────────────────
+ALTER TABLE "event_locks" ADD COLUMN "workspace_id" text;
+UPDATE "event_locks" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "event_locks" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "event_locks" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "event_locks_event_ts_channel_id_idx";
+CREATE UNIQUE INDEX "event_locks_workspace_event_ts_channel_id_idx" ON "event_locks" ("workspace_id", "event_ts", "channel_id");
+CREATE INDEX "event_locks_workspace_id_idx" ON "event_locks" ("workspace_id");
+
+-- ── error_events ────────────────────────────────────────────────────────────
+ALTER TABLE "error_events" ADD COLUMN "workspace_id" text;
+UPDATE "error_events" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "error_events" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "error_events" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+CREATE INDEX "error_events_workspace_id_idx" ON "error_events" ("workspace_id");
+
+-- ── emails_raw ──────────────────────────────────────────────────────────────
+ALTER TABLE "emails_raw" ADD COLUMN "workspace_id" text;
+UPDATE "emails_raw" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "emails_raw" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "emails_raw" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "emails_raw_user_gmail_msg_idx";
+CREATE UNIQUE INDEX "emails_raw_workspace_user_gmail_msg_idx" ON "emails_raw" ("workspace_id", "user_id", "gmail_message_id");
+CREATE INDEX "emails_raw_workspace_id_idx" ON "emails_raw" ("workspace_id");
+
+-- ── oauth_tokens ────────────────────────────────────────────────────────────
+ALTER TABLE "oauth_tokens" ADD COLUMN "workspace_id" text;
+UPDATE "oauth_tokens" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "oauth_tokens" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "oauth_tokens" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "oauth_tokens_user_provider_idx";
+CREATE UNIQUE INDEX "oauth_tokens_workspace_user_provider_idx" ON "oauth_tokens" ("workspace_id", "user_id", "provider");
+CREATE INDEX "oauth_tokens_workspace_id_idx" ON "oauth_tokens" ("workspace_id");
+
+-- ── voice_calls ─────────────────────────────────────────────────────────────
+ALTER TABLE "voice_calls" ADD COLUMN "workspace_id" text;
+UPDATE "voice_calls" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "voice_calls" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "voice_calls" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+ALTER TABLE "voice_calls" DROP CONSTRAINT IF EXISTS "voice_calls_conversation_id_unique";
+CREATE UNIQUE INDEX "voice_calls_workspace_conversation_id_idx" ON "voice_calls" ("workspace_id", "conversation_id");
+CREATE INDEX "voice_calls_workspace_id_idx" ON "voice_calls" ("workspace_id");
+
+-- ── feedback ────────────────────────────────────────────────────────────────
+ALTER TABLE "feedback" ADD COLUMN "workspace_id" text;
+UPDATE "feedback" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "feedback" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "feedback" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+ALTER TABLE "feedback" DROP CONSTRAINT IF EXISTS "feedback_unique_vote";
+ALTER TABLE "feedback" ADD CONSTRAINT "feedback_workspace_unique_vote" UNIQUE ("workspace_id", "message_ts", "channel_id", "user_id");
+CREATE INDEX "feedback_workspace_id_idx" ON "feedback" ("workspace_id");
+
+-- ── credentials ─────────────────────────────────────────────────────────────
+ALTER TABLE "credentials" ADD COLUMN "workspace_id" text;
+UPDATE "credentials" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "credentials" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "credentials" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+ALTER TABLE "credentials" DROP CONSTRAINT IF EXISTS "credentials_owner_id_name_unique";
+ALTER TABLE "credentials" ADD CONSTRAINT "credentials_workspace_owner_id_name_unique" UNIQUE ("workspace_id", "owner_id", "name");
+CREATE INDEX "credentials_workspace_id_idx" ON "credentials" ("workspace_id");
+
+-- ── credential_grants ───────────────────────────────────────────────────────
+ALTER TABLE "credential_grants" ADD COLUMN "workspace_id" text;
+UPDATE "credential_grants" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "credential_grants" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "credential_grants" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+CREATE INDEX "credential_grants_workspace_id_idx" ON "credential_grants" ("workspace_id");
+
+-- ── credential_audit_log ────────────────────────────────────────────────────
+ALTER TABLE "credential_audit_log" ADD COLUMN "workspace_id" text;
+UPDATE "credential_audit_log" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "credential_audit_log" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "credential_audit_log" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+CREATE INDEX "credential_audit_log_workspace_id_idx" ON "credential_audit_log" ("workspace_id");
+
+-- ── content ─────────────────────────────────────────────────────────────────
+ALTER TABLE "content" ADD COLUMN "workspace_id" text;
+UPDATE "content" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;
+ALTER TABLE "content" ALTER COLUMN "workspace_id" SET NOT NULL;
+ALTER TABLE "content" ALTER COLUMN "workspace_id" SET DEFAULT 'default';
+DROP INDEX IF EXISTS "content_slug_idx";
+CREATE UNIQUE INDEX "content_workspace_slug_idx" ON "content" ("workspace_id", "slug");
+CREATE INDEX "content_workspace_id_idx" ON "content" ("workspace_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1773225600000,
       "tag": "0032_content_index_table",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1773312000000,
+      "tag": "0033_add_workspace_id",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -176,7 +176,7 @@ async function upsertRecords(
         rawPath: record.rawPath,
       })
       .onConflictDoUpdate({
-        target: content.slug,
+        target: [content.workspaceId, content.slug],
         set: {
           type: record.type,
           title: record.title,

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,9 +30,9 @@ import { logger } from "./lib/logger.js";
 import { recordError } from "./lib/metrics.js";
 import { safePostMessage } from "./lib/slack-messaging.js";
 import crypto from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { db } from "./db/client.js";
-import { notes, feedback } from "./db/schema.js";
+import { notes, feedback, DEFAULT_WORKSPACE_ID } from "./db/schema.js";
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -312,15 +312,17 @@ app.post("/api/slack/interactions", async (c) => {
         });
 
         if (messageTs && channelId && userId) {
+          const workspaceId = payload.team?.id ?? DEFAULT_WORKSPACE_ID;
           const feedbackPromise = (async () => {
             try {
               await db.insert(feedback).values({
+                workspaceId,
                 messageTs,
                 channelId,
                 userId,
                 value: action.value,
               }).onConflictDoUpdate({
-                target: [feedback.messageTs, feedback.channelId, feedback.userId],
+                target: [feedback.workspaceId, feedback.messageTs, feedback.channelId, feedback.userId],
                 set: { value: sql`excluded.value` },
               });
 
@@ -796,7 +798,7 @@ app.post("/api/webhook/cursor-agent", async (c) => {
         const trackingRows = await db
           .select({ content: notes.content })
           .from(notes)
-          .where(eq(notes.topic, `cursor-agent:${agentId}`))
+          .where(and(eq(notes.workspaceId, DEFAULT_WORKSPACE_ID), eq(notes.topic, `cursor-agent:${agentId}`)))
           .limit(1);
 
         if (trackingRows[0]?.content) {

--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -1,7 +1,7 @@
 import { WebClient } from "@slack/web-api";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { jobs, notes, jobExecutions } from "../db/schema.js";
+import { jobs, notes, jobExecutions, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import { createHeadlessAgent } from "../lib/agents.js";
@@ -49,11 +49,11 @@ function parseContinuationTag(description: string): string | null {
   return match ? match[1] : null;
 }
 
-async function loadPlanNote(topic: string): Promise<string | null> {
+async function loadPlanNote(topic: string, workspaceId: string = DEFAULT_WORKSPACE_ID): Promise<string | null> {
   const rows = await db
     .select({ content: notes.content })
     .from(notes)
-    .where(eq(notes.topic, topic))
+    .where(and(eq(notes.workspaceId, workspaceId), eq(notes.topic, topic)))
     .limit(1);
   return rows[0]?.content ?? null;
 }
@@ -81,10 +81,12 @@ export async function executeJob(
   }
 
   // Insert execution trace row
+  const jobWorkspaceId = job.workspaceId ?? DEFAULT_WORKSPACE_ID;
   const [execution] = await db
     .insert(jobExecutions)
     .values({
       jobId,
+      workspaceId: jobWorkspaceId,
       status: "running",
       trigger,
       callbackChannel: job.channelId || null,
@@ -117,7 +119,7 @@ export async function executeJob(
         : "";
 
     if (isContinuation) {
-      const planContent = await loadPlanNote(planTopic);
+      const planContent = await loadPlanNote(planTopic, jobWorkspaceId);
       const nextSteps = job.description.replace(CONTINUE_TAG_RE, "");
 
       prompt = planContent
@@ -165,6 +167,7 @@ export async function executeJob(
     const { agent } = await createHeadlessAgent({
       slackClient,
       context: {
+        workspaceId: jobWorkspaceId,
         userId: job.requestedBy,
         channelId: job.channelId || undefined,
         threadTs: job.threadTs || undefined,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,8 +15,20 @@ import {
   vector,
   date,
   check,
+  primaryKey,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+
+// ── Multi-tenant workspace column ───────────────────────────────────────────
+// Every per-workspace table includes this column. Slack team_id is used as the
+// workspace identifier. Existing single-tenant data uses 'default'.
+// NOTE (future): partitioning by workspace_id would benefit messages, memories,
+// and emailsRaw at scale — defer until row counts justify it.
+
+export const DEFAULT_WORKSPACE_ID = "default";
+
+const workspaceId = () =>
+  text("workspace_id").notNull().default(DEFAULT_WORKSPACE_ID);
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 
@@ -53,6 +65,7 @@ export const messages = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     slackTs: text("slack_ts").notNull(),
     slackThreadTs: text("slack_thread_ts"),
     channelId: text("channel_id").notNull(),
@@ -65,7 +78,8 @@ export const messages = pgTable(
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("messages_slack_ts_idx").on(table.slackTs),
+    uniqueIndex("messages_workspace_slack_ts_idx").on(table.workspaceId, table.slackTs),
+    index("messages_workspace_id_idx").on(table.workspaceId),
     index("messages_channel_created_idx").on(table.channelId, table.createdAt),
     index("messages_thread_idx").on(table.slackThreadTs),
     index("messages_embedding_idx").using(
@@ -83,6 +97,7 @@ export const memories = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     content: text("content").notNull(),
     type: memoryTypeEnum("type").notNull(),
     sourceMessageId: uuid("source_message_id").references(() => messages.id),
@@ -101,6 +116,7 @@ export const memories = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
+    index("memories_workspace_id_idx").on(table.workspaceId),
     index("memories_embedding_idx").using(
       "hnsw",
       table.embedding.op("vector_cosine_ops"),
@@ -138,6 +154,7 @@ export const userProfiles = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     slackUserId: text("slack_user_id").notNull(),
     displayName: text("display_name").notNull(),
     timezone: text("timezone"),
@@ -158,7 +175,8 @@ export const userProfiles = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("user_profiles_slack_user_id_idx").on(table.slackUserId),
+    uniqueIndex("user_profiles_workspace_slack_user_id_idx").on(table.workspaceId, table.slackUserId),
+    index("user_profiles_workspace_id_idx").on(table.workspaceId),
   ],
 );
 
@@ -170,6 +188,7 @@ export const people = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     displayName: text("display_name"),
     slackUserId: text("slack_user_id"),
     jobTitle: text("job_title"),
@@ -182,9 +201,10 @@ export const people = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("people_slack_user_id_idx")
-      .on(table.slackUserId)
+    uniqueIndex("people_workspace_slack_user_id_idx")
+      .on(table.workspaceId, table.slackUserId)
       .where(sql`slack_user_id IS NOT NULL`),
+    index("people_workspace_id_idx").on(table.workspaceId),
   ],
 );
 
@@ -196,6 +216,7 @@ export const addresses = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     personId: uuid("person_id")
       .notNull()
       .references(() => people.id),
@@ -205,7 +226,8 @@ export const addresses = pgTable(
     createdAt: timestamptz("created_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("addresses_channel_value_idx").on(table.channel, table.value),
+    uniqueIndex("addresses_workspace_channel_value_idx").on(table.workspaceId, table.channel, table.value),
+    index("addresses_workspace_id_idx").on(table.workspaceId),
     index("addresses_person_id_idx").on(table.personId),
   ],
 );
@@ -218,6 +240,7 @@ export const channels = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     slackChannelId: text("slack_channel_id").notNull(),
     name: text("name").notNull(),
     type: channelTypeEnum("type").notNull(),
@@ -225,18 +248,26 @@ export const channels = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("channels_slack_channel_id_idx").on(table.slackChannelId),
+    uniqueIndex("channels_workspace_slack_channel_id_idx").on(table.workspaceId, table.slackChannelId),
+    index("channels_workspace_id_idx").on(table.workspaceId),
   ],
 );
 
 // ── Settings ────────────────────────────────────────────────────────────────
 
-export const settings = pgTable("settings", {
-  key: text("key").primaryKey(),
-  value: text("value").notNull(),
-  updatedAt: timestamptz("updated_at").notNull().defaultNow(),
-  updatedBy: text("updated_by"),
-});
+export const settings = pgTable(
+  "settings",
+  {
+    workspaceId: workspaceId(),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    updatedAt: timestamptz("updated_at").notNull().defaultNow(),
+    updatedBy: text("updated_by"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.workspaceId, table.key] }),
+  ],
+);
 
 // ── Notes (agent scratchpad with three-tier hierarchy) ──────────────────────
 
@@ -246,6 +277,7 @@ export const notes = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     topic: text("topic").notNull(),
     content: text("content").notNull(),
     category: text("category").notNull().default("knowledge"),
@@ -255,7 +287,8 @@ export const notes = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("notes_topic_idx").on(table.topic),
+    uniqueIndex("notes_workspace_topic_idx").on(table.workspaceId, table.topic),
+    index("notes_workspace_id_idx").on(table.workspaceId),
     index("notes_category_idx").on(table.category),
     index("notes_embedding_idx").using(
       "hnsw",
@@ -272,6 +305,7 @@ export const resources = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     url: text("url").notNull(),
     parentUrl: text("parent_url"),
     title: text("title"),
@@ -294,7 +328,8 @@ export const resources = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("resources_url_idx").on(table.url),
+    uniqueIndex("resources_workspace_url_idx").on(table.workspaceId, table.url),
+    index("resources_workspace_id_idx").on(table.workspaceId),
     index("resources_embedding_idx").using(
       "hnsw",
       table.embedding.op("vector_cosine_ops"),
@@ -325,6 +360,7 @@ export const jobs = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     name: text("name").notNull(),
     description: text("description").notNull(),
     playbook: text("playbook"),
@@ -350,7 +386,8 @@ export const jobs = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("jobs_name_idx").on(table.name),
+    uniqueIndex("jobs_workspace_name_idx").on(table.workspaceId, table.name),
+    index("jobs_workspace_id_idx").on(table.workspaceId),
     index("jobs_enabled_idx").on(table.enabled),
     index("jobs_status_execute_idx").on(table.status, table.executeAt),
   ],
@@ -364,6 +401,7 @@ export const jobExecutions = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     jobId: uuid("job_id").references(() => jobs.id),
     startedAt: timestamptz("started_at").notNull().defaultNow(),
     finishedAt: timestamptz("finished_at"),
@@ -377,6 +415,7 @@ export const jobExecutions = pgTable(
     error: text("error"),
   },
   (table) => [
+    index("job_executions_workspace_id_idx").on(table.workspaceId),
     index("job_executions_job_id_idx").on(table.jobId),
     index("job_executions_started_at_idx").on(table.startedAt),
   ],
@@ -390,15 +429,18 @@ export const eventLocks = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     eventTs: text("event_ts").notNull(),
     channelId: text("channel_id").notNull(),
     claimedAt: timestamptz("claimed_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("event_locks_event_ts_channel_id_idx").on(
+    uniqueIndex("event_locks_workspace_event_ts_channel_id_idx").on(
+      table.workspaceId,
       table.eventTs,
       table.channelId,
     ),
+    index("event_locks_workspace_id_idx").on(table.workspaceId),
   ],
 );
 
@@ -410,6 +452,7 @@ export const errorEvents = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     timestamp: timestamptz("timestamp").notNull().defaultNow(),
     errorName: text("error_name").notNull(),
     errorMessage: text("error_message").notNull(),
@@ -422,6 +465,7 @@ export const errorEvents = pgTable(
     resolved: boolean("resolved").default(false),
   },
   (table) => [
+    index("error_events_workspace_id_idx").on(table.workspaceId),
     index("error_events_timestamp_idx").on(table.timestamp),
     index("error_events_error_code_idx").on(table.errorCode),
   ],
@@ -436,6 +480,7 @@ export const emailsRaw = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     userId: text("user_id").notNull(),
     gmailMessageId: text("gmail_message_id").notNull(),
     gmailThreadId: text("gmail_thread_id").notNull(),
@@ -461,10 +506,12 @@ export const emailsRaw = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("emails_raw_user_gmail_msg_idx").on(
+    uniqueIndex("emails_raw_workspace_user_gmail_msg_idx").on(
+      table.workspaceId,
       table.userId,
       table.gmailMessageId,
     ),
+    index("emails_raw_workspace_id_idx").on(table.workspaceId),
     index("emails_raw_user_thread_idx").on(table.userId, table.gmailThreadId),
     index("emails_raw_user_triage_idx").on(table.userId, table.triage),
     index("emails_raw_user_thread_state_idx").on(table.userId, table.threadState),
@@ -482,6 +529,7 @@ export const oauthTokens = pgTable(
   "oauth_tokens",
   {
     id: serial("id").primaryKey(),
+    workspaceId: workspaceId(),
     userId: text("user_id").notNull(),
     provider: text("provider").notNull().default("google"),
     email: text("email"),
@@ -491,10 +539,12 @@ export const oauthTokens = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("oauth_tokens_user_provider_idx").on(
+    uniqueIndex("oauth_tokens_workspace_user_provider_idx").on(
+      table.workspaceId,
       table.userId,
       table.provider,
     ),
+    index("oauth_tokens_workspace_id_idx").on(table.workspaceId),
     index("oauth_tokens_email_idx").on(table.email),
   ],
 );
@@ -506,7 +556,8 @@ export const voiceCalls = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
-    conversationId: text("conversation_id").notNull().unique(),
+    workspaceId: workspaceId(),
+    conversationId: text("conversation_id").notNull(),
     agentId: text("agent_id"),
     direction: text("direction").notNull().default("outbound"),
     phoneNumber: text("phone_number"),
@@ -523,6 +574,8 @@ export const voiceCalls = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
+    uniqueIndex("voice_calls_workspace_conversation_id_idx").on(table.workspaceId, table.conversationId),
+    index("voice_calls_workspace_id_idx").on(table.workspaceId),
     index("voice_calls_agent_id_idx").on(table.agentId),
     index("voice_calls_status_idx").on(table.status),
     index("voice_calls_created_at_idx").on(table.createdAt),
@@ -564,6 +617,7 @@ export type NewVoiceCall = typeof voiceCalls.$inferInsert;
 
 /** Context for tools that need to know the current conversation's routing. */
 export interface ScheduleContext {
+  workspaceId?: string;
   userId?: string;
   channelId?: string;
   threadTs?: string;
@@ -577,6 +631,7 @@ export const feedback = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     messageTs: text("message_ts").notNull(),
     channelId: text("channel_id").notNull(),
     userId: text("user_id").notNull(),
@@ -584,7 +639,8 @@ export const feedback = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique("feedback_unique_vote").on(table.messageTs, table.channelId, table.userId),
+    unique("feedback_workspace_unique_vote").on(table.workspaceId, table.messageTs, table.channelId, table.userId),
+    index("feedback_workspace_id_idx").on(table.workspaceId),
   ],
 );
 
@@ -599,6 +655,7 @@ export const credentials = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     ownerId: text("owner_id").notNull(),
     name: text("name").notNull(),
     type: text("type").notNull().default("token"),
@@ -610,7 +667,8 @@ export const credentials = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    unique("credentials_owner_id_name_unique").on(table.ownerId, table.name),
+    unique("credentials_workspace_owner_id_name_unique").on(table.workspaceId, table.ownerId, table.name),
+    index("credentials_workspace_id_idx").on(table.workspaceId),
     check(
       "credentials_name_check",
       sql`${table.name} ~ '^[a-z][a-z0-9_]{1,62}$'`,
@@ -628,6 +686,7 @@ export const credentialGrants = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     credentialId: uuid("credential_id")
       .notNull()
       .references(() => credentials.id, { onDelete: "cascade" }),
@@ -642,6 +701,7 @@ export const credentialGrants = pgTable(
       table.credentialId,
       table.granteeId,
     ),
+    index("credential_grants_workspace_id_idx").on(table.workspaceId),
     index("idx_grants_grantee").on(table.granteeId),
     check(
       "credential_grants_permission_check",
@@ -656,6 +716,7 @@ export const credentialAuditLog = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     credentialId: uuid("credential_id").references(() => credentials.id, {
       onDelete: "set null",
     }),
@@ -666,6 +727,7 @@ export const credentialAuditLog = pgTable(
     timestamp: timestamptz("timestamp").notNull().defaultNow(),
   },
   (table) => [
+    index("credential_audit_log_workspace_id_idx").on(table.workspaceId),
     index("idx_audit_credential").on(table.credentialId, table.timestamp),
     index("idx_audit_accessed_by").on(table.accessedBy, table.timestamp),
     check(
@@ -690,6 +752,7 @@ export const content = pgTable(
     id: uuid("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId(),
     slug: text("slug").notNull(),
     type: text("type").notNull(),
     title: text("title").notNull(),
@@ -708,7 +771,8 @@ export const content = pgTable(
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("content_slug_idx").on(table.slug),
+    uniqueIndex("content_workspace_slug_idx").on(table.workspaceId, table.slug),
+    index("content_workspace_id_idx").on(table.workspaceId),
     index("content_type_idx").on(table.type),
     index("content_published_at_idx").on(table.publishedAt),
     index("content_tags_idx").using("gin", table.tags),

--- a/src/db/seed-skills.ts
+++ b/src/db/seed-skills.ts
@@ -9,7 +9,7 @@
 
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
-import { notes } from "./schema.js";
+import { notes, DEFAULT_WORKSPACE_ID } from "./schema.js";
 
 const connectionString = process.env.DATABASE_URL;
 
@@ -80,12 +80,13 @@ try {
     await db
       .insert(notes)
       .values({
+        workspaceId: DEFAULT_WORKSPACE_ID,
         topic: skill.topic,
         content: skill.content,
         category: skill.category,
         updatedAt: new Date(),
       })
-      .onConflictDoNothing();
+      .onConflictDoNothing({ target: [notes.workspaceId, notes.topic] });
 
     console.log(`  - ${skill.topic}: seeded (or already exists)`);
   }

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -66,7 +66,7 @@ export async function createInteractiveAgent(
 
 export interface HeadlessAgentOptions {
   slackClient: WebClient;
-  context?: { userId?: string; channelId?: string; threadTs?: string };
+  context?: ScheduleContext;
   systemPrompt: string;
 }
 

--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -5,6 +5,7 @@ import {
   credentialGrants,
   credentialAuditLog,
   userProfiles,
+  DEFAULT_WORKSPACE_ID,
   type Credential,
 } from "../db/schema.js";
 import { encryptCredential, decryptCredential } from "./credentials.js";
@@ -47,6 +48,7 @@ async function audit(
   accessedBy: string,
   action: AuditAction,
   context?: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<void> {
   try {
     await db.insert(credentialAuditLog).values({
@@ -55,6 +57,7 @@ async function audit(
       accessedBy,
       action,
       context,
+      workspaceId,
     });
   } catch (error) {
     logger.error("Failed to write credential audit log", {
@@ -117,6 +120,7 @@ export async function storeApiCredential(
   expiresAt?: Date,
   type: "token" | "oauth_client" = "token",
   tokenUrl?: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<Credential> {
   validateKey();
   validateName(name);
@@ -144,9 +148,10 @@ export async function storeApiCredential(
       tokenUrl: type === "oauth_client" ? (tokenUrl ?? null) : null,
       value: encrypted,
       expiresAt: expiresAt ?? null,
+      workspaceId,
     })
     .onConflictDoUpdate({
-      target: [credentials.ownerId, credentials.name],
+      target: [credentials.workspaceId, credentials.ownerId, credentials.name],
       set: {
         value: encrypted,
         type,
@@ -158,7 +163,7 @@ export async function storeApiCredential(
     .returning();
 
   const isUpdate = row.createdAt.getTime() !== row.updatedAt.getTime();
-  await audit(row.id, name, ownerId, isUpdate ? "update" : "create");
+  await audit(row.id, name, ownerId, isUpdate ? "update" : "create", undefined, workspaceId);
 
   return row;
 }
@@ -169,6 +174,7 @@ async function fetchAndAuthorize(
   ownerId: string,
   requestingUserId: string,
   intent: "read" | "write",
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<typeof credentials.$inferSelect | null> {
   validateKey();
   validateName(name);
@@ -176,25 +182,31 @@ async function fetchAndAuthorize(
   const rows = await db
     .select()
     .from(credentials)
-    .where(and(eq(credentials.ownerId, ownerId), eq(credentials.name, name)))
+    .where(
+      and(
+        eq(credentials.workspaceId, workspaceId),
+        eq(credentials.ownerId, ownerId),
+        eq(credentials.name, name),
+      ),
+    )
     .limit(1);
 
   const cred = rows[0];
   if (!cred) return null;
 
   if (cred.expiresAt && cred.expiresAt < new Date()) {
-    await audit(cred.id, name, requestingUserId, "expired_access_attempt");
+    await audit(cred.id, name, requestingUserId, "expired_access_attempt", undefined, workspaceId);
     await notifyOwnerExpired(cred.ownerId, name).catch(() => {});
     return null;
   }
 
   const allowed = await hasPermission(ownerId, cred.id, requestingUserId, intent);
   if (!allowed) {
-    await audit(cred.id, name, requestingUserId, intent, "access_denied");
+    await audit(cred.id, name, requestingUserId, intent, "access_denied", workspaceId);
     throw new Error(`Access denied: ${requestingUserId} cannot ${intent} credential "${name}" owned by ${ownerId}`);
   }
 
-  await audit(cred.id, name, requestingUserId, "read");
+  await audit(cred.id, name, requestingUserId, "read", undefined, workspaceId);
   return cred;
 }
 
@@ -203,8 +215,9 @@ export async function getApiCredential(
   ownerId: string,
   requestingUserId: string,
   intent: "read" | "write",
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<string | null> {
-  const cred = await fetchAndAuthorize(name, ownerId, requestingUserId, intent);
+  const cred = await fetchAndAuthorize(name, ownerId, requestingUserId, intent, workspaceId);
   if (!cred) return null;
   return decryptCredential(cred.value);
 }
@@ -214,8 +227,9 @@ export async function getApiCredentialWithType(
   ownerId: string,
   requestingUserId: string,
   intent: "read" | "write",
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<{ value: string; type: string; access_token?: string; expires_in?: number } | null> {
-  const cred = await fetchAndAuthorize(name, ownerId, requestingUserId, intent);
+  const cred = await fetchAndAuthorize(name, ownerId, requestingUserId, intent, workspaceId);
   if (!cred) return null;
 
   const decrypted = decryptCredential(cred.value);
@@ -299,6 +313,7 @@ export async function getJobApiCredential(
   jobId: string,
   creatorId: string,
   declaredCredentialIds: string[],
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<string | null> {
   validateKey();
   validateName(name);
@@ -310,6 +325,7 @@ export async function getJobApiCredential(
     .from(credentials)
     .where(
       and(
+        eq(credentials.workspaceId, workspaceId),
         eq(credentials.name, name),
         eq(credentials.ownerId, creatorId),
         sql`${credentials.id} = ANY(${declaredCredentialIds})`,
@@ -321,12 +337,12 @@ export async function getJobApiCredential(
   if (!cred) return null;
 
   if (cred.expiresAt && cred.expiresAt < new Date()) {
-    await audit(cred.id, name, `job:${jobId}`, "expired_access_attempt");
+    await audit(cred.id, name, `job:${jobId}`, "expired_access_attempt", undefined, workspaceId);
     await notifyOwnerExpired(creatorId, name).catch(() => {});
     return null;
   }
 
-  await audit(cred.id, name, `job:${jobId}`, "use", `creator:${creatorId}`);
+  await audit(cred.id, name, `job:${jobId}`, "use", `creator:${creatorId}`, workspaceId);
   return decryptCredential(cred.value);
 }
 
@@ -347,6 +363,7 @@ export async function getCredentialById(
 
 export async function listApiCredentials(
   userId: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<
   Array<{
     id: string;
@@ -366,7 +383,7 @@ export async function listApiCredentials(
       expires_at: credentials.expiresAt,
     })
     .from(credentials)
-    .where(eq(credentials.ownerId, userId));
+    .where(and(eq(credentials.workspaceId, workspaceId), eq(credentials.ownerId, userId)));
 
   const granted = await db
     .select({
@@ -381,6 +398,7 @@ export async function listApiCredentials(
     .innerJoin(credentials, eq(credentialGrants.credentialId, credentials.id))
     .where(
       and(
+        eq(credentials.workspaceId, workspaceId),
         eq(credentialGrants.granteeId, userId),
         isNull(credentialGrants.revokedAt),
       ),
@@ -440,12 +458,12 @@ export async function deleteApiCredential(
   if (!cred) return false;
 
   if (cred.ownerId !== requestingUserId) {
-    await audit(cred.id, cred.name, requestingUserId, "delete", "access_denied");
+    await audit(cred.id, cred.name, requestingUserId, "delete", "access_denied", cred.workspaceId);
     return false;
   }
 
   await db.delete(credentials).where(eq(credentials.id, credentialId));
-  await audit(null, cred.name, requestingUserId, "delete");
+  await audit(null, cred.name, requestingUserId, "delete", undefined, cred.workspaceId);
   return true;
 }
 
@@ -487,7 +505,7 @@ export async function grantApiCredentialAccess(
       },
     });
 
-  await audit(credentialId, cred.name, granterId, "grant", `grantee:${granteeId} permission:${permission}`);
+  await audit(credentialId, cred.name, granterId, "grant", `grantee:${granteeId} permission:${permission}`, cred.workspaceId);
 }
 
 export async function revokeApiCredentialAccess(
@@ -520,7 +538,7 @@ export async function revokeApiCredentialAccess(
       ),
     );
 
-  await audit(credentialId, cred.name, revokerId, "revoke", `grantee:${granteeId}`);
+  await audit(credentialId, cred.name, revokerId, "revoke", `grantee:${granteeId}`, cred.workspaceId);
 }
 
 function scrubValue(error: unknown, plaintext: string): Error {
@@ -539,8 +557,9 @@ export async function withApiCredential<T>(
   requestingUserId: string,
   intent: "read" | "write",
   fn: (value: string) => Promise<T>,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<T> {
-  const plaintext = await getApiCredential(name, ownerId, requestingUserId, intent);
+  const plaintext = await getApiCredential(name, ownerId, requestingUserId, intent, workspaceId);
   if (plaintext === null) {
     throw new Error(`Credential "${name}" not found`);
   }
@@ -549,14 +568,18 @@ export async function withApiCredential<T>(
     const result = await fn(plaintext);
 
     const rows = await db
-      .select({ id: credentials.id })
+      .select({ id: credentials.id, workspaceId: credentials.workspaceId })
       .from(credentials)
       .where(
-        and(eq(credentials.ownerId, ownerId), eq(credentials.name, name)),
+        and(
+          eq(credentials.workspaceId, workspaceId),
+          eq(credentials.ownerId, ownerId),
+          eq(credentials.name, name),
+        ),
       )
       .limit(1);
     if (rows[0]) {
-      await audit(rows[0].id, name, requestingUserId, "use");
+      await audit(rows[0].id, name, requestingUserId, "use", undefined, rows[0].workspaceId);
     }
 
     return result;

--- a/src/lib/email-sync.ts
+++ b/src/lib/email-sync.ts
@@ -1,7 +1,7 @@
 import TurndownService from "turndown";
 import { and, eq, isNull, sql, inArray, asc } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { emailsRaw, type NewEmailRaw } from "../db/schema.js";
+import { emailsRaw, DEFAULT_WORKSPACE_ID, type NewEmailRaw } from "../db/schema.js";
 import {
   getGmailClientForUser,
   getHeader,
@@ -191,6 +191,7 @@ async function batchGetMessages(
 function messageToRow(
   msg: any,
   userId: string,
+  workspaceId: string,
   userEmail: string | null,
 ): NewEmailRaw | null {
   if (!msg?.id || !msg?.threadId) return null;
@@ -229,6 +230,7 @@ function messageToRow(
   }
 
   return {
+    workspaceId,
     userId,
     gmailMessageId: msg.id,
     gmailThreadId: msg.threadId,
@@ -256,6 +258,7 @@ function messageToRow(
  */
 export async function syncEmails(
   userId: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
   options: SyncOptions = {},
 ): Promise<SyncResult> {
   const result: SyncResult = { synced: 0, skipped: 0, errors: 0, errorDetails: [] };
@@ -322,7 +325,7 @@ export async function syncEmails(
         continue;
       }
       try {
-        const row = messageToRow(msg, userId, userEmail);
+        const row = messageToRow(msg, userId, workspaceId, userEmail);
         if (row) {
           rows.push(row);
           if (!uniqueSenders.has(row.fromEmail)) {
@@ -365,7 +368,7 @@ export async function syncEmails(
           .insert(emailsRaw)
           .values(rows)
           .onConflictDoNothing({
-            target: [emailsRaw.userId, emailsRaw.gmailMessageId],
+            target: [emailsRaw.workspaceId, emailsRaw.userId, emailsRaw.gmailMessageId],
           });
         result.synced += insertResult.rowCount ?? 0;
         result.skipped += rows.length - (insertResult.rowCount ?? 0);
@@ -411,7 +414,7 @@ export async function syncEmails(
       const msg = retryMap.get(e.gmailMessageId);
       if (!msg) continue;
       try {
-        const row = messageToRow(msg, userId, userEmail);
+        const row = messageToRow(msg, userId, workspaceId, userEmail);
         if (row) {
           retryRows.push(row);
           recoveredIds.add(e.gmailMessageId);
@@ -425,7 +428,7 @@ export async function syncEmails(
           .insert(emailsRaw)
           .values(retryRows)
           .onConflictDoNothing({
-            target: [emailsRaw.userId, emailsRaw.gmailMessageId],
+            target: [emailsRaw.workspaceId, emailsRaw.userId, emailsRaw.gmailMessageId],
           });
         result.synced += insertResult.rowCount ?? 0;
         result.skipped += retryRows.length - (insertResult.rowCount ?? 0);
@@ -470,6 +473,7 @@ export async function syncEmails(
             .from(emailsRaw)
             .where(
               and(
+                eq(emailsRaw.workspaceId, workspaceId),
                 eq(emailsRaw.userId, userId),
                 isNull(emailsRaw.embedding),
               ),
@@ -479,7 +483,7 @@ export async function syncEmails(
     )];
 
     if (threadIds.length > 0) {
-      const embedded = await embedEmailThreads(userId, threadIds);
+      const embedded = await embedEmailThreads(userId, workspaceId, threadIds);
       logger.info("Email sync: embedded threads", {
         userId,
         threadsEmbedded: embedded,
@@ -524,6 +528,7 @@ function buildThreadText(
 
 async function embedEmailThreads(
   userId: string,
+  workspaceId: string,
   threadIds: string[],
 ): Promise<number> {
   const BATCH_SIZE = 50;
@@ -543,6 +548,7 @@ async function embedEmailThreads(
       .from(emailsRaw)
       .where(
         and(
+          eq(emailsRaw.workspaceId, workspaceId),
           eq(emailsRaw.userId, userId),
           inArray(emailsRaw.gmailThreadId, batchThreadIds),
         ),
@@ -580,6 +586,7 @@ async function embedEmailThreads(
           })
           .where(
             and(
+              eq(emailsRaw.workspaceId, workspaceId),
               eq(emailsRaw.userId, userId),
               eq(emailsRaw.gmailThreadId, orderedThreadIds[j]),
             ),
@@ -606,6 +613,7 @@ async function embedEmailThreads(
  */
 export async function backfillEmailEmbeddings(
   userId: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<{ embedded: number; errors: number }> {
   const result = { embedded: 0, errors: 0 };
 
@@ -614,6 +622,7 @@ export async function backfillEmailEmbeddings(
     .from(emailsRaw)
     .where(
       and(
+        eq(emailsRaw.workspaceId, workspaceId),
         eq(emailsRaw.userId, userId),
         isNull(emailsRaw.embedding),
       ),
@@ -629,7 +638,7 @@ export async function backfillEmailEmbeddings(
   logger.info("Backfill: starting", { userId, threads: threadIds.length });
 
   try {
-    result.embedded = await embedEmailThreads(userId, threadIds);
+    result.embedded = await embedEmailThreads(userId, workspaceId, threadIds);
   } catch (err) {
     logger.error("Backfill: failed", { userId, error: String(err) });
   }

--- a/src/lib/email-triage.ts
+++ b/src/lib/email-triage.ts
@@ -2,7 +2,7 @@ import { generateObject } from "ai";
 import { z } from "zod";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { emailsRaw } from "../db/schema.js";
+import { emailsRaw, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { getFastModel } from "./ai.js";
 import { logger } from "./logger.js";
 
@@ -100,6 +100,7 @@ ${threadText}`;
  */
 export async function computeThreadStates(
   userId: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<ThreadStateSummary> {
   const summary: ThreadStateSummary = {
     processed: 0,
@@ -119,7 +120,12 @@ export async function computeThreadStates(
       threadStateUpdatedAt: emailsRaw.threadStateUpdatedAt,
     })
     .from(emailsRaw)
-    .where(eq(emailsRaw.userId, userId));
+    .where(
+      and(
+        eq(emailsRaw.workspaceId, workspaceId),
+        eq(emailsRaw.userId, userId),
+      ),
+    );
 
   if (metaRows.length === 0) {
     logger.info("No emails found for user", { userId });
@@ -169,6 +175,7 @@ export async function computeThreadStates(
     .from(emailsRaw)
     .where(
       and(
+        eq(emailsRaw.workspaceId, workspaceId),
         eq(emailsRaw.userId, userId),
         inArray(emailsRaw.gmailThreadId, threadIdsBatch),
       ),
@@ -224,7 +231,8 @@ export async function computeThreadStates(
           updated_at = now()
         FROM (VALUES ${valuesList})
           AS v(thread_id, state, reason)
-        WHERE e.user_id = ${userId}
+        WHERE e.workspace_id = ${workspaceId}
+          AND e.user_id = ${userId}
           AND e.gmail_thread_id = v.thread_id
       `);
     } catch (err) {

--- a/src/lib/error-logger.ts
+++ b/src/lib/error-logger.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/client.js";
-import { errorEvents } from "../db/schema.js";
+import { errorEvents, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { logger } from "./logger.js";
 import { safePostMessage } from "./slack-messaging.js";
 
@@ -14,6 +14,7 @@ export interface LogErrorParams {
   channelType?: string;
   context?: Record<string, unknown>;
   stackTrace?: string;
+  workspaceId?: string;
 }
 
 // ── Rate Limiting ────────────────────────────────────────────────────────────
@@ -181,6 +182,7 @@ export function logError(params: LogErrorParams): void {
         channelType: params.channelType,
         context: params.context,
         stackTrace: params.stackTrace,
+        workspaceId: params.workspaceId ?? DEFAULT_WORKSPACE_ID,
       })
       .catch(() => {});
   }

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -112,9 +112,9 @@ async function createBaseOAuth2Client() {
  * Get an authenticated OAuth2Client for a given user.
  * No args = Aura's own token (U0AFEC1C69F). Pass a userId for per-user tokens.
  */
-export async function getOAuth2Client(userId?: string) {
+export async function getOAuth2Client(userId?: string, workspaceId?: string) {
   const resolvedUserId = userId || process.env.AURA_BOT_USER_ID || "aura";
-  const tokenRow = await getUserRefreshToken(resolvedUserId);
+  const tokenRow = await getUserRefreshToken(resolvedUserId, workspaceId);
   if (!tokenRow) return null;
 
   const oauth2Client = await createBaseOAuth2Client();
@@ -127,8 +127,8 @@ export async function getOAuth2Client(userId?: string) {
 /**
  * Returns an authenticated Gmail client for Aura, or null if credentials are missing.
  */
-export async function getGmailClient() {
-  const auth = await getOAuth2Client();
+export async function getGmailClient(workspaceId?: string) {
+  const auth = await getOAuth2Client(undefined, workspaceId);
   if (!auth) {
     logger.warn("Gmail: No OAuth2 client available (checked oauth_tokens and env)");
     return null;
@@ -716,12 +716,16 @@ export interface DraftSummary {
  */
 export async function getUserRefreshToken(
   userId: string,
+  workspaceId?: string,
 ): Promise<{ refreshToken: string; email: string | null } | null> {
   try {
     const { eq, and } = await import("drizzle-orm");
     const { db } = await import("../db/client.js");
-    const { oauthTokens } = await import("../db/schema.js");
+    const { oauthTokens, DEFAULT_WORKSPACE_ID } = await import(
+      "../db/schema.js"
+    );
 
+    const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
     const rows = await db
       .select({
         refreshToken: oauthTokens.refreshToken,
@@ -730,6 +734,7 @@ export async function getUserRefreshToken(
       .from(oauthTokens)
       .where(
         and(
+          eq(oauthTokens.workspaceId, wsId),
           eq(oauthTokens.userId, userId),
           eq(oauthTokens.provider, "google"),
         ),
@@ -754,13 +759,18 @@ export async function saveUserRefreshToken(
   userId: string,
   refreshToken: string,
   email?: string,
+  workspaceId?: string,
 ): Promise<void> {
   const { db } = await import("../db/client.js");
-  const { oauthTokens } = await import("../db/schema.js");
+  const { oauthTokens, DEFAULT_WORKSPACE_ID } = await import(
+    "../db/schema.js"
+  );
 
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
   await db
     .insert(oauthTokens)
     .values({
+      workspaceId: wsId,
       userId,
       provider: "google",
       refreshToken,
@@ -769,7 +779,7 @@ export async function saveUserRefreshToken(
       updatedAt: new Date(),
     })
     .onConflictDoUpdate({
-      target: [oauthTokens.userId, oauthTokens.provider],
+      target: [oauthTokens.workspaceId, oauthTokens.userId, oauthTokens.provider],
       set: {
         refreshToken,
         email: email || undefined,
@@ -785,8 +795,11 @@ export async function saveUserRefreshToken(
  * Get an authenticated Gmail client for a specific Slack user.
  * Returns null if the user has not authorized or credentials are missing.
  */
-export async function getGmailClientForUser(userId: string) {
-  const userToken = await getUserRefreshToken(userId);
+export async function getGmailClientForUser(
+  userId: string,
+  workspaceId?: string,
+) {
+  const userToken = await getUserRefreshToken(userId, workspaceId);
   if (!userToken) {
     logger.warn("Gmail: No OAuth token for user", { userId });
     return null;

--- a/src/lib/person-resolution.ts
+++ b/src/lib/person-resolution.ts
@@ -4,6 +4,7 @@ import {
   people,
   addresses,
   userProfiles,
+  DEFAULT_WORKSPACE_ID,
   type Person,
 } from "../db/schema.js";
 import { logger } from "./logger.js";
@@ -14,13 +15,21 @@ import { logger } from "./logger.js";
 export async function resolvePersonByAddress(
   channel: string,
   value: string,
+  workspaceId?: string,
 ): Promise<Person | null> {
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
   const normalised = normaliseValue(channel, value);
   const rows = await db
     .select({ person: people })
     .from(addresses)
     .innerJoin(people, eq(addresses.personId, people.id))
-    .where(and(eq(addresses.channel, channel), eq(addresses.value, normalised)))
+    .where(
+      and(
+        eq(addresses.workspaceId, wsId),
+        eq(addresses.channel, channel),
+        eq(addresses.value, normalised),
+      ),
+    )
     .limit(1);
 
   return rows.length > 0 ? rows[0].person : null;
@@ -34,10 +43,12 @@ export async function createPersonWithAddress(
   displayName: string | null,
   channel: string,
   value: string,
+  workspaceId?: string,
 ): Promise<Person> {
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
   const normalised = normaliseValue(channel, value);
 
-  const personValues: Record<string, unknown> = { displayName };
+  const personValues: Record<string, unknown> = { displayName, workspaceId: wsId };
   if (channel === "slack") {
     personValues.slackUserId = normalised;
   }
@@ -52,6 +63,7 @@ export async function createPersonWithAddress(
       .insert(addresses)
       .values({
         personId: person.id,
+        workspaceId: wsId,
         channel,
         value: normalised,
         isPrimary: true,
@@ -61,7 +73,7 @@ export async function createPersonWithAddress(
 
     if (insertedAddress.length === 0) {
       await db.delete(people).where(eq(people.id, person.id));
-      const existing = await resolvePersonByAddress(channel, value);
+      const existing = await resolvePersonByAddress(channel, value, wsId);
       if (!existing) {
         throw new Error(
           `Address conflict but could not resolve person for ${channel}:${value}`,
@@ -94,15 +106,23 @@ export async function linkProfileToPerson(
  * Ensure a profile is linked to a person (called from getOrCreateProfile).
  * Creates a person + slack address if one doesn't exist yet.
  */
-export async function ensurePersonLinked(profile: {
-  id: string;
-  slackUserId: string;
-  displayName: string | null;
-  personId?: string | null;
-}): Promise<string> {
+export async function ensurePersonLinked(
+  profile: {
+    id: string;
+    slackUserId: string;
+    displayName: string | null;
+    personId?: string | null;
+  },
+  workspaceId?: string,
+): Promise<string> {
   if (profile.personId) return profile.personId;
 
-  const existing = await resolvePersonByAddress("slack", profile.slackUserId);
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
+  const existing = await resolvePersonByAddress(
+    "slack",
+    profile.slackUserId,
+    wsId,
+  );
   if (existing) {
     await linkProfileToPerson(profile.id, existing.id);
     return existing.id;
@@ -112,6 +132,7 @@ export async function ensurePersonLinked(profile: {
     profile.displayName,
     "slack",
     profile.slackUserId,
+    wsId,
   );
   await linkProfileToPerson(profile.id, person.id);
   return person.id;
@@ -124,21 +145,23 @@ export async function ensurePersonLinked(profile: {
  *   2. Create an address row (channel='slack', value=slack_user_id, is_primary=true)
  *   3. Set user_profiles.person_id = new person.id
  */
-export async function backfillPeopleFromProfiles(): Promise<{
-  created: number;
-  skipped: number;
-}> {
+export async function backfillPeopleFromProfiles(
+  workspaceId?: string,
+): Promise<{ created: number; skipped: number }> {
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
   const unlinked = await db
     .select()
     .from(userProfiles)
-    .where(isNull(userProfiles.personId));
+    .where(
+      and(eq(userProfiles.workspaceId, wsId), isNull(userProfiles.personId)),
+    );
 
   let created = 0;
   let skipped = 0;
 
   for (const profile of unlinked) {
     try {
-      await ensurePersonLinked(profile);
+      await ensurePersonLinked(profile, wsId);
       created++;
     } catch (error) {
       logger.error("Failed to backfill profile", {
@@ -166,13 +189,20 @@ export async function backfillPeopleFromProfiles(): Promise<{
 export async function resolveOrCreateFromEmail(
   email: string,
   displayName: string | null,
+  workspaceId?: string,
 ): Promise<string> {
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
   const normEmail = email.toLowerCase();
 
-  const existing = await resolvePersonByAddress("email", normEmail);
+  const existing = await resolvePersonByAddress("email", normEmail, wsId);
   if (existing) return existing.id;
 
-  const person = await createPersonWithAddress(displayName, "email", normEmail);
+  const person = await createPersonWithAddress(
+    displayName,
+    "email",
+    normEmail,
+    wsId,
+  );
   return person.id;
 }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,17 +1,17 @@
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { settings } from "../db/schema.js";
+import { settings, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { logger } from "./logger.js";
 
 /**
  * Read a single setting by key. Returns null if not set.
  */
-export async function getSetting(key: string): Promise<string | null> {
+export async function getSetting(key: string, workspaceId: string = DEFAULT_WORKSPACE_ID): Promise<string | null> {
   try {
     const rows = await db
       .select({ value: settings.value })
       .from(settings)
-      .where(eq(settings.key, key))
+      .where(and(eq(settings.workspaceId, workspaceId), eq(settings.key, key)))
       .limit(1);
 
     return rows[0]?.value ?? null;
@@ -28,13 +28,14 @@ export async function setSetting(
   key: string,
   value: string,
   updatedBy?: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<void> {
   try {
     await db
       .insert(settings)
-      .values({ key, value, updatedBy, updatedAt: new Date() })
+      .values({ workspaceId, key, value, updatedBy, updatedAt: new Date() })
       .onConflictDoUpdate({
-        target: settings.key,
+        target: [settings.workspaceId, settings.key],
         set: { value, updatedBy, updatedAt: new Date() },
       });
 
@@ -48,9 +49,9 @@ export async function setSetting(
 /**
  * Read all settings as a key-value record.
  */
-export async function getAllSettings(): Promise<Record<string, string>> {
+export async function getAllSettings(workspaceId: string = DEFAULT_WORKSPACE_ID): Promise<Record<string, string>> {
   try {
-    const rows = await db.select().from(settings);
+    const rows = await db.select().from(settings).where(eq(settings.workspaceId, workspaceId));
     const result: Record<string, string> = {};
     for (const row of rows) {
       result[row.key] = row.value;
@@ -74,24 +75,26 @@ const JSON_CACHE_TTL_MS = 60_000; // 1 minute
 export async function getSettingJSON<T = unknown>(
   key: string,
   fallback: T | null = null,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<T | null> {
+  const cacheKey = `${workspaceId}:${key}`;
   const now = Date.now();
-  const cached = jsonSettingsCache.get(key);
+  const cached = jsonSettingsCache.get(cacheKey);
   if (cached && cached.expiresAt > now) return cached.value as T;
 
-  const raw = await getSetting(key);
+  const raw = await getSetting(key, workspaceId);
   if (raw === null) {
-    jsonSettingsCache.set(key, { value: fallback, expiresAt: now + JSON_CACHE_TTL_MS });
+    jsonSettingsCache.set(cacheKey, { value: fallback, expiresAt: now + JSON_CACHE_TTL_MS });
     return fallback;
   }
 
   try {
     const parsed = JSON.parse(raw) as T;
-    jsonSettingsCache.set(key, { value: parsed, expiresAt: now + JSON_CACHE_TTL_MS });
+    jsonSettingsCache.set(cacheKey, { value: parsed, expiresAt: now + JSON_CACHE_TTL_MS });
     return parsed;
   } catch {
     logger.warn("Failed to parse JSON setting", { key, raw });
-    jsonSettingsCache.set(key, { value: fallback, expiresAt: now + JSON_CACHE_TTL_MS });
+    jsonSettingsCache.set(cacheKey, { value: fallback, expiresAt: now + JSON_CACHE_TTL_MS });
     return fallback;
   }
 }

--- a/src/lib/skill-index.ts
+++ b/src/lib/skill-index.ts
@@ -10,19 +10,22 @@
  * - Level 3 (lazy): referenced resources executed when needed
  */
 
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { notes } from "../db/schema.js";
+import { notes, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 
 /**
  * Build a compact skill index for injection into system prompts.
  * Returns empty string if no skill notes exist.
  */
-export async function buildSkillIndex(): Promise<string> {
+export async function buildSkillIndex(
+  workspaceId?: string,
+): Promise<string> {
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
   const skills = await db
     .select({ topic: notes.topic, content: notes.content })
     .from(notes)
-    .where(eq(notes.category, "skill"));
+    .where(and(eq(notes.workspaceId, wsId), eq(notes.category, "skill")));
 
   if (skills.length === 0) return "";
 

--- a/src/memory/retrieve.ts
+++ b/src/memory/retrieve.ts
@@ -1,7 +1,7 @@
-import { sql, or, inArray } from "drizzle-orm";
+import { sql, or, inArray, and, eq } from "drizzle-orm";
 import { rerank } from "ai";
 import { db } from "../db/client.js";
-import { memories, messages, type Memory, type Message } from "../db/schema.js";
+import { memories, messages, type Memory, type Message, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { embedText } from "../lib/embeddings.js";
 import { getRerankingModel } from "../lib/ai.js";
 import { logger } from "../lib/logger.js";
@@ -13,6 +13,8 @@ interface RetrievalOptions {
   queryEmbedding?: number[];
   /** The Slack user ID of the person asking */
   currentUserId: string;
+  /** Workspace ID for multi-tenancy (defaults to "default") */
+  workspaceId?: string;
   /** Maximum number of memories to return */
   limit?: number;
   /** Minimum relevance score threshold */
@@ -64,7 +66,8 @@ async function extractLexemes(
 export async function retrieveMemories(
   options: RetrievalOptions,
 ): Promise<Memory[]> {
-  const { query, queryEmbedding: precomputed, currentUserId, limit = 20, minRelevanceScore = 0.1 } = options;
+  const { query, queryEmbedding: precomputed, currentUserId, workspaceId: wsIdOpt, limit = 20, minRelevanceScore = 0.1 } = options;
+  const wsId = wsIdOpt ?? DEFAULT_WORKSPACE_ID;
   const start = Date.now();
 
   try {
@@ -82,7 +85,7 @@ export async function retrieveMemories(
       OR ${memories.relatedUserIds} @> ARRAY[${currentUserId}]::text[]
     )`;
 
-    const baseFilter = sql`${memories.embedding} IS NOT NULL AND ${memories.relevanceScore} >= ${minRelevanceScore}`;
+    const baseFilter = sql`${memories.embedding} IS NOT NULL AND ${memories.relevanceScore} >= ${minRelevanceScore} AND ${memories.workspaceId} = ${wsId}`;
 
     logger.debug(`Extracted ${lexemes.length} lexemes for fulltext search`, {
       lexemes,
@@ -179,6 +182,7 @@ export async function retrieveMemories(
         relevanceScore: row.relevance_score ?? 1,
         shareable: row.shareable ?? 0,
         searchVector: row.search_vector ?? null,
+        workspaceId: row.workspace_id ?? DEFAULT_WORKSPACE_ID,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
       } as Memory,
@@ -283,6 +287,8 @@ interface ConversationRetrievalOptions {
   query: string;
   /** Pre-computed query embedding (avoids double-embedding when called alongside retrieveMemories) */
   queryEmbedding?: number[];
+  /** Workspace ID for multi-tenancy (defaults to "default") */
+  workspaceId?: string;
   /** Maximum number of individual message matches to search */
   matchLimit?: number;
   /** Maximum number of conversation threads to return */
@@ -309,11 +315,13 @@ export async function retrieveConversations(
   const {
     query,
     queryEmbedding: precomputed,
+    workspaceId: wsIdOpt,
     matchLimit = 20,
     threadLimit = 5,
     minSimilarity = 0.3,
     excludeThreadTs,
   } = options;
+  const wsId = wsIdOpt ?? DEFAULT_WORKSPACE_ID;
   const start = Date.now();
 
   try {
@@ -327,7 +335,7 @@ export async function retrieveConversations(
         similarity: sql<number>`1 - (${messages.embedding} <=> ${embeddingLiteral}::vector)`.as("similarity"),
       })
       .from(messages)
-      .where(sql`${messages.embedding} IS NOT NULL`)
+      .where(and(sql`${messages.embedding} IS NOT NULL`, eq(messages.workspaceId, wsId)))
       .orderBy(sql`${messages.embedding} <=> ${embeddingLiteral}::vector`)
       .limit(matchLimit);
 
@@ -388,10 +396,13 @@ export async function retrieveConversations(
       .select()
       .from(messages)
       .where(
-        or(
-          inArray(messages.slackThreadTs, threadKeys),
-          inArray(messages.slackTs, threadKeys),
-        )!,
+        and(
+          eq(messages.workspaceId, wsId),
+          or(
+            inArray(messages.slackThreadTs, threadKeys),
+            inArray(messages.slackTs, threadKeys),
+          )!,
+        ),
       )
       .orderBy(messages.createdAt);
 

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,6 +1,6 @@
 import { eq, sql, isNull, and } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { messages, memories, notes, eventLocks, type NewMessage, type NewMemory } from "../db/schema.js";
+import { messages, memories, notes, eventLocks, DEFAULT_WORKSPACE_ID, type NewMessage, type NewMemory } from "../db/schema.js";
 import { embedText, embedTexts } from "../lib/embeddings.js";
 import { logger } from "../lib/logger.js";
 import type { ToolCallRecord } from "../pipeline/respond.js";
@@ -18,10 +18,10 @@ export function toDbChannelType(ct: ChannelType): DbChannelType {
  * Returns true if this caller claimed the event, false if it was already claimed.
  * Safe against race conditions — uses INSERT ... ON CONFLICT DO NOTHING RETURNING id.
  */
-export async function claimEvent(eventTs: string, channelId: string): Promise<boolean> {
+export async function claimEvent(eventTs: string, channelId: string, workspaceId?: string): Promise<boolean> {
   const result = await db
     .insert(eventLocks)
-    .values({ eventTs, channelId })
+    .values({ eventTs, channelId, workspaceId: workspaceId ?? DEFAULT_WORKSPACE_ID })
     .onConflictDoNothing()
     .returning({ id: eventLocks.id });
   return result.length > 0;
@@ -267,6 +267,7 @@ interface ToolCallStorageContext {
   channelId: string;
   channelType: ChannelType;
   userId: string;
+  workspaceId?: string;
 }
 
 /**
@@ -285,6 +286,7 @@ export async function storeToolCallMessages(
     channelId: ctx.channelId,
     channelType: toDbChannelType(ctx.channelType),
     userId: ctx.userId,
+    workspaceId: ctx.workspaceId ?? DEFAULT_WORKSPACE_ID,
     role: "tool" as const,
     content: summarizeToolCall(tc),
     metadata: {
@@ -350,6 +352,7 @@ export async function storeChannelReadMessage(
     channelId: ctx.channelId,
     channelType: toDbChannelType(ctx.channelType),
     userId: ctx.userId,
+    workspaceId: ctx.workspaceId ?? DEFAULT_WORKSPACE_ID,
     role: "tool" as const,
     content,
     metadata: {

--- a/src/memory/transparency.ts
+++ b/src/memory/transparency.ts
@@ -1,6 +1,6 @@
-import { eq, sql, and, like, or, arrayContains } from "drizzle-orm";
+import { eq, sql, and } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { memories, userProfiles, type Memory } from "../db/schema.js";
+import { memories, userProfiles, DEFAULT_WORKSPACE_ID, type Memory } from "../db/schema.js";
 import { logger } from "../lib/logger.js";
 import { embedText } from "../lib/embeddings.js";
 
@@ -18,6 +18,7 @@ import { embedText } from "../lib/embeddings.js";
  */
 export async function getKnowledgeAboutUser(
   slackUserId: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<{
   profile: {
     displayName: string;
@@ -33,7 +34,7 @@ export async function getKnowledgeAboutUser(
   const [profile] = await db
     .select()
     .from(userProfiles)
-    .where(eq(userProfiles.slackUserId, slackUserId))
+    .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)))
     .limit(1);
 
   // Get all memories related to this user
@@ -46,7 +47,10 @@ export async function getKnowledgeAboutUser(
     })
     .from(memories)
     .where(
-      sql`${slackUserId} = ANY(${memories.relatedUserIds})`,
+      and(
+        eq(memories.workspaceId, workspaceId),
+        sql`${slackUserId} = ANY(${memories.relatedUserIds})`,
+      ),
     )
     .orderBy(sql`${memories.relevanceScore} DESC`)
     .limit(50);
@@ -155,6 +159,7 @@ export function formatKnowledgeSummary(
 export async function forgetMemories(
   slackUserId: string,
   whatToForget: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<{
   forgottenCount: number;
   examples: string[];
@@ -176,6 +181,7 @@ export async function forgetMemories(
       .from(memories)
       .where(
         and(
+          eq(memories.workspaceId, workspaceId),
           sql`${slackUserId} = ANY(${memories.relatedUserIds})`,
           sql`${memories.embedding} IS NOT NULL`,
         ),

--- a/src/personality/system-prompt.ts
+++ b/src/personality/system-prompt.ts
@@ -1,7 +1,7 @@
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
 import type { Memory, UserProfile } from "../db/schema.js";
-import { notes } from "../db/schema.js";
+import { notes, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { getCurrentTimeContext, relativeTime } from "../lib/temporal.js";
 import { buildSkillIndex } from "../lib/skill-index.js";
 import { logger } from "../lib/logger.js";
@@ -37,6 +37,8 @@ interface SystemPromptContext {
   mentionedPeople?: PersonProfile[];
   /** The person sending the message, looked up from the people DB */
   interlocutor?: PersonProfile;
+  /** Workspace ID for notes filtering */
+  workspaceId?: string;
 }
 
 /**
@@ -389,11 +391,12 @@ export async function buildSystemPrompt(
   // Self-directive: agent's own persistent context, loaded every invocation
   // Hard cap at ~2000 tokens (~8000 chars) to prevent context-window overflow
   const SELF_DIRECTIVE_MAX_CHARS = 8000;
+  const wsId = context.workspaceId ?? DEFAULT_WORKSPACE_ID;
   try {
     const rows = await db
       .select({ content: notes.content })
       .from(notes)
-      .where(eq(notes.topic, "self-directive"))
+      .where(and(eq(notes.workspaceId, wsId), eq(notes.topic, "self-directive")))
       .limit(1);
     if (rows[0]?.content) {
       let content = rows[0].content;
@@ -420,7 +423,7 @@ export async function buildSystemPrompt(
     const indexRows = await db
       .select({ content: notes.content })
       .from(notes)
-      .where(eq(notes.topic, "notes-index"))
+      .where(and(eq(notes.workspaceId, wsId), eq(notes.topic, "notes-index")))
       .limit(1);
     if (indexRows[0]?.content) {
       let indexContent = indexRows[0].content;
@@ -442,7 +445,7 @@ export async function buildSystemPrompt(
   }
 
   // Skill index (progressive disclosure -- lightweight topic + first line)
-  const skillIndex = await buildSkillIndex();
+  const skillIndex = await buildSkillIndex(wsId);
   if (skillIndex) {
     stableParts.push(skillIndex);
   }

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -29,6 +29,7 @@ import {
 import { downloadEventFiles } from "../lib/files.js";
 import { pauseSandbox } from "../lib/sandbox.js";
 import { getSettingJSON } from "../lib/settings.js";
+import { DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { logger } from "../lib/logger.js";
 import { logError } from "../lib/error-logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
@@ -134,7 +135,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
   }
 
   // 1a. Dedup: atomically claim this event; skip if another handler got there first
-  const claimed = await claimEvent(context.messageTs, context.channelId);
+  const claimed = await claimEvent(context.messageTs, context.channelId, teamId);
   if (!claimed) {
     logger.debug("Skipping duplicate event", {
       ts: context.messageTs,
@@ -180,7 +181,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       channelId: context.channelId,
     });
     // Still store the message for long-term memory, but don't respond
-    const storePromise = storeUserMessage(context, event);
+    const storePromise = storeUserMessage(context, event, teamId);
     if (waitUntil) {
       waitUntil(storePromise);
     } else {
@@ -273,7 +274,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
 
     // Ensure user has a profile and resolve their timezone
     const { name: displayName, timezone: slackTimezone } = await resolveDisplayName(client, context.userId);
-    const userProfile = await getOrCreateProfile(context.userId, displayName, slackTimezone);
+    const userProfile = await getOrCreateProfile(context.userId, displayName, slackTimezone, teamId);
     const userTimezone = userProfile.timezone || "UTC";
 
     // 3. Check for transparency commands first
@@ -281,6 +282,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       { ...context, text: messageText },
       client,
       replyThreadTs,
+      teamId,
     );
     if (transparencyResult) {
       recordPipelineMetrics({
@@ -308,6 +310,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       { ...context, text: messageText },
       conversation,
       client,
+      teamId,
     );
     const retrievalMs = Date.now() - retrievalStart;
 
@@ -329,7 +332,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       dynamicContext,
       userMessage: messageText,
       slackClient: client,
-      context: { userId: context.userId, channelId: context.channelId, threadTs: replyThreadTs, timezone: userTimezone },
+      context: { workspaceId: teamId, userId: context.userId, channelId: context.channelId, threadTs: replyThreadTs, timezone: userTimezone },
       files: fileParts,
       channelId: context.channelId,
       threadTs: replyThreadTs,
@@ -392,6 +395,7 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       displayName,
       client,
       threadMessageCount: conversation.thread?.length ?? 0,
+      workspaceId: teamId,
       ...(() => {
         const all = (conversation.thread ?? conversation.recentMessages)
           .map(m => ({ displayName: m.displayName, text: m.text }));
@@ -462,8 +466,10 @@ async function handleTransparencyCommands(
   context: MessageContext,
   client: WebClient,
   replyThreadTs?: string,
+  workspaceId?: string,
 ): Promise<boolean> {
   const text = context.text.toLowerCase().trim();
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
 
   // "What do you know about me?" command
   if (
@@ -471,7 +477,7 @@ async function handleTransparencyCommands(
     text.includes("what do you remember about me")
   ) {
     try {
-      const knowledge = await getKnowledgeAboutUser(context.userId);
+      const knowledge = await getKnowledgeAboutUser(context.userId, wsId);
       const summary = formatKnowledgeSummary(knowledge);
       await safePostMessage(client, {
         channel: context.channelId,
@@ -507,9 +513,10 @@ async function handleTransparencyCommands(
 /**
  * Store the user's message in the background.
  */
-async function storeUserMessage(context: MessageContext, event: SlackEvent): Promise<void> {
+async function storeUserMessage(context: MessageContext, event: SlackEvent, workspaceId?: string): Promise<void> {
   try {
     await storeMessage({
+      workspaceId: workspaceId ?? DEFAULT_WORKSPACE_ID,
       slackTs: context.messageTs,
       slackThreadTs: context.threadTs,
       channelId: context.channelId,
@@ -546,12 +553,15 @@ async function runBackgroundTasks(params: {
   threadMessageCount: number;
   recentThreadMessages: Array<{ displayName: string; text: string }>;
   threadMessagesElided: boolean;
+  workspaceId?: string;
 }): Promise<void> {
-  const { context, event, response, toolCalls, displayName, client, threadMessageCount, recentThreadMessages, threadMessagesElided } = params;
+  const { context, event, response, toolCalls, displayName, client, threadMessageCount, recentThreadMessages, threadMessagesElided, workspaceId } = params;
+  const wsId = workspaceId ?? DEFAULT_WORKSPACE_ID;
 
   try {
     // Store the user's message
     const userMessageId = await storeMessage({
+      workspaceId: wsId,
       slackTs: context.messageTs,
       slackThreadTs: context.threadTs,
       channelId: context.channelId,
@@ -565,6 +575,7 @@ async function runBackgroundTasks(params: {
     // Store Aura's response with a pseudo-timestamp
     const assistantTs = `${context.messageTs}-aura`;
     await storeMessage({
+      workspaceId: wsId,
       slackTs: assistantTs,
       slackThreadTs: context.threadTs || context.messageTs,
       channelId: context.channelId,
@@ -582,6 +593,7 @@ async function runBackgroundTasks(params: {
         channelId: context.channelId,
         channelType: context.channelType,
         userId: context.userId,
+        workspaceId: wsId,
       };
 
       await storeToolCallMessages(toolCalls, storageCtx);
@@ -617,11 +629,12 @@ async function runBackgroundTasks(params: {
     });
 
     // Record interaction and potentially update profile
-    await recordInteraction(context.userId);
+    await recordInteraction(context.userId, wsId);
     await updateProfileFromConversation(
       context.userId,
       context.text,
       response,
+      wsId,
     );
 
     // Set or update DM thread title for the Assistant History tab.

--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -40,6 +40,7 @@ export async function assemblePrompt(
   context: MessageContext,
   conversation: ConversationContext,
   client?: WebClient,
+  workspaceId?: string,
 ): Promise<AssembledPrompt> {
   const start = Date.now();
 
@@ -77,6 +78,7 @@ export async function assemblePrompt(
           query: queryText,
           queryEmbedding,
           currentUserId: context.userId,
+          workspaceId,
           limit: 15,
         })
       : Promise.resolve([] as Memory[]),
@@ -84,13 +86,14 @@ export async function assemblePrompt(
       ? retrieveConversations({
           query: queryText,
           queryEmbedding,
+          workspaceId,
           threadLimit: 3,
           matchLimit: 15,
           minSimilarity: 0.35,
           excludeThreadTs: context.threadTs,
         })
       : Promise.resolve([] as ConversationThread[]),
-    getProfile(context.userId),
+    getProfile(context.userId, workspaceId),
     lookupMentionedPeople(mentionedUserIds),
     lookupPerson(context.userId),
   ]);
@@ -137,6 +140,7 @@ export async function assemblePrompt(
     isChannelHistory,
     mentionedPeople,
     interlocutor: interlocutor ?? undefined,
+    workspaceId,
   });
 
   // Dynamic per-call context — separated so the stable prompt stays cache-friendly

--- a/src/pipeline/respond.ts
+++ b/src/pipeline/respond.ts
@@ -129,7 +129,13 @@ interface RespondOptions {
   dynamicContext?: string;
   userMessage: string;
   slackClient: WebClient;
-  context?: { userId?: string; channelId?: string; threadTs?: string; timezone?: string };
+  context?: {
+    userId?: string;
+    channelId?: string;
+    threadTs?: string;
+    timezone?: string;
+    workspaceId?: string;
+  };
   files?: FileContentPart[];
   channelId: string;
   threadTs?: string;

--- a/src/tools/conversations.ts
+++ b/src/tools/conversations.ts
@@ -2,7 +2,7 @@ import { defineTool } from "../lib/tool.js";
 import { z } from "zod";
 import { sql, and, eq, gte, lte } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { messages } from "../db/schema.js";
+import { messages, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { embedText } from "../lib/embeddings.js";
 import { logger } from "../lib/logger.js";
@@ -47,6 +47,7 @@ export interface ThreadGroup {
 }
 
 export function createConversationSearchTools(context?: ScheduleContext) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
   return {
     search_my_conversations: defineTool({
       description:
@@ -117,7 +118,7 @@ export function createConversationSearchTools(context?: ScheduleContext) {
             };
           }
 
-          const conditions: ReturnType<typeof eq>[] = [];
+          const conditions: ReturnType<typeof eq>[] = [eq(messages.workspaceId, wsId)];
 
           if (user_id) {
             conditions.push(eq(messages.userId, user_id));
@@ -285,6 +286,7 @@ export function createConversationSearchTools(context?: ScheduleContext) {
                   FROM messages
                   WHERE (slack_thread_ts = ${threadKey} OR slack_ts = ${threadKey})
                     AND channel_id = ${thread.channel_id}
+                    AND workspace_id = ${wsId}
                   ORDER BY created_at ASC
                   LIMIT 20
                 `);

--- a/src/tools/cursor-agent.ts
+++ b/src/tools/cursor-agent.ts
@@ -1,8 +1,8 @@
 import { defineTool } from "../lib/tool.js";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { notes } from "../db/schema.js";
+import { notes, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
@@ -14,6 +14,7 @@ const DEFAULT_REPO = process.env.DEFAULT_GITHUB_REPO ?? "AuraHQ-ai/aura";
  * Provides async dispatch of Cursor agents for complex multi-file code tasks.
  */
 export function createCursorAgentTools(context?: ScheduleContext) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
   return {
     dispatch_cursor_agent: defineTool({
       description:
@@ -144,6 +145,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
           await db
             .insert(notes)
             .values({
+              workspaceId: wsId,
               topic: `cursor-agent:${result.id}`,
               content: trackingContent,
               category: "plan",
@@ -151,7 +153,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
               updatedAt: new Date(),
             })
             .onConflictDoUpdate({
-              target: notes.topic,
+              target: [notes.workspaceId, notes.topic],
               set: {
                 content: trackingContent,
                 category: "plan",
@@ -297,7 +299,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
           const trackingRows = await db
             .select({ content: notes.content })
             .from(notes)
-            .where(eq(notes.topic, `cursor-agent:${agent_id}`))
+            .where(and(eq(notes.workspaceId, wsId), eq(notes.topic, `cursor-agent:${agent_id}`)))
             .limit(1);
 
           if (trackingRows[0]?.content) {
@@ -307,6 +309,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
             await db
               .insert(notes)
               .values({
+                workspaceId: wsId,
                 topic: `cursor-agent:${agent_id}`,
                 content: trackingRows[0].content + followupNote,
                 category: "plan",
@@ -314,7 +317,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
                 updatedAt: new Date(),
               })
               .onConflictDoUpdate({
-                target: notes.topic,
+                target: [notes.workspaceId, notes.topic],
                 set: {
                   content: trackingRows[0].content + followupNote,
                   expiresAt: sevenDays,

--- a/src/tools/email-sync.ts
+++ b/src/tools/email-sync.ts
@@ -6,7 +6,7 @@ import type { WebClient } from "@slack/web-api";
 import { logger } from "../lib/logger.js";
 import { isAdmin } from "../lib/permissions.js";
 import { db } from "../db/client.js";
-import { emailsRaw } from "../db/schema.js";
+import { emailsRaw, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { resolveUserByName } from "./slack.js";
 import { threadStateValues } from "../lib/email-triage.js";
@@ -18,6 +18,8 @@ export function createEmailSyncTools(
   client: WebClient,
   context?: ScheduleContext,
 ) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
+
   return {
     sync_emails: defineTool({
       description:
@@ -103,7 +105,7 @@ export function createEmailSyncTools(
             }
           }
 
-          const syncResult = await syncEmails(user.id, {
+          const syncResult = await syncEmails(user.id, wsId, {
             query: gmailQuery,
             maxMessages: max_messages || 500,
           });
@@ -117,7 +119,7 @@ export function createEmailSyncTools(
             const { computeThreadStates } = await import(
               "../lib/email-triage.js"
             );
-            threadStates = await computeThreadStates(user.id);
+            threadStates = await computeThreadStates(user.id, wsId);
           }
 
           const syncSummary = `Synced ${syncResult.synced} emails (${syncResult.skipped} already existed, ${syncResult.errors} errors)`;
@@ -213,6 +215,7 @@ export function createEmailSyncTools(
             .from(emailsRaw)
             .where(
               and(
+                eq(emailsRaw.workspaceId, wsId),
                 eq(emailsRaw.userId, userId),
                 stateFilter,
               ),
@@ -259,6 +262,7 @@ export function createEmailSyncTools(
             .from(emailsRaw)
             .where(
               and(
+                eq(emailsRaw.workspaceId, wsId),
                 eq(emailsRaw.userId, userId),
                 inArray(emailsRaw.gmailThreadId, threadIds)
               )
@@ -369,9 +373,11 @@ export function createEmailSyncTools(
 
           const userId = user.id;
 
-          const conditions = [eq(emailsRaw.userId, userId)];
-
-          conditions.push(eq(emailsRaw.gmailThreadId, gmail_thread_id));
+          const conditions = [
+            eq(emailsRaw.workspaceId, wsId),
+            eq(emailsRaw.userId, userId),
+            eq(emailsRaw.gmailThreadId, gmail_thread_id),
+          ];
 
           // Find distinct threads that match
           const matchingThreads = await db
@@ -400,6 +406,7 @@ export function createEmailSyncTools(
             })
             .where(
               and(
+                eq(emailsRaw.workspaceId, wsId),
                 eq(emailsRaw.userId, userId),
                 inArray(emailsRaw.gmailThreadId, threadIds),
               ),
@@ -503,6 +510,7 @@ export function createEmailSyncTools(
                 })
                 .where(
                   and(
+                    eq(emailsRaw.workspaceId, wsId),
                     eq(emailsRaw.userId, userId),
                     eq(emailsRaw.gmailThreadId, update.gmail_thread_id),
                   ),
@@ -616,7 +624,10 @@ export function createEmailSyncTools(
           }
 
           const userId = user.id;
-          const conditions = [eq(emailsRaw.userId, userId)];
+          const conditions = [
+            eq(emailsRaw.workspaceId, wsId),
+            eq(emailsRaw.userId, userId),
+          ];
 
           if (thread_state) {
             conditions.push(eq(emailsRaw.threadState, thread_state));

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -4,7 +4,7 @@ import { eq, and, or, desc, isNotNull, ne, sql } from "drizzle-orm";
 import type { WebClient } from "@slack/web-api";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
-import { jobs, jobExecutions } from "../db/schema.js";
+import { jobs, jobExecutions, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { FrequencyConfig, ScheduleContext } from "../db/schema.js";
 import { waitUntil } from "@vercel/functions";
 import { isAdmin } from "../lib/permissions.js";
@@ -25,6 +25,7 @@ export function createJobTools(
   client: WebClient,
   context?: ScheduleContext,
 ) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
   return {
     create_job: defineTool({
       description:
@@ -144,7 +145,7 @@ export function createJobTools(
             const existing = await db
               .select({ cronSchedule: jobs.cronSchedule, timezone: jobs.timezone })
               .from(jobs)
-              .where(eq(jobs.name, name))
+              .where(and(eq(jobs.workspaceId, wsId), eq(jobs.name, name)))
               .limit(1);
 
             if (existing.length > 0 && existing[0].cronSchedule) {
@@ -186,6 +187,7 @@ export function createJobTools(
               .from(jobs)
               .where(
                 and(
+                  eq(jobs.workspaceId, wsId),
                   eq(jobs.requestedBy, requestedBy),
                   eq(jobs.status, "pending"),
                   eq(jobs.enabled, 1),
@@ -221,6 +223,7 @@ export function createJobTools(
           await db
             .insert(jobs)
             .values({
+              workspaceId: wsId,
               name: jobName,
               description,
               playbook: playbook || null,
@@ -235,7 +238,7 @@ export function createJobTools(
               updatedAt: new Date(),
             })
             .onConflictDoUpdate({
-              target: jobs.name,
+              target: [jobs.workspaceId, jobs.name],
               set: updateSet,
             });
 
@@ -287,7 +290,7 @@ export function createJobTools(
       }),
       execute: async ({ status, recurring_only, limit }) => {
         try {
-          const conditions = [eq(jobs.status, status)];
+          const conditions = [eq(jobs.workspaceId, wsId), eq(jobs.status, status)];
           if (recurring_only) {
             conditions.push(
               and(isNotNull(jobs.cronSchedule), ne(jobs.cronSchedule, ""))!,
@@ -355,8 +358,8 @@ export function createJobTools(
           }
 
           const condition = job_id
-            ? eq(jobs.id, job_id)
-            : eq(jobs.name, name!);
+            ? and(eq(jobs.workspaceId, wsId), eq(jobs.id, job_id))!
+            : and(eq(jobs.workspaceId, wsId), eq(jobs.name, name!))!;
 
           const rows = await db
             .select()
@@ -462,6 +465,7 @@ export function createJobTools(
           const [job] = await db
             .insert(jobs)
             .values({
+              workspaceId: wsId,
               name: jobName,
               description: task,
               playbook: playbook || null,
@@ -553,7 +557,7 @@ export function createJobTools(
             const [job] = await db
               .select({ id: jobs.id })
               .from(jobs)
-              .where(eq(jobs.name, job_name))
+              .where(and(eq(jobs.workspaceId, wsId), eq(jobs.name, job_name)))
               .limit(1);
             if (!job)
               return {
@@ -567,8 +571,8 @@ export function createJobTools(
 
           const query = db.select().from(jobExecutions);
           const executions = await (condition
-            ? query.where(condition)
-            : query
+            ? query.where(and(eq(jobExecutions.workspaceId, wsId), condition)!)
+            : query.where(eq(jobExecutions.workspaceId, wsId))
           )
             .orderBy(desc(jobExecutions.startedAt))
             .limit(limit);

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -2,7 +2,7 @@ import { defineTool } from "../lib/tool.js";
 import { z } from "zod";
 import { eq, and, gt, or, isNull, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { notes, jobs } from "../db/schema.js";
+import { notes, jobs, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
@@ -23,6 +23,7 @@ function withLineNumbers(content: string): string {
 /** Fetch a note by topic. */
 async function getNoteByTopic(
   topic: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<{
   id: string;
   topic: string;
@@ -34,7 +35,7 @@ async function getNoteByTopic(
   const rows = await db
     .select()
     .from(notes)
-    .where(eq(notes.topic, topic))
+    .where(and(eq(notes.workspaceId, workspaceId), eq(notes.topic, topic)))
     .limit(1);
   return rows[0] ?? null;
 }
@@ -46,9 +47,9 @@ function parseContinuationDepth(content: string): number {
 }
 
 /** Fire-and-forget: embed note content and update the embedding column. Uses updatedAt guard to avoid stale writes. */
-function updateNoteEmbedding(text: string, topic: string, savedAt: Date): void {
+function updateNoteEmbedding(text: string, topic: string, savedAt: Date, workspaceId: string = DEFAULT_WORKSPACE_ID): void {
   embedText(text).then(embedding => {
-    db.update(notes).set({ embedding }).where(and(eq(notes.topic, topic), eq(notes.updatedAt, savedAt))).catch(e => logger.error("Note embedding failed", { topic, error: String(e) }));
+    db.update(notes).set({ embedding }).where(and(eq(notes.workspaceId, workspaceId), eq(notes.topic, topic), eq(notes.updatedAt, savedAt))).catch(e => logger.error("Note embedding failed", { topic, error: String(e) }));
   }).catch(e => logger.error("Note embedText failed", { topic, error: String(e) }));
 }
 
@@ -61,6 +62,8 @@ function updateNoteEmbedding(text: string, topic: string, savedAt: Date): void {
  * @param context Optional schedule context for checkpoint_plan routing (channelId, threadTs, userId)
  */
 export function createNoteTools(context?: ScheduleContext) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
+
   return {
     save_note: defineTool({
       description:
@@ -127,6 +130,7 @@ export function createNoteTools(context?: ScheduleContext) {
           await db
             .insert(notes)
             .values({
+              workspaceId: wsId,
               topic,
               content,
               category: effectiveCategory,
@@ -134,11 +138,11 @@ export function createNoteTools(context?: ScheduleContext) {
               updatedAt: savedAt,
             })
             .onConflictDoUpdate({
-              target: notes.topic,
+              target: [notes.workspaceId, notes.topic],
               set: updateSet,
             });
 
-          updateNoteEmbedding(content, topic, savedAt);
+          updateNoteEmbedding(content, topic, savedAt, wsId);
 
           logger.info("save_note tool called", {
             topic,
@@ -169,7 +173,7 @@ export function createNoteTools(context?: ScheduleContext) {
       }),
       execute: async ({ topic }) => {
         try {
-          const note = await getNoteByTopic(topic);
+          const note = await getNoteByTopic(topic, wsId);
           if (!note) {
             return {
               ok: false,
@@ -214,7 +218,7 @@ export function createNoteTools(context?: ScheduleContext) {
       execute: async ({ category }) => {
         try {
           const now = new Date();
-          const conditions = [];
+          const conditions = [eq(notes.workspaceId, wsId)];
 
           if (category) {
             conditions.push(eq(notes.category, category));
@@ -313,7 +317,7 @@ export function createNoteTools(context?: ScheduleContext) {
             return { ok: false, error: "Only admins can edit the self-directive." };
           }
 
-          const note = await getNoteByTopic(topic);
+          const note = await getNoteByTopic(topic, wsId);
           if (!note) {
             return {
               ok: false,
@@ -389,9 +393,9 @@ export function createNoteTools(context?: ScheduleContext) {
           await db
             .update(notes)
             .set({ content: newContent, embedding: null, updatedAt: savedAt })
-            .where(eq(notes.topic, topic));
+            .where(and(eq(notes.workspaceId, wsId), eq(notes.topic, topic)));
 
-          updateNoteEmbedding(newContent, topic, savedAt);
+          updateNoteEmbedding(newContent, topic, savedAt, wsId);
 
           const finalLineCount = newContent.split("\n").length;
 
@@ -432,7 +436,7 @@ export function createNoteTools(context?: ScheduleContext) {
             return { ok: false, error: "Only admins can delete the self-directive." };
           }
 
-          const note = await getNoteByTopic(topic);
+          const note = await getNoteByTopic(topic, wsId);
           if (!note) {
             return {
               ok: false,
@@ -440,7 +444,7 @@ export function createNoteTools(context?: ScheduleContext) {
             };
           }
 
-          await db.delete(notes).where(eq(notes.topic, topic));
+          await db.delete(notes).where(and(eq(notes.workspaceId, wsId), eq(notes.topic, topic)));
 
           logger.info("delete_note tool called", { topic });
 
@@ -503,6 +507,7 @@ export function createNoteTools(context?: ScheduleContext) {
               .from(notes)
               .where(
                 and(
+                  eq(notes.workspaceId, wsId),
                   sql`${notes.embedding} IS NOT NULL`,
                   or(isNull(notes.expiresAt), gt(notes.expiresAt, new Date()))!,
                 ),
@@ -543,7 +548,8 @@ export function createNoteTools(context?: ScheduleContext) {
                   websearch_to_tsquery('english', unaccent(${trimmed}))
                 ) as rank
               FROM notes
-              WHERE to_tsvector('english', unaccent(content))
+              WHERE workspace_id = ${wsId}
+                AND to_tsvector('english', unaccent(content))
                 @@ websearch_to_tsquery('english', unaccent(${trimmed}))
                 AND (expires_at IS NULL OR expires_at > now())
               ORDER BY rank DESC
@@ -561,7 +567,8 @@ export function createNoteTools(context?: ScheduleContext) {
                 substring(content from greatest(1, position(lower(${trimmed}) in lower(content)) - 100)
                   for 200) as snippet
               FROM notes
-              WHERE lower(content) LIKE ${pattern} ESCAPE '\\'
+              WHERE workspace_id = ${wsId}
+                AND lower(content) LIKE ${pattern} ESCAPE '\\'
                 AND (expires_at IS NULL OR expires_at > now())
               ORDER BY updated_at DESC
               LIMIT ${limit}
@@ -648,7 +655,7 @@ export function createNoteTools(context?: ScheduleContext) {
           }
 
           // Read existing plan note to check continuation depth
-          const existing = await getNoteByTopic(topic);
+          const existing = await getNoteByTopic(topic, wsId);
           let depth = 0;
           if (existing) {
             depth = parseContinuationDepth(existing.content);
@@ -667,6 +674,7 @@ export function createNoteTools(context?: ScheduleContext) {
             await db
               .insert(notes)
               .values({
+                workspaceId: wsId,
                 topic,
                 content: noteContent,
                 category: "plan",
@@ -674,7 +682,7 @@ export function createNoteTools(context?: ScheduleContext) {
                 updatedAt: savedAt,
               })
               .onConflictDoUpdate({
-                target: notes.topic,
+                target: [notes.workspaceId, notes.topic],
                 set: {
                   content: noteContent,
                   category: "plan",
@@ -684,7 +692,7 @@ export function createNoteTools(context?: ScheduleContext) {
                 },
               });
 
-            updateNoteEmbedding(noteContent, topic, savedAt);
+            updateNoteEmbedding(noteContent, topic, savedAt, wsId);
 
             logger.info("checkpoint_plan: depth limit reached", {
               topic,
@@ -715,6 +723,7 @@ export function createNoteTools(context?: ScheduleContext) {
           await db
             .insert(notes)
             .values({
+              workspaceId: wsId,
               topic,
               content: noteContent,
               category: "plan",
@@ -722,7 +731,7 @@ export function createNoteTools(context?: ScheduleContext) {
               updatedAt: savedAt,
             })
             .onConflictDoUpdate({
-              target: notes.topic,
+              target: [notes.workspaceId, notes.topic],
               set: {
                 content: noteContent,
                 category: "plan",
@@ -732,10 +741,11 @@ export function createNoteTools(context?: ScheduleContext) {
               },
             });
 
-          updateNoteEmbedding(noteContent, topic, savedAt);
+          updateNoteEmbedding(noteContent, topic, savedAt, wsId);
 
           // 2. Insert a continuation job with channelId + threadTs for routing
           await db.insert(jobs).values({
+            workspaceId: wsId,
             name: `continue-${topic}-${Date.now().toString(36)}`,
             description,
             executeAt,

--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -8,6 +8,7 @@ import {
   addresses,
   userProfiles,
   messages,
+  DEFAULT_WORKSPACE_ID,
   type ScheduleContext,
 } from "../db/schema.js";
 
@@ -19,6 +20,7 @@ const E164_RE = /^\+[1-9]\d{1,14}$/;
 
 interface RawPersonRow {
   id: string;
+  workspace_id: string;
   display_name: string | null;
   slack_user_id: string | null;
   job_title: string | null;
@@ -34,6 +36,7 @@ interface RawPersonRow {
 function mapRawPerson(row: RawPersonRow): typeof people.$inferSelect {
   return {
     id: row.id,
+    workspaceId: row.workspace_id,
     displayName: row.display_name,
     slackUserId: row.slack_user_id,
     jobTitle: row.job_title,
@@ -68,7 +71,10 @@ interface PersonResult {
   };
 }
 
-async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonResult> {
+async function enrichPerson(
+  person: typeof people.$inferSelect,
+  wsId: string,
+): Promise<PersonResult> {
   const addrs = await db
     .select({
       id: addresses.id,
@@ -77,14 +83,14 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
       isPrimary: addresses.isPrimary,
     })
     .from(addresses)
-    .where(eq(addresses.personId, person.id));
+    .where(and(eq(addresses.personId, person.id), eq(addresses.workspaceId, wsId)));
 
   let managerName: string | null = null;
   if (person.managerId) {
     const [mgr] = await db
       .select({ displayName: people.displayName })
       .from(people)
-      .where(eq(people.id, person.managerId))
+      .where(and(eq(people.id, person.managerId), eq(people.workspaceId, wsId)))
       .limit(1);
     managerName = mgr?.displayName ?? null;
   }
@@ -102,7 +108,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
         slackUserId: userProfiles.slackUserId,
       })
       .from(userProfiles)
-      .where(eq(userProfiles.slackUserId, person.slackUserId))
+      .where(and(eq(userProfiles.slackUserId, person.slackUserId), eq(userProfiles.workspaceId, wsId)))
       .limit(1);
 
     if (profile) {
@@ -116,7 +122,7 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
           lastAuraDm: sql<string>`max(${messages.createdAt}) filter (where ${messages.channelType} = 'dm')`,
         })
         .from(messages)
-        .where(eq(messages.userId, profile.slackUserId));
+        .where(and(eq(messages.userId, profile.slackUserId), eq(messages.workspaceId, wsId)));
 
       workspaceMessages = Number(msgStats?.workspaceMessages ?? 0);
       auraDmMessages = Number(msgStats?.auraDmMessages ?? 0);
@@ -152,12 +158,15 @@ async function enrichPerson(person: typeof people.$inferSelect): Promise<PersonR
   };
 }
 
-async function findPeople(query: string): Promise<(typeof people.$inferSelect)[]> {
+async function findPeople(
+  query: string,
+  wsId: string,
+): Promise<(typeof people.$inferSelect)[]> {
   if (SLACK_ID_RE.test(query)) {
     return db
       .select()
       .from(people)
-      .where(eq(people.slackUserId, query))
+      .where(and(eq(people.slackUserId, query), eq(people.workspaceId, wsId)))
       .limit(1);
   }
 
@@ -166,7 +175,13 @@ async function findPeople(query: string): Promise<(typeof people.$inferSelect)[]
       .select({ person: people })
       .from(addresses)
       .innerJoin(people, eq(addresses.personId, people.id))
-      .where(and(eq(addresses.channel, "email"), eq(addresses.value, query.toLowerCase())))
+      .where(
+        and(
+          eq(addresses.channel, "email"),
+          eq(addresses.value, query.toLowerCase()),
+          eq(addresses.workspaceId, wsId),
+        ),
+      )
       .limit(1);
     return rows.map((r) => r.person);
   }
@@ -174,7 +189,8 @@ async function findPeople(query: string): Promise<(typeof people.$inferSelect)[]
   const rows = await db.execute(sql`
     SELECT p.*
     FROM people p
-    WHERE similarity(p.display_name, ${query}) > 0.3
+    WHERE p.workspace_id = ${wsId}
+      AND similarity(p.display_name, ${query}) > 0.3
     ORDER BY similarity(p.display_name, ${query}) DESC
     LIMIT 3
   `);
@@ -186,6 +202,8 @@ async function findPeople(query: string): Promise<(typeof people.$inferSelect)[]
 // ── Tool Definitions ────────────────────────────────────────────────────────
 
 export function createPeopleTools(context?: ScheduleContext) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
+
   return {
     get_person: defineTool({
       description:
@@ -202,13 +220,13 @@ export function createPeopleTools(context?: ScheduleContext) {
       }),
       execute: async ({ query }) => {
         try {
-          const matched = await findPeople(query.trim());
+          const matched = await findPeople(query.trim(), wsId);
 
           if (matched.length === 0) {
             return { ok: false as const, error: `No person found matching '${query}'` };
           }
 
-          const results = await Promise.all(matched.map(enrichPerson));
+          const results = await Promise.all(matched.map((p) => enrichPerson(p, wsId)));
 
           logger.info("get_person tool called", {
             query,
@@ -308,14 +326,14 @@ export function createPeopleTools(context?: ScheduleContext) {
             const [exists] = await db
               .select({ id: people.id })
               .from(people)
-              .where(eq(people.id, person_id))
+              .where(and(eq(people.id, person_id), eq(people.workspaceId, wsId)))
               .limit(1);
             if (!exists) {
               return { ok: false as const, error: `Person ${person_id} not found` };
             }
             resolvedId = person_id;
           } else {
-            const matched = await findPeople(query!.trim());
+            const matched = await findPeople(query!.trim(), wsId);
             if (matched.length === 0) {
               return { ok: false as const, error: `No person found matching '${query}'` };
             }
@@ -342,7 +360,7 @@ export function createPeopleTools(context?: ScheduleContext) {
               if (UUID_RE.test(fields.manager_id)) {
                 updateSet.managerId = fields.manager_id;
               } else {
-                const mgrMatches = await findPeople(fields.manager_id);
+                const mgrMatches = await findPeople(fields.manager_id, wsId);
                 if (mgrMatches.length === 0) {
                   return { ok: false as const, error: `Could not resolve manager '${fields.manager_id}'` };
                 }
@@ -360,10 +378,10 @@ export function createPeopleTools(context?: ScheduleContext) {
             if (fields.notes !== undefined) updateSet.notes = fields.notes;
 
             if (fields.phone !== undefined) {
-              await upsertPrimaryAddress(resolvedId, "phone", fields.phone.toLowerCase());
+              await upsertPrimaryAddress(resolvedId, "phone", fields.phone.toLowerCase(), wsId);
             }
             if (fields.email !== undefined) {
-              await upsertPrimaryAddress(resolvedId, "email", fields.email.toLowerCase());
+              await upsertPrimaryAddress(resolvedId, "email", fields.email.toLowerCase(), wsId);
             }
           }
 
@@ -380,6 +398,7 @@ export function createPeopleTools(context?: ScheduleContext) {
                 and(
                   eq(addresses.channel, add_address.channel),
                   eq(addresses.value, normalizedValue),
+                  eq(addresses.workspaceId, wsId),
                 ),
               )
               .limit(1);
@@ -396,6 +415,7 @@ export function createPeopleTools(context?: ScheduleContext) {
                 channel: add_address.channel,
                 value: normalizedValue,
                 isPrimary: add_address.is_primary ?? false,
+                workspaceId: wsId,
               });
             } else if (add_address.is_primary && !existingAddr[0].isPrimary) {
               await db
@@ -418,6 +438,7 @@ export function createPeopleTools(context?: ScheduleContext) {
                   eq(addresses.personId, resolvedId),
                   eq(addresses.channel, remove_address.channel),
                   eq(addresses.value, normalizedRemoveValue),
+                  eq(addresses.workspaceId, wsId),
                 ),
               );
           }
@@ -425,19 +446,19 @@ export function createPeopleTools(context?: ScheduleContext) {
           await db
             .update(people)
             .set(updateSet)
-            .where(eq(people.id, resolvedId));
+            .where(and(eq(people.id, resolvedId), eq(people.workspaceId, wsId)));
 
           const [updated] = await db
             .select()
             .from(people)
-            .where(eq(people.id, resolvedId))
+            .where(and(eq(people.id, resolvedId), eq(people.workspaceId, wsId)))
             .limit(1);
 
           if (!updated) {
             return { ok: false as const, error: `Person ${resolvedId} not found after update` };
           }
 
-          const result = await enrichPerson(updated);
+          const result = await enrichPerson(updated, wsId);
 
           logger.info("update_person tool called", {
             personId: resolvedId,
@@ -472,6 +493,7 @@ async function upsertPrimaryAddress(
   personId: string,
   channel: string,
   value: string,
+  wsId: string,
 ): Promise<void> {
   const existing = await db
     .select()
@@ -481,6 +503,7 @@ async function upsertPrimaryAddress(
         eq(addresses.personId, personId),
         eq(addresses.channel, channel),
         eq(addresses.isPrimary, true),
+        eq(addresses.workspaceId, wsId),
       ),
     )
     .limit(1);
@@ -491,7 +514,13 @@ async function upsertPrimaryAddress(
     const conflict = await db
       .select()
       .from(addresses)
-      .where(and(eq(addresses.channel, channel), eq(addresses.value, value)))
+      .where(
+        and(
+          eq(addresses.channel, channel),
+          eq(addresses.value, value),
+          eq(addresses.workspaceId, wsId),
+        ),
+      )
       .limit(1);
 
     if (conflict.length > 0) {
@@ -513,7 +542,13 @@ async function upsertPrimaryAddress(
     const byChannelValue = await db
       .select()
       .from(addresses)
-      .where(and(eq(addresses.channel, channel), eq(addresses.value, value)))
+      .where(
+        and(
+          eq(addresses.channel, channel),
+          eq(addresses.value, value),
+          eq(addresses.workspaceId, wsId),
+        ),
+      )
       .limit(1);
 
     if (byChannelValue.length > 0) {
@@ -528,7 +563,7 @@ async function upsertPrimaryAddress(
     } else {
       await db
         .insert(addresses)
-        .values({ personId, channel, value, isPrimary: true });
+        .values({ personId, channel, value, isPrimary: true, workspaceId: wsId });
     }
   }
 }

--- a/src/tools/resources.ts
+++ b/src/tools/resources.ts
@@ -4,7 +4,7 @@ import { generateText } from "ai";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db/client.js";
-import { resources } from "../db/schema.js";
+import { resources, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { getFastModel } from "../lib/ai.js";
 import { embedText } from "../lib/embeddings.js";
@@ -252,6 +252,7 @@ interface ResourceListRow {
 }
 
 export function createResourceTools(context?: ScheduleContext) {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
   return {
     ingest_resource: defineTool({
       description:
@@ -327,7 +328,7 @@ export function createResourceTools(context?: ScheduleContext) {
               contentHash: resources.contentHash,
             })
             .from(resources)
-            .where(eq(resources.url, normalizedUrl))
+            .where(and(eq(resources.workspaceId, wsId), eq(resources.url, normalizedUrl)))
             .limit(1);
           const current = currentRows[0];
 
@@ -345,6 +346,7 @@ export function createResourceTools(context?: ScheduleContext) {
           await db
             .insert(resources)
             .values({
+              workspaceId: wsId,
               url: normalizedUrl,
               parentUrl: nextParentUrl,
               title: nextTitle,
@@ -355,7 +357,7 @@ export function createResourceTools(context?: ScheduleContext) {
               updatedAt: now,
             })
             .onConflictDoUpdate({
-              target: resources.url,
+              target: [resources.workspaceId, resources.url],
               set: {
                 parentUrl: nextParentUrl,
                 title: nextTitle,
@@ -428,7 +430,7 @@ export function createResourceTools(context?: ScheduleContext) {
                 crawledAt: now,
                 updatedAt: now,
               })
-              .where(eq(resources.url, normalizedUrl));
+              .where(and(eq(resources.workspaceId, wsId), eq(resources.url, normalizedUrl)));
 
             logger.info("ingest_resource unchanged", {
               url: normalizedUrl,
@@ -470,7 +472,7 @@ export function createResourceTools(context?: ScheduleContext) {
               crawledAt: now,
               updatedAt: now,
             })
-            .where(eq(resources.url, normalizedUrl));
+            .where(and(eq(resources.workspaceId, wsId), eq(resources.url, normalizedUrl)));
 
           logger.info("ingest_resource tool called", {
             url: normalizedUrl,
@@ -502,7 +504,7 @@ export function createResourceTools(context?: ScheduleContext) {
               crawledAt: now,
               updatedAt: now,
             })
-            .where(eq(resources.url, normalizedUrl));
+            .where(and(eq(resources.workspaceId, wsId), eq(resources.url, normalizedUrl)));
 
           logger.error("ingest_resource tool failed", {
             url: normalizedUrl,
@@ -556,6 +558,7 @@ export function createResourceTools(context?: ScheduleContext) {
             const embeddingLiteral = JSON.stringify(queryEmbedding);
 
             const conditions = [
+              eq(resources.workspaceId, wsId),
               eq(resources.status, "ready"),
               sql`${resources.embedding} IS NOT NULL`,
             ];
@@ -597,7 +600,7 @@ export function createResourceTools(context?: ScheduleContext) {
             };
           }
 
-          const conditions = [eq(resources.status, "ready")];
+          const conditions = [eq(resources.workspaceId, wsId), eq(resources.status, "ready")];
           if (source) conditions.push(eq(resources.source, source));
           const where = and(...conditions);
 
@@ -706,7 +709,7 @@ export function createResourceTools(context?: ScheduleContext) {
           const rows = await db
             .select()
             .from(resources)
-            .where(eq(resources.url, normalizedUrl))
+            .where(and(eq(resources.workspaceId, wsId), eq(resources.url, normalizedUrl)))
             .limit(1);
           const resource = rows[0];
 
@@ -779,7 +782,7 @@ export function createResourceTools(context?: ScheduleContext) {
       }),
       execute: async ({ source, status, limit }) => {
         try {
-          const conditions = [eq(resources.status, status)];
+          const conditions = [eq(resources.workspaceId, wsId), eq(resources.status, status)];
           if (source) conditions.push(eq(resources.source, source));
 
           const rows = await db

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -2,7 +2,7 @@ import { defineTool } from "../lib/tool.js";
 import { z } from "zod";
 import { eq, and, gt, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { voiceCalls } from "../db/schema.js";
+import { voiceCalls, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import type { ScheduleContext } from "../db/schema.js";
 import { isAdmin } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
@@ -183,6 +183,7 @@ async function resolvePhoneNumberIdFromCache(
 // ── Tool Definitions ─────────────────────────────────────────────────────────
 
 export function createVoiceTools(client: WebClient, context?: ScheduleContext): Record<string, any> {
+  const wsId = context?.workspaceId ?? DEFAULT_WORKSPACE_ID;
   const tools: Record<string, any> = {};
 
   if (process.env.ELEVENLABS_API_KEY) {
@@ -352,6 +353,7 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
           .from(voiceCalls)
           .where(
             and(
+              eq(voiceCalls.workspaceId, wsId),
               gt(voiceCalls.createdAt, sql`now() - interval '1 hour'`),
               eq(voiceCalls.direction, "outbound"),
             ),
@@ -533,6 +535,7 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
         .from(voiceCalls)
         .where(
           and(
+            eq(voiceCalls.workspaceId, wsId),
             gt(voiceCalls.createdAt, sql`now() - interval '1 hour'`),
             eq(voiceCalls.direction, "sms_outbound"),
           ),
@@ -603,6 +606,7 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
           await db
             .insert(voiceCalls)
             .values({
+              workspaceId: wsId,
               conversationId: data.sid as string,
               direction: "sms_outbound",
               phoneNumber: phone_number,
@@ -610,7 +614,7 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
               status: "completed",
               callContext: message,
             })
-            .onConflictDoNothing({ target: voiceCalls.conversationId });
+            .onConflictDoNothing({ target: [voiceCalls.workspaceId, voiceCalls.conversationId] });
         } catch (dbError: any) {
           logger.error("send_sms DB insert failed (SMS was sent)", {
             error: dbError.message,
@@ -681,6 +685,7 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
           .from(voiceCalls)
           .where(
             and(
+              eq(voiceCalls.workspaceId, wsId),
               gt(voiceCalls.createdAt, sql`now() - interval '1 hour'`),
               eq(voiceCalls.direction, "voice_note"),
             ),
@@ -798,13 +803,14 @@ export function createVoiceTools(client: WebClient, context?: ScheduleContext): 
             await db
               .insert(voiceCalls)
               .values({
+                workspaceId: wsId,
                 conversationId: `voice_note_${fileId}`,
                 direction: "voice_note",
                 slackUserId: context?.userId ?? null,
                 status: "completed",
                 callContext: text.substring(0, 500),
               })
-              .onConflictDoNothing({ target: voiceCalls.conversationId });
+              .onConflictDoNothing({ target: [voiceCalls.workspaceId, voiceCalls.conversationId] });
           } catch (dbError: any) {
             logger.error("send_voice_note DB insert failed (voice note was sent)", {
               error: dbError.message,

--- a/src/users/profiles.ts
+++ b/src/users/profiles.ts
@@ -1,9 +1,10 @@
-import { eq, sql } from "drizzle-orm";
+import { eq, sql, and } from "drizzle-orm";
 import { generateObject, generateText, Output } from "ai";
 import { z } from "zod";
 import { db } from "../db/client.js";
 import {
   userProfiles,
+  DEFAULT_WORKSPACE_ID,
   type UserProfile,
   type CommunicationStyle,
   type KnownFacts,
@@ -19,12 +20,13 @@ export async function getOrCreateProfile(
   slackUserId: string,
   displayName: string,
   timezone?: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<UserProfile> {
   // Try to find existing
   const existing = await db
     .select()
     .from(userProfiles)
-    .where(eq(userProfiles.slackUserId, slackUserId))
+    .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)))
     .limit(1);
 
   if (existing.length > 0) {
@@ -33,7 +35,7 @@ export async function getOrCreateProfile(
       await db
         .update(userProfiles)
         .set({ timezone, updatedAt: new Date() })
-        .where(eq(userProfiles.slackUserId, slackUserId));
+        .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)));
       Object.assign(profile, { timezone });
     }
     if (!profile.personId) {
@@ -54,11 +56,12 @@ export async function getOrCreateProfile(
   const result = await db
     .insert(userProfiles)
     .values({
+      workspaceId,
       slackUserId,
       displayName,
       timezone,
     })
-    .onConflictDoNothing({ target: userProfiles.slackUserId })
+    .onConflictDoNothing({ target: [userProfiles.workspaceId, userProfiles.slackUserId] })
     .returning();
 
   if (result.length > 0) {
@@ -80,7 +83,7 @@ export async function getOrCreateProfile(
   const [concurrentlyCreated] = await db
     .select()
     .from(userProfiles)
-    .where(eq(userProfiles.slackUserId, slackUserId))
+    .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)))
     .limit(1);
 
   return concurrentlyCreated;
@@ -90,7 +93,7 @@ export async function getOrCreateProfile(
  * Increment interaction count and update last interaction time.
  * Called after every exchange.
  */
-export async function recordInteraction(slackUserId: string): Promise<void> {
+export async function recordInteraction(slackUserId: string, workspaceId: string = DEFAULT_WORKSPACE_ID): Promise<void> {
   await db
     .update(userProfiles)
     .set({
@@ -98,7 +101,7 @@ export async function recordInteraction(slackUserId: string): Promise<void> {
       lastInteractionAt: new Date(),
       updatedAt: new Date(),
     })
-    .where(eq(userProfiles.slackUserId, slackUserId));
+    .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)));
 }
 
 /**
@@ -130,13 +133,14 @@ export async function updateProfileFromConversation(
   slackUserId: string,
   userMessage: string,
   assistantResponse: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<void> {
   try {
     // Get current profile
     const [profile] = await db
       .select()
       .from(userProfiles)
-      .where(eq(userProfiles.slackUserId, slackUserId))
+      .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)))
       .limit(1);
 
     if (!profile) return;
@@ -205,7 +209,7 @@ Only include new facts that are clearly stated or strongly implied. Don't specul
         knownFacts: mergedFacts,
         updatedAt: new Date(),
       })
-      .where(eq(userProfiles.slackUserId, slackUserId));
+      .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)));
 
     logger.info("Updated user profile", {
       slackUserId,
@@ -225,11 +229,12 @@ Only include new facts that are clearly stated or strongly implied. Don't specul
  */
 export async function getProfile(
   slackUserId: string,
+  workspaceId: string = DEFAULT_WORKSPACE_ID,
 ): Promise<UserProfile | null> {
   const results = await db
     .select()
     .from(userProfiles)
-    .where(eq(userProfiles.slackUserId, slackUserId))
+    .where(and(eq(userProfiles.workspaceId, workspaceId), eq(userProfiles.slackUserId, slackUserId)))
     .limit(1);
 
   return results[0] || null;

--- a/src/webhook/elevenlabs.ts
+++ b/src/webhook/elevenlabs.ts
@@ -2,14 +2,14 @@ import { Hono } from "hono";
 import { WebClient } from "@slack/web-api";
 import { waitUntil } from "@vercel/functions";
 import crypto from "node:crypto";
-import { sql } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { logger } from "../lib/logger.js";
 import { recordError } from "../lib/metrics.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import { formatForSlack } from "../lib/format.js";
 import { embedText } from "../lib/embeddings.js";
 import { db } from "../db/client.js";
-import { voiceCalls, notes } from "../db/schema.js";
+import { voiceCalls, notes, DEFAULT_WORKSPACE_ID } from "../db/schema.js";
 import { getUserList, resolveUserByName } from "../tools/slack.js";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 
@@ -57,7 +57,7 @@ async function handleLookupContext(
       const results = await db
         .select({ topic: notes.topic, content: notes.content })
         .from(notes)
-        .where(sql`embedding IS NOT NULL`)
+        .where(and(eq(notes.workspaceId, DEFAULT_WORKSPACE_ID), sql`embedding IS NOT NULL`))
         .orderBy(sql`embedding <=> ${JSON.stringify(vector)}::vector`)
         .limit(5);
 
@@ -95,7 +95,7 @@ async function handleLookupContext(
         const relatedNotes = await db
           .select({ topic: notes.topic, content: notes.content })
           .from(notes)
-          .where(ilike(notes.topic, `%${escapedName}%`))
+          .where(and(eq(notes.workspaceId, DEFAULT_WORKSPACE_ID), ilike(notes.topic, `%${escapedName}%`)))
           .limit(3);
 
         if (relatedNotes.length > 0) {
@@ -285,6 +285,7 @@ elevenlabsWebhookApp.post("/post-call", async (c) => {
       await db
         .insert(voiceCalls)
         .values({
+          workspaceId: DEFAULT_WORKSPACE_ID,
           conversationId,
           agentId: agentId ?? null,
           direction,
@@ -299,7 +300,7 @@ elevenlabsWebhookApp.post("/post-call", async (c) => {
           metadata: strippedMetadata,
         })
         .onConflictDoUpdate({
-          target: voiceCalls.conversationId,
+          target: [voiceCalls.workspaceId, voiceCalls.conversationId],
           set: {
             status: callStatus,
             durationSeconds: duration ?? null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements multi-tenant support by adding `workspace_id` to all core database tables.

This PR introduces a `workspace_id` column to all 21 core database tables, along with a Drizzle migration to backfill existing data and create workspace-scoped indexes. All relevant database queries in `src/lib/` and `src/tools/` have been updated to filter by `workspace_id`, which is now threaded through the pipeline from the incoming Slack event's `team_id`. This change is crucial for enabling multi-workspace functionality required for Slack App Directory listing.

---
<p><a href="https://cursor.com/agents/bc-41ffe6bc-66ce-4db6-870c-5e69db486fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ffe6bc-66ce-4db6-870c-5e69db486fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->