### PR TITLE
feat: governance layer PR B -- defineTool interceptor, approval reactions, sandbox scoping (#649)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,8 @@ import {
   hasPermission,
 } from "./lib/api-credentials.js";
 import { resolveConfirmation } from "./lib/confirmation.js";
+import { handleApprovalReaction } from "./lib/approval.js";
+import { executionContext } from "./lib/tool.js";
 import { setSetting } from "./lib/settings.js";
 import { logger } from "./lib/logger.js";
 import { recordError } from "./lib/metrics.js";
@@ -159,11 +161,39 @@ app.post("/api/slack/events", async (c) => {
   if (body.event) {
     const event = body.event;
 
-    // Handle reaction events -- store as memory for awareness
+    // Handle reaction events -- store as memory + governance approval
     if (event.type === "reaction_added" && event.user && event.item) {
       const reactionPromise = (async () => {
         try {
-          // Resolve user name for the memory
+          // ── Governance: check if this is an approval/rejection reaction ──
+          if (
+            event.item?.type === "message" &&
+            ["white_check_mark", "x"].includes(event.reaction)
+          ) {
+            try {
+              const msgResult = await slackClient.conversations.history({
+                channel: event.item.channel,
+                latest: event.item.ts,
+                limit: 1,
+                inclusive: true,
+              });
+              const msg = msgResult.messages?.[0];
+              const actionLogId = (msg?.metadata as any)?.event_payload?.action_log_id;
+
+              if (actionLogId) {
+                await handleApprovalReaction({
+                  actionLogId,
+                  reaction: event.reaction,
+                  reactorUserId: event.user,
+                });
+                return;
+              }
+            } catch (approvalErr) {
+              logger.warn("Failed to process approval reaction", { error: approvalErr });
+            }
+          }
+
+          // ── Store as a lightweight memory via the store module ──
           let userName = event.user;
           try {
             const userResult = await slackClient.users.info({ user: event.user });
@@ -174,7 +204,6 @@ app.post("/api/slack/events", async (c) => {
               event.user;
           } catch {}
 
-          // Store as a lightweight memory via the store module
           const { storeMessage } = await import("./memory/store.js");
           await storeMessage({
             slackTs: `reaction-${event.event_ts}`,
@@ -242,15 +271,20 @@ app.post("/api/slack/events", async (c) => {
       channel: event.channel,
     });
 
-    // Run pipeline asynchronously.
+    // Run pipeline asynchronously inside governance execution context.
     // On Vercel, we must acknowledge within 3 seconds, so we process
     // in the background using waitUntil where available.
-    const pipelinePromise = runPipeline({
-      event,
-      client: slackClient,
-      botUserId,
-      teamId: body.team_id,
-    }).catch((err) => {
+    const userId = event.user || "unknown";
+    const pipelinePromise = executionContext.run(
+      { triggeredBy: userId, triggerType: "user_message" },
+      () =>
+        runPipeline({
+          event,
+          client: slackClient,
+          botUserId,
+          teamId: body.team_id,
+        }),
+    ).catch((err) => {
       recordError("pipeline", err, {
         eventType: event.type,
         channel: event.channel,

--- a/src/cron/execute-job.ts
+++ b/src/cron/execute-job.ts
@@ -5,6 +5,7 @@ import { jobs, notes, jobExecutions } from "../db/schema.js";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import { createHeadlessAgent } from "../lib/agents.js";
+import { executionContext, PendingApprovalError } from "../lib/tool.js";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -172,7 +173,14 @@ export async function executeJob(
       systemPrompt,
     });
 
-    const generateResult = await agent.generate({ prompt });
+    const generateResult = await executionContext.run(
+      {
+        triggeredBy: job.requestedBy,
+        triggerType: "scheduled_job",
+        jobId: job.id,
+      },
+      () => agent.generate({ prompt }),
+    );
 
     const { text, steps, totalUsage: usage } = generateResult;
 
@@ -253,6 +261,37 @@ export async function executeJob(
 
     return true;
   } catch (error: any) {
+    // Governance: if a tool requires approval, suspend the job
+    if (error instanceof PendingApprovalError) {
+      try {
+        await db
+          .update(jobExecutions)
+          .set({
+            status: "failed",
+            finishedAt: new Date(),
+            error: `Awaiting approval: ${error.actionLogId}`,
+          })
+          .where(eq(jobExecutions.id, executionId));
+      } catch { /* non-critical */ }
+
+      await db
+        .update(jobs)
+        .set({
+          status: "pending",
+          approvalStatus: "awaiting_approval",
+          pendingActionLogId: error.actionLogId,
+          updatedAt: new Date(),
+        })
+        .where(eq(jobs.id, jobId));
+
+      logger.info("executeJob: job suspended awaiting approval", {
+        jobId,
+        jobName: job.name,
+        actionLogId: error.actionLogId,
+      });
+      return true;
+    }
+
     // Update execution trace with failure (protected so it can't break retry logic)
     try {
       await db

--- a/src/cron/heartbeat.ts
+++ b/src/cron/heartbeat.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, lt, lte, sql, isNull, or, inArray } from "drizzle-orm";
+import { eq, and, lt, lte, sql, isNull, or, inArray, ne } from "drizzle-orm";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "../db/schema.js";
@@ -102,6 +102,8 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
         and(
           eq(jobs.status, "pending"),
           eq(jobs.enabled, 1),
+          // Skip jobs awaiting governance approval
+          or(isNull(jobs.approvalStatus), ne(jobs.approvalStatus, "awaiting_approval")),
           or(
             // One-shot/continuation: due when executeAt <= now
             lte(jobs.executeAt, now),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -346,6 +346,8 @@ export const jobs = pgTable(
     lastExecutionDate: text("last_execution_date"),
     enabled: integer("enabled").notNull().default(1),
     requiredCredentialIds: jsonb("required_credential_ids").$type<string[]>().default([]),
+    approvalStatus: text("approval_status"),
+    pendingActionLogId: uuid("pending_action_log_id"),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
@@ -353,6 +355,10 @@ export const jobs = pgTable(
     uniqueIndex("jobs_name_idx").on(table.name),
     index("jobs_enabled_idx").on(table.enabled),
     index("jobs_status_execute_idx").on(table.status, table.executeAt),
+    check(
+      "jobs_approval_status_check",
+      sql`${table.approvalStatus} IS NULL OR ${table.approvalStatus} IN ('pending_approval','awaiting_approval','approved','rejected')`,
+    ),
   ],
 );
 
@@ -529,6 +535,75 @@ export const voiceCalls = pgTable(
   ],
 );
 
+// ── Action Log (governance audit trail) ──────────────────────────────────────
+
+export const actionLog = pgTable(
+  "action_log",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    toolName: text("tool_name").notNull(),
+    params: jsonb("params").notNull(),
+    triggerType: text("trigger_type").notNull(),
+    triggeredBy: text("triggered_by").notNull(),
+    jobId: uuid("job_id").references(() => jobs.id),
+    credentialName: text("credential_name"),
+    riskTier: text("risk_tier").notNull(),
+    status: text("status").notNull(),
+    result: jsonb("result"),
+    approvedBy: text("approved_by"),
+    approvedAt: timestamptz("approved_at"),
+    idempotencyKey: text("idempotency_key"),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    check(
+      "action_log_status_check",
+      sql`${table.status} IN ('executed','pending_approval','approved','rejected','failed')`,
+    ),
+    check(
+      "action_log_risk_tier_check",
+      sql`${table.riskTier} IN ('read','write','destructive')`,
+    ),
+    check(
+      "action_log_trigger_type_check",
+      sql`${table.triggerType} IN ('user_message','scheduled_job','autonomous')`,
+    ),
+    unique("action_log_idempotency_key_unique").on(table.idempotencyKey),
+    index("action_log_tool_name_idx").on(table.toolName),
+    index("action_log_triggered_by_idx").on(table.triggeredBy),
+    index("action_log_status_idx").on(table.status),
+    index("action_log_created_at_idx").on(table.createdAt),
+  ],
+);
+
+// ── Approval Policies (runtime governance config) ────────────────────────────
+
+export const approvalPolicies = pgTable(
+  "approval_policies",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    toolPattern: text("tool_pattern"),
+    urlPattern: text("url_pattern"),
+    httpMethods: text("http_methods").array(),
+    credentialName: text("credential_name"),
+    riskTier: text("risk_tier").notNull(),
+    approverIds: text("approver_ids").array(),
+    approvalChannel: text("approval_channel"),
+    createdBy: text("created_by").notNull(),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    check(
+      "approval_policies_risk_tier_check",
+      sql`${table.riskTier} IN ('read','write','destructive')`,
+    ),
+  ],
+);
+
 // ── Type exports ───────────────────────────────────────────────────────────
 
 export type Message = typeof messages.$inferSelect;
@@ -561,6 +636,10 @@ export type Address = typeof addresses.$inferSelect;
 export type NewAddress = typeof addresses.$inferInsert;
 export type VoiceCall = typeof voiceCalls.$inferSelect;
 export type NewVoiceCall = typeof voiceCalls.$inferInsert;
+export type ActionLog = typeof actionLog.$inferSelect;
+export type NewActionLog = typeof actionLog.$inferInsert;
+export type ApprovalPolicy = typeof approvalPolicies.$inferSelect;
+export type NewApprovalPolicy = typeof approvalPolicies.$inferInsert;
 
 /** Context for tools that need to know the current conversation's routing. */
 export interface ScheduleContext {

--- a/src/lib/approval.ts
+++ b/src/lib/approval.ts
@@ -1,0 +1,301 @@
+import { eq, sql } from "drizzle-orm";
+import { db } from "../db/client.js";
+import { actionLog, approvalPolicies, jobs } from "../db/schema.js";
+import type { ApprovalPolicy } from "../db/schema.js";
+import { isAdmin } from "./permissions.js";
+import { logger } from "./logger.js";
+
+// ── Policy Lookup ────────────────────────────────────────────────────────────
+
+export type RiskTier = "read" | "write" | "destructive";
+
+interface LookupParams {
+  toolName: string;
+  url?: string;
+  method?: string;
+  credentialName?: string;
+}
+
+interface PolicyResult {
+  riskTier: RiskTier;
+  policy: ApprovalPolicy | null;
+}
+
+/**
+ * Look up the applicable approval policy for a tool call.
+ *
+ * Matching order:
+ * 1. For http_request: most-specific url_pattern + http_methods match
+ * 2. Exact tool_pattern match
+ * 3. Fallback defaults: GET=read, POST/PATCH/PUT=write, DELETE=destructive;
+ *    for non-http tools, default to "write"
+ */
+export async function lookupPolicy(params: LookupParams): Promise<PolicyResult> {
+  const { toolName, url, method, credentialName } = params;
+
+  const allPolicies = await db
+    .select()
+    .from(approvalPolicies)
+    .orderBy(sql`length(coalesce(url_pattern, '')) DESC`);
+
+  // For http_request, try url_pattern + method matching first
+  if (toolName === "http_request" && url) {
+    for (const policy of allPolicies) {
+      if (!policy.urlPattern) continue;
+
+      if (!urlMatchesPattern(url, policy.urlPattern)) continue;
+
+      if (policy.httpMethods && policy.httpMethods.length > 0) {
+        if (method && !policy.httpMethods.includes(method.toUpperCase())) continue;
+      }
+
+      if (policy.credentialName && policy.credentialName !== credentialName) continue;
+
+      return { riskTier: policy.riskTier as RiskTier, policy };
+    }
+  }
+
+  // Try exact tool_pattern match
+  for (const policy of allPolicies) {
+    if (!policy.toolPattern) continue;
+    if (policy.toolPattern !== toolName) continue;
+    if (policy.credentialName && policy.credentialName !== credentialName) continue;
+
+    return { riskTier: policy.riskTier as RiskTier, policy };
+  }
+
+  // Fallback defaults
+  if (toolName === "http_request" && method) {
+    const upperMethod = method.toUpperCase();
+    if (upperMethod === "GET" || upperMethod === "HEAD" || upperMethod === "OPTIONS") {
+      return { riskTier: "read", policy: null };
+    }
+    if (upperMethod === "DELETE") {
+      return { riskTier: "destructive", policy: null };
+    }
+    return { riskTier: "write", policy: null };
+  }
+
+  return { riskTier: "write", policy: null };
+}
+
+function urlMatchesPattern(url: string, pattern: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const urlPath = parsed.hostname + parsed.pathname;
+    const regexStr = "^" + pattern.replace(/\*/g, "[^/]*") + "(/.*)?$";
+    return new RegExp(regexStr).test(urlPath);
+  } catch {
+    return false;
+  }
+}
+
+// ── Approval Message ─────────────────────────────────────────────────────────
+
+export interface RequestApprovalParams {
+  actionLogId: string;
+  toolName: string;
+  params: unknown;
+  riskTier: string;
+  policy: ApprovalPolicy | null;
+  triggeredBy: string;
+  jobId?: string;
+}
+
+/**
+ * Post an approval request message to the appropriate Slack channel.
+ * Embeds the action_log ID in message metadata for the reaction handler.
+ */
+export async function requestApproval(params: RequestApprovalParams): Promise<void> {
+  const { WebClient } = await import("@slack/web-api");
+  const botToken = process.env.SLACK_BOT_TOKEN || "";
+  const slackClient = new WebClient(botToken);
+
+  const { actionLogId, toolName, params: toolParams, riskTier, policy, triggeredBy, jobId } = params;
+
+  const paramsDisplay = typeof toolParams === "object"
+    ? JSON.stringify(toolParams, null, 2).slice(0, 2000)
+    : String(toolParams).slice(0, 2000);
+
+  const blocks: any[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: `:warning: Approval Required — ${toolName}`, emoji: true },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Risk Tier:*\n\`${riskTier}\`` },
+        { type: "mrkdwn", text: `*Triggered By:*\n<@${triggeredBy}>` },
+      ],
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `*Parameters:*\n\`\`\`${paramsDisplay}\`\`\`` },
+    },
+    {
+      type: "context",
+      elements: [
+        { type: "mrkdwn", text: `React with :white_check_mark: to approve or :x: to reject` },
+      ],
+    },
+  ];
+
+  if (jobId) {
+    blocks.splice(2, 0, {
+      type: "section",
+      fields: [{ type: "mrkdwn", text: `*Job ID:*\n\`${jobId}\`` }],
+    });
+  }
+
+  const metadata = {
+    event_type: "aura_approval_request",
+    event_payload: { action_log_id: actionLogId },
+  };
+
+  const channel = policy?.approvalChannel || triggeredBy;
+
+  try {
+    await slackClient.chat.postMessage({
+      channel,
+      text: `Approval required for ${toolName} (${riskTier}). React ✅ to approve, ❌ to reject.`,
+      blocks,
+      metadata,
+    });
+    logger.info("Approval request posted", { actionLogId, toolName, channel });
+  } catch (err: any) {
+    logger.error("Failed to post approval request", { actionLogId, error: err.message });
+    // If posting to a channel fails, try DM to triggeredBy
+    if (channel !== triggeredBy) {
+      try {
+        await slackClient.chat.postMessage({
+          channel: triggeredBy,
+          text: `Approval required for ${toolName} (${riskTier}). React ✅ to approve, ❌ to reject.`,
+          blocks,
+          metadata,
+        });
+      } catch (dmErr: any) {
+        logger.error("Failed to post approval DM fallback", { actionLogId, error: dmErr.message });
+      }
+    }
+  }
+}
+
+// ── Approval Reaction Handler ────────────────────────────────────────────────
+
+export interface HandleApprovalReactionParams {
+  actionLogId: string;
+  reaction: string;
+  reactorUserId: string;
+}
+
+/**
+ * Handle an approval or rejection reaction on an action_log entry.
+ * Called from the reaction_added event handler in app.ts.
+ */
+export async function handleApprovalReaction(params: HandleApprovalReactionParams): Promise<void> {
+  const { actionLogId, reaction, reactorUserId } = params;
+
+  const logRows = await db
+    .select()
+    .from(actionLog)
+    .where(eq(actionLog.id, actionLogId))
+    .limit(1);
+
+  const logRow = logRows[0];
+  if (!logRow || logRow.status !== "pending_approval") {
+    logger.info("Approval reaction: action not pending", { actionLogId, status: logRow?.status });
+    return;
+  }
+
+  // Look up the policy that gated this action to verify approver authorization
+  const { policy } = await lookupPolicy({
+    toolName: logRow.toolName,
+    credentialName: logRow.credentialName ?? undefined,
+  });
+
+  const approverIds = policy?.approverIds ?? null;
+  const isAuthorized = approverIds
+    ? approverIds.includes(reactorUserId)
+    : isAdmin(reactorUserId);
+
+  if (!isAuthorized) {
+    logger.info("Approval reaction: reactor not authorized", {
+      actionLogId,
+      reactorUserId,
+      approverIds,
+    });
+    return;
+  }
+
+  const { WebClient } = await import("@slack/web-api");
+  const botToken = process.env.SLACK_BOT_TOKEN || "";
+  const slackClient = new WebClient(botToken);
+
+  if (reaction === "white_check_mark") {
+    await db
+      .update(actionLog)
+      .set({
+        status: "approved",
+        approvedBy: reactorUserId,
+        approvedAt: new Date(),
+      })
+      .where(eq(actionLog.id, actionLogId));
+
+    // Re-enqueue the associated job
+    await db
+      .update(jobs)
+      .set({
+        status: "pending",
+        approvalStatus: "approved",
+        executeAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(jobs.pendingActionLogId, actionLogId));
+
+    logger.info("Action approved", { actionLogId, approvedBy: reactorUserId });
+
+    // Notify job creator
+    if (logRow.triggeredBy && logRow.triggeredBy !== "unknown") {
+      try {
+        await slackClient.chat.postMessage({
+          channel: logRow.triggeredBy,
+          text: `Your action \`${logRow.toolName}\` has been approved by <@${reactorUserId}>.`,
+        });
+      } catch { /* non-critical */ }
+    }
+  } else if (reaction === "x") {
+    await db
+      .update(actionLog)
+      .set({
+        status: "rejected",
+        approvedBy: reactorUserId,
+        approvedAt: new Date(),
+      })
+      .where(eq(actionLog.id, actionLogId));
+
+    // Cancel the associated job
+    const cancelledJobs = await db
+      .update(jobs)
+      .set({
+        status: "cancelled",
+        approvalStatus: "rejected",
+        updatedAt: new Date(),
+      })
+      .where(eq(jobs.pendingActionLogId, actionLogId))
+      .returning({ id: jobs.id, requestedBy: jobs.requestedBy });
+
+    logger.info("Action rejected", { actionLogId, rejectedBy: reactorUserId });
+
+    // Notify job creator
+    const job = cancelledJobs[0];
+    if (job?.requestedBy && job.requestedBy !== "aura") {
+      try {
+        await slackClient.chat.postMessage({
+          channel: job.requestedBy,
+          text: `Your action \`${logRow.toolName}\` was rejected by <@${reactorUserId}>. The associated job has been cancelled.`,
+        });
+      } catch { /* non-critical */ }
+    }
+  }
+}

--- a/src/lib/sandbox.ts
+++ b/src/lib/sandbox.ts
@@ -43,6 +43,11 @@ async function loadE2B() {
  * passed at creation time, and persistence across pause/resume is
  * unreliable (see e2b-dev/E2B#884). Per-command `envs` is the only
  * mechanism that works consistently.
+ *
+ * GOVERNANCE: Only compute-infrastructure keys belong here. External
+ * service API keys (Close, Stripe, PostHog, Claap, etc.) must be
+ * accessed via the credentials table through the governed http_request
+ * tool. This prevents run_command from bypassing the governance layer.
  */
 export async function getSandboxEnvs(): Promise<Record<string, string>> {
   const envs: Record<string, string> = {};
@@ -63,12 +68,8 @@ export async function getSandboxEnvs(): Promise<Record<string, string>> {
   if (process.env.OPENAI_API_KEY) {
     envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
   }
-  if (process.env.POSTHOG_API_KEY) {
-    envs.POSTHOG_API_KEY = process.env.POSTHOG_API_KEY;
-  }
-  if (process.env.CLAAP_API_KEY) {
-    envs.CLAAP_API_KEY = process.env.CLAAP_API_KEY;
-  }
+  // POSTHOG_API_KEY and CLAAP_API_KEY removed — external service
+  // credentials should flow through the governed http_request tool.
   const saKeyB64 =
     process.env.GOOGLE_SA_KEY_B64 ||
     (process.env.GOOGLE_SERVICE_ACCOUNT_KEY

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -1,5 +1,30 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { tool, type Tool } from "ai";
+import { eq } from "drizzle-orm";
 import type { ZodType } from "zod";
+import { db } from "../db/client.js";
+import { actionLog } from "../db/schema.js";
+import { lookupPolicy, requestApproval } from "./approval.js";
+import { logger } from "./logger.js";
+
+// ── Execution Context (AsyncLocalStorage) ────────────────────────────────────
+
+export interface ExecutionContext {
+  triggeredBy: string;
+  triggerType: "user_message" | "scheduled_job" | "autonomous";
+  jobId?: string;
+}
+
+export const executionContext = new AsyncLocalStorage<ExecutionContext>();
+
+// ── PendingApprovalError ─────────────────────────────────────────────────────
+
+export class PendingApprovalError extends Error {
+  constructor(public readonly actionLogId: string) {
+    super(`Action pending approval: ${actionLogId}`);
+    this.name = "PendingApprovalError";
+  }
+}
 
 // ── Slack Card Metadata ──────────────────────────────────────────────────────
 // Co-located with tool definitions via defineTool() so that Slack card behavior
@@ -32,10 +57,17 @@ export function getSlackMeta(t: unknown): SlackToolMetadata | undefined {
 }
 
 /**
+ * Mutable name ref stored in a closure so registerToolNames() can fill it
+ * in after the tools map is built.
+ */
+interface ToolNameRef {
+  name?: string;
+}
+
+/**
  * Wrapper around AI SDK's tool() that co-locates Slack card metadata with the
- * tool definition. The optional `slack` field is attached directly to the
- * returned tool object so respond.ts can read it at runtime without maintaining
- * separate switch blocks.
+ * tool definition and adds a governance interceptor. Every tool call is logged
+ * to action_log; destructive-tier calls are gated behind approval.
  *
  * Usage:
  * ```ts
@@ -58,18 +90,155 @@ export function defineTool<TInput, TOutput>(config: {
   slack?: SlackToolMetadata<TInput, TOutput>;
   toModelOutput?: Tool<TInput, TOutput>["toModelOutput"];
 }) {
-  const { slack, ...toolConfig } = config;
-  // The spread loses the generic relationship between TInput/TOutput and the
-  // Tool intersection type, so we go through `unknown` to satisfy the compiler.
+  const { slack, ...rest } = config;
+  const originalExecute = rest.execute;
+
+  const toolRef: ToolNameRef = {};
+
+  const governedExecute = async (input: TInput): Promise<TOutput> => {
+    const toolName = toolRef.name || "unknown";
+    const ctx = executionContext.getStore() ?? {
+      triggeredBy: "unknown",
+      triggerType: "autonomous" as const,
+    };
+
+    let riskTier: "read" | "write" | "destructive" = "write";
+    let policy: Awaited<ReturnType<typeof lookupPolicy>>["policy"] = null;
+
+    try {
+      const httpInput = input as Record<string, unknown>;
+      const lookup = await lookupPolicy({
+        toolName,
+        url: toolName === "http_request" ? (httpInput.url as string) : undefined,
+        method: toolName === "http_request" ? (httpInput.method as string) : undefined,
+        credentialName: httpInput.credential_name as string | undefined,
+      });
+      riskTier = lookup.riskTier;
+      policy = lookup.policy;
+    } catch (policyErr) {
+      logger.warn("Governance: policy lookup failed, defaulting to write tier", {
+        toolName,
+        error: policyErr,
+      });
+    }
+
+    // Destructive: write pending log → post approval message → throw
+    if (riskTier === "destructive") {
+      const [logEntry] = await db
+        .insert(actionLog)
+        .values({
+          toolName,
+          params: input as any,
+          triggerType: ctx.triggerType,
+          triggeredBy: ctx.triggeredBy,
+          jobId: ctx.jobId ?? null,
+          credentialName: (input as any)?.credential_name ?? null,
+          riskTier,
+          status: "pending_approval",
+        })
+        .returning({ id: actionLog.id });
+
+      await requestApproval({
+        actionLogId: logEntry.id,
+        toolName,
+        params: input,
+        riskTier,
+        policy,
+        triggeredBy: ctx.triggeredBy,
+        jobId: ctx.jobId,
+      });
+
+      throw new PendingApprovalError(logEntry.id);
+    }
+
+    // Read / Write: execute, then log result
+    let logId: string | undefined;
+
+    try {
+      // Write the log entry before execution (captures params before credential injection)
+      try {
+        const [logEntry] = await db
+          .insert(actionLog)
+          .values({
+            toolName,
+            params: input as any,
+            triggerType: ctx.triggerType,
+            triggeredBy: ctx.triggeredBy,
+            jobId: ctx.jobId ?? null,
+            credentialName: (input as any)?.credential_name ?? null,
+            riskTier,
+            status: "executed",
+          })
+          .returning({ id: actionLog.id });
+        logId = logEntry.id;
+      } catch (logErr) {
+        logger.warn("Governance: failed to write action_log entry", {
+          toolName,
+          error: logErr,
+        });
+      }
+
+      const result = await originalExecute(input);
+
+      // Update log with result
+      if (logId) {
+        try {
+          await db
+            .update(actionLog)
+            .set({ result: result as any })
+            .where(eq(actionLog.id, logId));
+        } catch { /* non-critical */ }
+      }
+
+      return result;
+    } catch (error: any) {
+      // Update log with failure status
+      if (logId) {
+        try {
+          await db
+            .update(actionLog)
+            .set({
+              status: "failed",
+              result: { error: error.message } as any,
+            })
+            .where(eq(actionLog.id, logId));
+        } catch { /* non-critical */ }
+      }
+      throw error;
+    }
+  };
+
+  const toolConfig = { ...rest, execute: governedExecute };
   const t = tool<TInput, TOutput>(
     toolConfig as unknown as Tool<TInput, TOutput>,
   );
   if (slack) {
     (t as any).slack = slack;
   }
+  (t as any).__toolRef = toolRef;
+
   return t as Tool<TInput, TOutput> & {
     slack?: SlackToolMetadata<TInput, TOutput>;
   };
+}
+
+/**
+ * Stamp tool names from the map keys onto each tool's internal ref.
+ * Call this on the tools record after building it so the governance
+ * interceptor knows which tool is being invoked.
+ *
+ * Handles both defineTool()-created tools (have __toolRef) and
+ * plain AI SDK tools (skipped silently).
+ */
+export function registerToolNames<T extends Record<string, unknown>>(
+  tools: T,
+): T {
+  for (const [name, t] of Object.entries(tools)) {
+    if (t && typeof t === "object" && "__toolRef" in t) {
+      (t as any).__toolRef.name = name;
+    }
+  }
+  return tools;
 }
 
 /**

--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { WebClient } from "@slack/web-api";
 import { logger } from "../lib/logger.js";
-import { defineTool, binaryToModelOutput } from "../lib/tool.js";
+import { defineTool, binaryToModelOutput, registerToolNames } from "../lib/tool.js";
 import { isAdmin } from "../lib/permissions.js";
 import { createNoteTools } from "./notes.js";
 import { createJobTools } from "./jobs.js";
@@ -3054,5 +3054,5 @@ export function createSlackTools(client: WebClient, context?: ScheduleContext) {
     }
   }
 
-  return tools;
+  return registerToolNames(tools);
 }


### PR DESCRIPTION
Implements Phases 3, 4, and 6 from issue #649. Depends on PR #651 (schema + approval.ts + http_request tool).\n\n**Changes:**\n- `src/lib/tool.ts`: ExecutionContext via AsyncLocalStorage, PendingApprovalError, governance interceptor in defineTool()\n- `src/lib/approval.ts`: lookupPolicy(), requestApproval(), handleApprovalReaction()\n- `src/app.ts`: reaction_added approval handler + executionContext.run() wiring\n- `src/cron/execute-job.ts`: executionContext.run() + PendingApprovalError catch → awaiting_approval\n- `src/cron/heartbeat.ts`: skip jobs with approvalStatus = awaiting_approval\n- `src/lib/sandbox.ts`: remove POSTHOG_API_KEY + CLAAP_API_KEY from getSandboxEnvs()\n- `src/db/schema.ts`: actionLog + approvalPolicies table defs + jobs columns (may overlap with PR A -- needs rebase)\n\nNeeds rebase onto PR #651 branch before merge.