### PR TITLE
perf: run tsc + migrate once via buildCommand (~4x build speedup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "vercel-build": "tsc && tsx src/db/migrate.ts",
     "postinstall": "rm -rf node_modules/e2b/node_modules/chalk 2>/dev/null; true",
     "start": "node dist/index.js",
     "db:generate": "drizzle-kit generate",

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,28 @@
 {
   "installCommand": "npm install",
+  "buildCommand": "tsc && tsx src/db/migrate.ts",
   "framework": null,
-  "regions": ["fra1"],
+  "regions": [
+    "fra1"
+  ],
   "functions": {
     "api/**/*.ts": {
       "maxDuration": 800
     }
   },
   "rewrites": [
-    { "source": "/slack/events", "destination": "/api/slack/events" },
-    { "source": "/health", "destination": "/api/health" },
-    { "source": "/(.*)", "destination": "/api/index" }
+    {
+      "source": "/slack/events",
+      "destination": "/api/slack/events"
+    },
+    {
+      "source": "/health",
+      "destination": "/api/health"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/api/index"
+    }
   ],
   "crons": [
     {


### PR DESCRIPTION
## What

Ports the build optimization from [wieseljonas/nova#12](https://github.com/wieseljonas/nova/pull/12).

## Changes

- **vercel.json**: adds `buildCommand: "tsc && tsx src/db/migrate.ts"`
- **package.json**: removes `vercel-build` script (now redundant)

## Why

Vercel was running `tsc` and `db/migrate.ts` once per serverless function. Moving the build step to `buildCommand` in `vercel.json` runs it once globally, cutting build time from ~3m44s to under 1 minute (~4x speedup).

## Testing

Build behavior is unchanged -- same `tsc` + `migrate` steps, just run once instead of N times.