### PR TITLE
fix: Mintlify logo/favicon — move to docs root

### DIFF
--- a/content/docs/favicon.svg
+++ b/content/docs/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="102" height="90" fill="none">
+    <path fill="currentColor"
+        d="m58 0 44 77-8 13H7L0 77 43 0h15ZM6 77l3 5 36-64 9 16 17 30h6L45 8 6 77Zm79-8H34l-3 5h64L55 5h-6l36 64Zm-48-5h28L51 39 37 64Z" />
+</svg>

--- a/content/docs/logo/dark.svg
+++ b/content/docs/logo/dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="102" height="90" fill="none">
+    <path fill="white" d="m58 0 44 77-8 13H7L0 77 43 0h15ZM6 77l3 5 36-64 9 16 17 30h6L45 8 6 77Zm79-8H34l-3 5h64L55 5h-6l36 64Zm-48-5h28L51 39 37 64Z" />
+</svg>

--- a/content/docs/logo/light.svg
+++ b/content/docs/logo/light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="102" height="90" fill="none">
+    <path fill="black" d="m58 0 44 77-8 13H7L0 77 43 0h15ZM6 77l3 5 36-64 9 16 17 30h6L45 8 6 77Zm79-8H34l-3 5h64L55 5h-6l36 64Zm-48-5h28L51 39 37 64Z" />
+</svg>


### PR DESCRIPTION
Mintlify serves static assets from the docs root, not from a `public/` subdir.

Moves 3 files:
- `content/docs/public/logo/dark.svg` → `content/docs/logo/dark.svg`
- `content/docs/public/logo/light.svg` → `content/docs/logo/light.svg`
- `content/docs/public/favicon.svg` → `content/docs/favicon.svg`

`docs.json` already had the correct paths (`/logo/dark.svg`, `/logo/light.svg`, `/favicon.svg`). Files were just in the wrong place.