### PR TITLE
feat: look up thread/channel participants in people DB, cap at 10

### DIFF
--- a/src/pipeline/prompt.ts
+++ b/src/pipeline/prompt.ts
@@ -65,9 +65,25 @@ export async function assemblePrompt(
   // Extract @mentioned user IDs from message text (excluding the sender).
   // By this point, resolveSlackEntities has converted <@U066V1AN6> to @name (U066V1AN6).
   const MENTION_RE = /\((U[A-Z0-9]+)\)/g;
-  const mentionedUserIds = [...new Set(
-    [...(context.text || '').matchAll(MENTION_RE)].map(m => m[1])
-  )].filter(id => id !== context.userId);
+
+  // Also collect all thread and channel context participants so their
+  // gender/pronouns/language are available even without explicit @-mentions.
+  const threadParticipantIds = (conversation.thread ?? [])
+    .map(m => m.user)
+    .filter((id): id is string => !!id);
+
+  const recentParticipantIds = (conversation.recentMessages ?? [])
+    .map(m => m.user)
+    .filter((id): id is string => !!id);
+
+  // Cap at 10 to avoid context bloat. @-mentions come first (most relevant).
+  const mentionedUserIds = [...new Set([
+    ...[...(context.text || '').matchAll(MENTION_RE)].map(m => m[1]),
+    ...threadParticipantIds,
+    ...recentParticipantIds,
+  ])]
+    .filter(id => id !== context.userId)
+    .slice(0, 10);
 
   // Run memory retrieval, conversation retrieval, profile fetch, mentioned-people lookup,
   // and interlocutor lookup in parallel


### PR DESCRIPTION
Fixes #672

## What changed

`src/pipeline/prompt.ts` -- expanded `mentionedUserIds` collection:

**Before:** only `<@U...>` patterns in the current message text.

**After:** union of:
1. `<@U...>` mentions in current message (existing, prioritized)
2. All `.user` IDs from `conversation.thread`
3. All `.user` IDs from `conversation.recentMessages`

Deduped, filtered (exclude sender), **capped at 10** to prevent context bloat.

## Why

Thread participants (e.g. Joan in a thread with Jonas) weren't being looked up in the people DB, so gender/pronouns were unknown and Aura defaulted to wrong pronouns.

## Notes

- Bot filtering is implicit: `lookupMentionedPeople` only returns rows in the people DB, which excludes bots
- @-mentions come first in the set, so they're never squeezed out by the cap