### PR TITLE
fix: governance approval UX -- Approve/Reject buttons in-thread, null policy safety

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -277,7 +277,12 @@ app.post("/api/slack/events", async (c) => {
     // in the background using waitUntil where available.
     const userId = event.user || "unknown";
     const pipelinePromise = executionContext.run(
-      { triggeredBy: userId, triggerType: "user_message" },
+      {
+        triggeredBy: userId,
+        triggerType: "user_message",
+        channelId: event.channel || undefined,
+        threadTs: event.thread_ts || event.ts || undefined,
+      },
       () =>
         runPipeline({
           event,
@@ -572,6 +577,63 @@ app.post("/api/slack/interactions", async (c) => {
           }
         })();
         waitUntil(denyPromise);
+      }
+
+      // ── Governance approval buttons ─────────────────────────────────
+      if (action.action_id?.startsWith("governance_approve_")) {
+        const actionLogId = action.action_id.replace("governance_approve_", "");
+        const approvePromise = (async () => {
+          try {
+            const { handleApprovalReaction } = await import("./lib/approval.js");
+            await handleApprovalReaction({
+              actionLogId,
+              reaction: "white_check_mark",
+              reactorUserId: userId,
+              slackClient,
+            });
+            const gaChanId = payload.channel?.id;
+            const gaTs = payload.message?.ts;
+            if (gaChanId && gaTs) {
+              await slackClient.chat.update({
+                channel: gaChanId,
+                ts: gaTs,
+                text: `✅ Approved by <@${userId}>`,
+                blocks: [{ type: "section" as const, text: { type: "mrkdwn" as const, text: `✅ *Approved* by <@${userId}>` } }],
+              });
+            }
+          } catch (err) {
+            recordError("interactions.governance_approve", err, { userId, actionLogId });
+          }
+        })();
+        waitUntil(approvePromise);
+      }
+
+      if (action.action_id?.startsWith("governance_reject_")) {
+        const actionLogId = action.action_id.replace("governance_reject_", "");
+        const rejectPromise = (async () => {
+          try {
+            const { handleApprovalReaction } = await import("./lib/approval.js");
+            await handleApprovalReaction({
+              actionLogId,
+              reaction: "x",
+              reactorUserId: userId,
+              slackClient,
+            });
+            const grChanId = payload.channel?.id;
+            const grTs = payload.message?.ts;
+            if (grChanId && grTs) {
+              await slackClient.chat.update({
+                channel: grChanId,
+                ts: grTs,
+                text: `❌ Rejected by <@${userId}>`,
+                blocks: [{ type: "section" as const, text: { type: "mrkdwn" as const, text: `❌ *Rejected* by <@${userId}>` } }],
+              });
+            }
+          } catch (err) {
+            recordError("interactions.governance_reject", err, { userId, actionLogId });
+          }
+        })();
+        waitUntil(rejectPromise);
       }
     }
   }

--- a/src/lib/approval.ts
+++ b/src/lib/approval.ts
@@ -146,7 +146,7 @@ export async function requestApproval(args: {
   toolName: string;
   params: unknown;
   riskTier: string;
-  policy: ApprovalPolicy;
+  policy: ApprovalPolicy | null;
   context: ExecutionContext;
   slackClient?: InstanceType<typeof import("@slack/web-api").WebClient> | null;
 }): Promise<void> {
@@ -164,8 +164,8 @@ export async function requestApproval(args: {
     throw new Error(`action_log row ${actionLogId} not found`);
   }
 
-  const channel = policy.approvalChannel ?? undefined;
-  const approvers = policy.approverIds ?? [];
+  const channel = policy?.approvalChannel ?? undefined;
+  const approvers = policy?.approverIds ?? [];
   const approverMentions =
     approvers.length > 0
       ? approvers.map((id) => `<@${id}>`).join(", ")
@@ -201,11 +201,30 @@ export async function requestApproval(args: {
       },
     },
     {
+      type: "actions" as const,
+      elements: [
+        {
+          type: "button" as const,
+          text: { type: "plain_text" as const, text: "✅ Approve", emoji: true },
+          style: "primary" as const,
+          action_id: `governance_approve_${actionLogId}`,
+          value: actionLogId,
+        },
+        {
+          type: "button" as const,
+          text: { type: "plain_text" as const, text: "❌ Reject", emoji: true },
+          style: "danger" as const,
+          action_id: `governance_reject_${actionLogId}`,
+          value: actionLogId,
+        },
+      ],
+    },
+    {
       type: "context" as const,
       elements: [
         {
           type: "mrkdwn" as const,
-          text: `React with :white_check_mark: to approve or :x: to reject • ${approverMentions}\n\`action_log_id: ${actionLogId}\``,
+          text: `${approverMentions} • \`action_log_id: ${actionLogId}\``,
         },
       ],
     },
@@ -226,6 +245,7 @@ export async function requestApproval(args: {
 
   await slackClient.chat.postMessage({
     channel: targetChannel,
+    ...(context.threadTs ? { thread_ts: context.threadTs } : {}),
     text: `Approval required for ${toolName} (${riskTier})`,
     blocks,
     metadata: {

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -13,6 +13,8 @@ export interface ExecutionContext {
   triggeredBy: string;
   triggerType: "user_message" | "scheduled_job" | "autonomous";
   jobId?: string;
+  channelId?: string;
+  threadTs?: string;
 }
 
 export const executionContext = new AsyncLocalStorage<ExecutionContext>();
@@ -144,7 +146,7 @@ export function defineTool<TInput, TOutput>(config: {
         toolName,
         params: input,
         riskTier,
-        policy: policy!,
+        policy: policy,
         context: ctx,
       });
 


### PR DESCRIPTION
## What this fixes

Three bugs preventing the approval flow from working:

### 1. `channelId`/`threadTs` not passed into ExecutionContext
The `executionContext.run()` call in `app.ts` only passed `triggeredBy` and `triggerType`. So when `requestApproval` tried to resolve where to post, `context.channelId` was always `undefined`, falling through to opening a DM -- which then crashed because `policy` was null.

**Fix:** Pass `event.channel` and `event.thread_ts || event.ts` into the context. Also added `channelId`/`threadTs` to the `ExecutionContext` interface in `tool.ts`.

### 2. Null `policy` crash
`tool.ts` line 147 had `policy: policy!` (non-null assertion). When no rows exist in `approval_policies`, `policy` is `null`, and `requestApproval` would crash on `policy.approvalChannel`.

**Fix:** Remove `!`, make the `requestApproval` signature `policy: ApprovalPolicy | null`, use `policy?.approvalChannel` / `policy?.approverIds`.

### 3. Emoji reactions instead of Approve/Reject buttons
The approval message used a context block saying 'React with ✅ to approve'. No buttons.

**Fix:** Replace context block with an `actions` block containing green Approve + red Reject buttons. Added `governance_approve_{actionLogId}` and `governance_reject_{actionLogId}` button handlers in `app.ts` inside the `block_actions` for loop. Message updates to show who approved/rejected after the click.

### 4. Approval message not posted in-thread
When triggered from a thread, the approval message was posted to the channel root.

**Fix:** `postMessage` now passes `thread_ts: context.threadTs` when available.