### PR TITLE
feat: flexible auth_scheme credential system

### DIFF
--- a/drizzle/0034_credential_auth_scheme.sql
+++ b/drizzle/0034_credential_auth_scheme.sql
@@ -1,0 +1,20 @@
+-- Add auth_scheme column with safe default (idempotent)
+ALTER TABLE "credentials" ADD COLUMN IF NOT EXISTS "auth_scheme" text NOT NULL DEFAULT 'bearer';
+--> statement-breakpoint
+-- Migrate existing rows (keep old columns until JS migration completes)
+UPDATE "credentials" SET "auth_scheme" = 'oauth_client' WHERE "type" = 'oauth_client';
+--> statement-breakpoint
+UPDATE "credentials" SET "auth_scheme" = 'bearer' WHERE "type" = 'token';
+--> statement-breakpoint
+-- Add check constraint (idempotent guard)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'credentials_auth_scheme_check'
+      AND conrelid = 'credentials'::regclass
+  ) THEN
+    ALTER TABLE "credentials"
+      ADD CONSTRAINT "credentials_auth_scheme_check"
+      CHECK ("auth_scheme" IN ('bearer','basic','header','query','oauth_client'));
+  END IF;
+END $$;

--- a/drizzle/0035_google_service_account_auth_scheme.sql
+++ b/drizzle/0035_google_service_account_auth_scheme.sql
@@ -1,0 +1,6 @@
+-- Extend auth_scheme check constraint to include google_service_account
+ALTER TABLE "credentials" DROP CONSTRAINT IF EXISTS "credentials_auth_scheme_check";
+--> statement-breakpoint
+ALTER TABLE "credentials"
+  ADD CONSTRAINT "credentials_auth_scheme_check"
+  CHECK ("auth_scheme" IN ('bearer','basic','header','query','oauth_client','google_service_account'));

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,20 @@
       "when": 1773312000000,
       "tag": "0033_action_log_approval_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1773312001000,
+      "tag": "0034_credential_auth_scheme",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1773312002000,
+      "tag": "0035_google_service_account_auth_scheme",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import {
   openCredentialModal,
   openAddCredentialModal,
   buildAddCredentialBlocks,
+  buildUpdateCredentialBlocks,
   openUpdateCredentialModal,
   openShareCredentialModal,
   openCredentialAccessModal,
@@ -430,6 +431,7 @@ app.post("/api/slack/interactions", async (c) => {
 
       // ── User API Credential actions ──────────────────────────────────
       if (action.action_id === "api_credential_add" && payload.trigger_id) {
+        if (!isAdmin(userId)) continue;
         const addPromise = openAddCredentialModal(
           slackClient,
           payload.trigger_id,
@@ -439,32 +441,60 @@ app.post("/api/slack/interactions", async (c) => {
         waitUntil(addPromise);
       }
 
-      // Dynamic modal: swap fields when credential type changes
-      if (action.action_id === "cred_type" && payload.view) {
-        const selectedType = (action.selected_option?.value || "token") as "token" | "oauth_client";
+      // Dynamic modal: swap fields when credential auth scheme changes
+      if (action.action_id === "cred_auth_scheme" && payload.view) {
+        const selectedScheme = (action.selected_option?.value || "bearer") as
+          | "bearer"
+          | "basic"
+          | "header"
+          | "query"
+          | "oauth_client"
+          | "google_service_account";
         // Preserve the name field value if already filled
         const currentName = payload.view.state?.values?.cred_name_block?.cred_name?.value || "";
-        const blocks = buildAddCredentialBlocks(selectedType);
-        // Inject current name value into the block
-        if (currentName) {
-          const nameBlock = blocks.find((b: any) => b.block_id === "cred_name_block");
-          if (nameBlock) {
-            nameBlock.element.initial_value = currentName;
-          }
+        const isAdd = payload.view.callback_id === "api_credential_add_submit";
+        const blocks = isAdd
+          ? buildAddCredentialBlocks(selectedScheme)
+          : [
+              ...buildUpdateCredentialBlocks(selectedScheme),
+              {
+                type: "context",
+                elements: [
+                  {
+                    type: "mrkdwn",
+                    text: "This will replace the current credential value. Encrypted at rest with AES-256-GCM.",
+                  },
+                ],
+              },
+            ];
+
+        if (isAdd && currentName) {
+          const nameBlock = blocks.find(
+            (b: any) => b.block_id === "cred_name_block",
+          );
+          if (nameBlock) nameBlock.element.initial_value = currentName;
         }
+
+        const titleText =
+          payload.view.title?.text ||
+          (isAdd ? "Add API Credential" : "Update Credential");
         const updatePromise = slackClient.views.update({
           view_id: payload.view.id,
           hash: payload.view.hash,
           view: {
             type: "modal",
-            callback_id: "api_credential_add_submit",
-            title: { type: "plain_text", text: "Add API Credential" },
+            callback_id: payload.view.callback_id,
+            private_metadata: payload.view.private_metadata,
+            title: { type: "plain_text", text: titleText },
             submit: { type: "plain_text", text: "Save" },
             close: { type: "plain_text", text: "Cancel" },
             blocks,
           },
         }).catch((err: unknown) => {
-          recordError("interactions.cred_type_switch", err, { userId, selectedType });
+          recordError("interactions.cred_auth_scheme_switch", err, {
+            userId,
+            selectedScheme,
+          });
         });
         waitUntil(updatePromise);
       }
@@ -479,11 +509,14 @@ app.post("/api/slack/interactions", async (c) => {
             const creds = await listApiCredentials(userId);
             const cred = creds.find((c) => c.id === credId);
             const credName = cred?.name ?? "credential";
+            const credAuthScheme = (cred?.authScheme ??
+              "bearer") as "bearer" | "basic" | "header" | "query" | "oauth_client" | "google_service_account";
             const updatePromise = openUpdateCredentialModal(
               slackClient,
               payload.trigger_id,
               credId,
               credName,
+              credAuthScheme,
             ).catch((err) => {
               recordError("interactions.api_credential_update_modal", err, { userId, credId });
             });
@@ -665,42 +698,110 @@ app.post("/api/slack/interactions", async (c) => {
       }
     }
 
+
+/** Extract credential value from modal state based on auth scheme */
+function extractCredentialValue(
+  values: Record<string, any> | undefined,
+  authScheme: "bearer" | "basic" | "header" | "query" | "oauth_client" | "google_service_account"
+): string | undefined {
+  if (authScheme === "oauth_client") {
+    const clientId = values?.cred_client_id_block?.cred_client_id?.value;
+    const clientSecret = values?.cred_client_secret_block?.cred_client_secret?.value;
+    const tokenUrl = values?.cred_token_url_block?.cred_token_url?.value;
+    if (clientId && clientSecret && tokenUrl) {
+      return JSON.stringify({ client_id: clientId, client_secret: clientSecret, token_url: tokenUrl });
+    }
+  } else if (authScheme === "basic") {
+    const username = values?.cred_username_block?.cred_username?.value;
+    const password = values?.cred_password_block?.cred_password?.value ?? "";
+    if (username) {
+      return JSON.stringify({ username, password });
+    }
+  } else if (authScheme === "header" || authScheme === "query") {
+    const key = values?.cred_key_block?.cred_key?.value;
+    const secret = values?.cred_secret_block?.cred_secret?.value;
+    if (key && secret) {
+      return JSON.stringify({ key, secret });
+    }
+  } else if (authScheme === "google_service_account") {
+    const jsonKey = values?.cred_gsa_json_block?.cred_gsa_json?.value;
+    const scopes = values?.cred_gsa_scopes_block?.cred_gsa_scopes?.value;
+    if (jsonKey) {
+      // Embed scopes into the JSON key so they're stored together
+      try {
+        const parsed = JSON.parse(jsonKey);
+        if (scopes) parsed.scopes = scopes;
+        return JSON.stringify(parsed);
+      } catch {
+        return undefined; // Invalid JSON -- validation will catch this
+      }
+    }
+  } else {
+    return values?.cred_value_block?.cred_value?.value;
+  }
+  return undefined;
+}
+
     if (callbackId === "api_credential_add_submit" && userId) {
+      if (!isAdmin(userId)) return c.json({});
       const name = payload.view?.state?.values?.cred_name_block?.cred_name?.value;
       const expiryStr = payload.view?.state?.values?.cred_expiry_block?.cred_expiry?.selected_date;
-      const credType = (payload.view?.state?.values?.cred_type_block?.cred_type?.selected_option?.value || "token") as "token" | "oauth_client";
+      const authScheme = (payload.view?.state?.values?.cred_auth_scheme_block?.cred_auth_scheme?.selected_option?.value || "bearer") as
+        | "bearer"
+        | "basic"
+        | "header"
+        | "query"
+        | "oauth_client"
+        | "google_service_account";
 
-      let value: string | undefined;
-      let tokenUrl: string | undefined;
-      if (credType === "oauth_client") {
-        const clientId = payload.view?.state?.values?.cred_client_id_block?.cred_client_id?.value;
-        const clientSecret = payload.view?.state?.values?.cred_client_secret_block?.cred_client_secret?.value;
-        tokenUrl = payload.view?.state?.values?.cred_token_url_block?.cred_token_url?.value || undefined;
-        if (clientId && clientSecret) {
-          value = JSON.stringify({ client_id: clientId, client_secret: clientSecret });
-        }
-      } else {
-        value = payload.view?.state?.values?.cred_value_block?.cred_value?.value;
-      }
+      const value = extractCredentialValue(payload.view?.state?.values, authScheme);
 
       if (name && value) {
 
         const expiresAt = expiryStr ? new Date(expiryStr) : undefined;
         const addPromise = (async () => {
           try {
-            await storeApiCredential(userId, name, value, expiresAt, credType, tokenUrl);
+            await storeApiCredential(userId, name, value, expiresAt, authScheme);
             await publishHomeTab(slackClient, userId);
           } catch (err) {
             recordError("interactions.api_credential_add", err, { userId, name });
+            try {
+              await slackClient.chat.postMessage({
+                channel: userId,
+                text: `Failed to save credential "${name}": ${err instanceof Error ? err.message : String(err)}`,
+              });
+            } catch { /* best effort */ }
           }
         })();
         waitUntil(addPromise);
+      } else if (name && !value) {
+        // Value extraction failed -- return validation error to the modal
+        console.warn(`[credential-add] value extraction failed for scheme=${authScheme}, user=${userId}, name=${name}`);
+        const errorBlock = authScheme === "basic" ? "cred_username_block"
+          : authScheme === "oauth_client" ? "cred_client_id_block"
+          : authScheme === "google_service_account" ? "cred_gsa_json_block"
+          : authScheme === "header" || authScheme === "query" ? "cred_secret_block"
+          : "cred_value_block";
+        return c.json({
+          response_action: "errors",
+          errors: {
+            [errorBlock]: "Required field is missing. Please fill in all required fields.",
+          },
+        });
       }
     }
 
     if (callbackId === "api_credential_update_submit" && userId) {
       const credentialId = payload.view?.private_metadata;
-      const value = payload.view?.state?.values?.cred_value_block?.cred_value?.value;
+      const authScheme = (payload.view?.state?.values?.cred_auth_scheme_block?.cred_auth_scheme?.selected_option?.value || "bearer") as
+        | "bearer"
+        | "basic"
+        | "header"
+        | "query"
+        | "oauth_client"
+        | "google_service_account";
+
+      const value = extractCredentialValue(payload.view?.state?.values, authScheme);
 
       if (credentialId && value) {
         const updatePromise = (async () => {
@@ -719,7 +820,13 @@ app.post("/api/slack/interactions", async (c) => {
               return;
             }
 
-            await storeApiCredential(cred.owner_id, cred.name, value, cred.expires_at ?? undefined, (cred.type as "token" | "oauth_client") ?? "token");
+            await storeApiCredential(
+              cred.owner_id,
+              cred.name,
+              value,
+              cred.expires_at ?? undefined,
+              authScheme,
+            );
             await publishHomeTab(slackClient, userId);
           } catch (err) {
             recordError("interactions.api_credential_update", err, { userId, credentialId });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -680,8 +680,7 @@ export const credentials = pgTable(
       .default(sql`gen_random_uuid()`),
     ownerId: text("owner_id").notNull(),
     name: text("name").notNull(),
-    type: text("type").notNull().default("token"),
-    tokenUrl: text("token_url"),
+    authScheme: text("auth_scheme").notNull().default("bearer"),
     value: text("value").notNull(),
     keyVersion: integer("key_version").notNull().default(1),
     expiresAt: timestamptz("expires_at"),
@@ -695,8 +694,8 @@ export const credentials = pgTable(
       sql`${table.name} ~ '^[a-z][a-z0-9_]{1,62}$'`,
     ),
     check(
-      "credentials_type_check",
-      sql`${table.type} IN ('token', 'oauth_client')`,
+      "credentials_auth_scheme_check",
+      sql`${table.authScheme} IN ('bearer', 'basic', 'header', 'query', 'oauth_client', 'google_service_account')`,
     ),
   ],
 );

--- a/src/lib/api-credentials.ts
+++ b/src/lib/api-credentials.ts
@@ -41,6 +41,8 @@ type AuditAction =
   | "use"
   | "expired_access_attempt";
 
+export type AuthScheme = "bearer" | "basic" | "header" | "query" | "oauth_client" | "google_service_account";
+
 async function audit(
   credentialId: string | null,
   credentialName: string,
@@ -115,21 +117,64 @@ export async function storeApiCredential(
   name: string,
   plaintext: string,
   expiresAt?: Date,
-  type: "token" | "oauth_client" = "token",
-  tokenUrl?: string,
+  authScheme: AuthScheme = "bearer",
 ): Promise<Credential> {
   validateKey();
   validateName(name);
 
-  if (type === "oauth_client") {
+  if (authScheme === "oauth_client") {
     try {
       const parsed = JSON.parse(plaintext);
-      if (!parsed.client_id || !parsed.client_secret) {
-        throw new Error("oauth_client value must contain client_id and client_secret");
+      if (!parsed.client_id || !parsed.client_secret || !parsed.token_url) {
+        throw new Error(
+          "oauth_client value must contain client_id, client_secret, and token_url",
+        );
       }
     } catch (e: any) {
-      if (e.message.includes("client_id") || e.message.includes("client_secret")) throw e;
-      throw new Error("oauth_client value must be valid JSON with client_id and client_secret keys");
+      if (
+        e.message.includes("client_id") ||
+        e.message.includes("client_secret") ||
+        e.message.includes("token_url")
+      ) {
+        throw e;
+      }
+      throw new Error(
+        "oauth_client value must be valid JSON with client_id, client_secret, and token_url keys",
+      );
+    }
+  } else if (authScheme === "basic") {
+    try {
+      const parsed = JSON.parse(plaintext);
+      if (!parsed.username) {
+        throw new Error("basic value must contain a username (password is optional)");
+      }
+    } catch (e: any) {
+      if (e.message.includes("username")) throw e;
+      throw new Error("basic value must be valid JSON with username and password keys");
+    }
+  } else if (authScheme === "header" || authScheme === "query") {
+    try {
+      const parsed = JSON.parse(plaintext);
+      if (!parsed.key || !parsed.secret) {
+        throw new Error(`${authScheme} value must contain key and secret`);
+      }
+    } catch (e: any) {
+      if (!(e instanceof SyntaxError)) throw e;
+      throw new Error(`${authScheme} value must be valid JSON with key and secret keys`);
+    }
+  } else if (authScheme === "google_service_account") {
+    try {
+      const parsed = JSON.parse(plaintext);
+      if (!parsed.private_key || !parsed.client_email) {
+        throw new Error(
+          "google_service_account value must contain private_key and client_email",
+        );
+      }
+    } catch (e: any) {
+      if (e.message.includes("private_key") || e.message.includes("client_email")) throw e;
+      throw new Error(
+        "google_service_account value must be valid Google service account JSON key",
+      );
     }
   }
 
@@ -140,8 +185,7 @@ export async function storeApiCredential(
     .values({
       ownerId,
       name,
-      type,
-      tokenUrl: type === "oauth_client" ? (tokenUrl ?? null) : null,
+      authScheme,
       value: encrypted,
       expiresAt: expiresAt ?? null,
     })
@@ -149,8 +193,7 @@ export async function storeApiCredential(
       target: [credentials.ownerId, credentials.name],
       set: {
         value: encrypted,
-        type,
-        tokenUrl: type === "oauth_client" ? (tokenUrl ?? null) : null,
+        authScheme,
         expiresAt: expiresAt ?? null,
         updatedAt: new Date(),
       },
@@ -214,36 +257,78 @@ export async function getApiCredentialWithType(
   ownerId: string,
   requestingUserId: string,
   intent: "read" | "write",
-): Promise<{ value: string; type: string; access_token?: string; expires_in?: number } | null> {
+): Promise<{ value: string; authScheme: AuthScheme } | null> {
   const cred = await fetchAndAuthorize(name, ownerId, requestingUserId, intent);
   if (!cred) return null;
 
   const decrypted = decryptCredential(cred.value);
 
-  if (cred.type === "oauth_client" && cred.tokenUrl) {
-    let parsed: { client_id: string; client_secret: string };
+  if (cred.authScheme === "oauth_client") {
+    let parsed: { client_id?: string; client_secret?: string; token_url?: string };
     try {
       parsed = JSON.parse(decrypted);
     } catch {
       throw new Error(`oauth_client credential "${name}" has invalid JSON value`);
     }
     if (!parsed.client_id || !parsed.client_secret) {
-      throw new Error(`oauth_client credential "${name}" missing client_id or client_secret`);
+      throw new Error(
+        `oauth_client credential "${name}" missing client_id or client_secret`,
+      );
+    }
+    if (!parsed.token_url) {
+      throw new Error(
+        `oauth_client credential "${name}" missing token_url (may need manual repair if migrated from legacy format)`,
+      );
     }
     const tokenResponse = await exchangeOAuthToken(
-      cred.tokenUrl,
+      parsed.token_url,
       parsed.client_id,
       parsed.client_secret,
     );
     return {
       value: tokenResponse.access_token,
-      type: cred.type,
-      access_token: tokenResponse.access_token,
-      expires_in: tokenResponse.expires_in,
+      authScheme: cred.authScheme as AuthScheme,
     };
   }
 
-  return { value: decrypted, type: cred.type };
+  if (cred.authScheme === "google_service_account") {
+    const token = await exchangeGoogleServiceAccountToken(decrypted);
+    return {
+      value: token,
+      authScheme: cred.authScheme as AuthScheme,
+    };
+  }
+
+  return { value: decrypted, authScheme: cred.authScheme as AuthScheme };
+}
+
+async function exchangeGoogleServiceAccountToken(
+  jsonKeyStr: string,
+): Promise<string> {
+  const { GoogleAuth } = await import("google-auth-library");
+  let keyData: { client_email: string; private_key: string; scopes?: string };
+  try {
+    keyData = JSON.parse(jsonKeyStr);
+  } catch {
+    throw new Error("google_service_account credential has invalid JSON value");
+  }
+
+  const auth = new GoogleAuth({
+    credentials: {
+      client_email: keyData.client_email,
+      private_key: keyData.private_key,
+    },
+    scopes: keyData.scopes
+      ? keyData.scopes.split(",").map((s: string) => s.trim())
+      : ["https://www.googleapis.com/auth/cloud-platform"],
+  });
+
+  const client = await auth.getClient();
+  const tokenResponse = await client.getAccessToken();
+  if (!tokenResponse.token) {
+    throw new Error("google_service_account: failed to obtain access token");
+  }
+  return tokenResponse.token;
 }
 
 async function exchangeOAuthToken(
@@ -289,7 +374,7 @@ async function exchangeOAuthToken(
 }
 
 /**
- * Retrieve a credential for a scheduled job. Returns raw decrypted value.
+ * Retrieve a credential for a scheduled job. Returns raw decrypted value and auth scheme.
  * NOTE: Does not auto-exchange oauth_client tokens — jobs get raw client_id/client_secret JSON.
  * This is intentional: jobs may need different exchange flows or caching strategies.
  * Use getApiCredentialWithType for interactive tool calls that need auto-exchange.
@@ -299,7 +384,7 @@ export async function getJobApiCredential(
   jobId: string,
   creatorId: string,
   declaredCredentialIds: string[],
-): Promise<string | null> {
+): Promise<{ value: string; authScheme: AuthScheme } | null> {
   validateKey();
   validateName(name);
 
@@ -327,7 +412,7 @@ export async function getJobApiCredential(
   }
 
   await audit(cred.id, name, `job:${jobId}`, "use", `creator:${creatorId}`);
-  return decryptCredential(cred.value);
+  return { value: decryptCredential(cred.value), authScheme: cred.authScheme as AuthScheme };
 }
 
 export async function getCredentialById(
@@ -351,7 +436,7 @@ export async function listApiCredentials(
   Array<{
     id: string;
     name: string;
-    type: string;
+    authScheme: AuthScheme;
     owner_id: string;
     expires_at: Date | null;
     permission: "owner" | "read" | "write" | "admin";
@@ -361,7 +446,7 @@ export async function listApiCredentials(
     .select({
       id: credentials.id,
       name: credentials.name,
-      type: credentials.type,
+      authScheme: credentials.authScheme,
       owner_id: credentials.ownerId,
       expires_at: credentials.expiresAt,
     })
@@ -372,7 +457,7 @@ export async function listApiCredentials(
     .select({
       id: credentials.id,
       name: credentials.name,
-      type: credentials.type,
+      authScheme: credentials.authScheme,
       owner_id: credentials.ownerId,
       expires_at: credentials.expiresAt,
       permission: credentialGrants.permission,
@@ -387,8 +472,8 @@ export async function listApiCredentials(
     );
 
   return [
-    ...owned.map((r) => ({ ...r, permission: "owner" as const })),
-    ...granted.map((r) => ({ ...r, permission: r.permission as "read" | "write" | "admin" })),
+    ...owned.map((r) => ({ ...r, authScheme: r.authScheme as AuthScheme, permission: "owner" as const })),
+    ...granted.map((r) => ({ ...r, authScheme: r.authScheme as AuthScheme, permission: r.permission as "read" | "write" | "admin" })),
   ];
 }
 
@@ -579,4 +664,90 @@ export function maskApiCredential(value: string): string {
   const first4 = value.slice(0, 4);
   const last4 = value.slice(-4);
   return `${first4}***${last4}`;
+}
+
+/**
+ * One-time data migration: fold `token_url` from the old column into the encrypted
+ * value JSON blob for oauth_client credentials.
+ *
+ * Safe to call at startup — checks whether the legacy `type` column still exists
+ * before doing anything. After the SQL migration in 0034 drops that column, this
+ * is a no-op. Idempotent: re-running when already migrated does nothing.
+ */
+export async function runCredentialMigration(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) return;
+
+  // Check if the old `type` column still exists (pre-migration state)
+  const { neon } = await import("@neondatabase/serverless");
+  const rawSql = neon(connectionString);
+
+  const cols = await rawSql`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name = 'credentials'
+      AND column_name = 'type'
+  `;
+
+  if (cols.length === 0) {
+    // Column already gone — migration already ran, nothing to do
+    return;
+  }
+
+  logger.info("runCredentialMigration: folding token_url into oauth_client value blobs");
+
+  // Fetch all oauth_client rows via raw SQL (Drizzle schema no longer has these columns)
+  const rows = await rawSql`
+    SELECT id, value, token_url
+    FROM credentials
+    WHERE type = 'oauth_client'
+  `;
+
+  for (const row of rows) {
+    try {
+      const decrypted = decryptCredential(row.value as string);
+      let parsed: Record<string, string> = {};
+      try {
+        parsed = JSON.parse(decrypted);
+      } catch {
+        // value wasn't JSON yet — treat as empty object
+      }
+
+      // Migrate token_url if present; if null/undefined, leave it out of the JSON blob
+      // (credential will need manual repair later, but won't crash on read)
+      if (row.token_url && !parsed.token_url) {
+        parsed.token_url = row.token_url as string;
+      } else if (!row.token_url && !parsed.token_url) {
+        // No token_url available — log warning but continue migration
+        logger.warn("runCredentialMigration: oauth_client credential missing token_url", {
+          id: row.id,
+        });
+        // Don't set token_url in the blob; the credential will fail validation on read,
+        // but at least the migration won't crash
+      }
+
+      const { encryptCredential: enc } = await import("./credentials.js");
+      const reEncrypted = enc(JSON.stringify(parsed));
+
+      await rawSql`
+        UPDATE credentials
+        SET value = ${reEncrypted},
+            auth_scheme = 'oauth_client',
+            updated_at = NOW()
+        WHERE id = ${row.id}
+      `;
+    } catch (err) {
+      logger.error("runCredentialMigration: failed to migrate row", { id: row.id, err });
+    }
+  }
+
+  // Ensure all legacy token rows are marked as bearer
+  await rawSql`
+    UPDATE credentials
+    SET auth_scheme = 'bearer'
+    WHERE type = 'token'
+      AND auth_scheme != 'bearer'
+  `;
+
+  logger.info("runCredentialMigration: complete");
 }

--- a/src/slack/home.ts
+++ b/src/slack/home.ts
@@ -7,6 +7,7 @@ import {
   listApiCredentials,
   listGrantsForCredentials,
   getCredentialById,
+  type AuthScheme,
 } from "../lib/api-credentials.js";
 
 // ── Model Catalog ────────────────────────────────────────────────────────────
@@ -154,7 +155,7 @@ async function buildCredentialBlocks(): Promise<any[]> {
 
 // ── User API Credential Blocks ──────────────────────────────────────────────
 
-async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
+async function buildUserCredentialBlocks(userId: string, userIsAdmin: boolean): Promise<any[]> {
   const creds = await listApiCredentials(userId);
 
   const blocks: any[] = [
@@ -172,17 +173,21 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
         },
       ],
     },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "+ Add Credential", emoji: true },
-          action_id: "api_credential_add",
-          style: "primary",
-        },
-      ],
-    },
+    ...(userIsAdmin
+      ? [
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "+ Add Credential", emoji: true },
+                action_id: "api_credential_add",
+                style: "primary",
+              },
+            ],
+          },
+        ]
+      : []),
   ];
 
   if (creds.length === 0) {
@@ -224,12 +229,14 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
         : `  ·  expires ${expiresAt.toISOString().slice(0, 10)}`;
     }
 
-    const overflowOptions: any[] = [
-      {
+    const canWrite = isOwner || cred.permission === "write" || cred.permission === "admin";
+    const overflowOptions: any[] = [];
+    if (canWrite) {
+      overflowOptions.push({
         text: { type: "plain_text", text: "Update" },
         value: `api_credential_update_${cred.id}`,
-      },
-    ];
+      });
+    }
     if (isOwner) {
       overflowOptions.push(
         {
@@ -251,18 +258,21 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
       });
     }
 
-    blocks.push({
+    const section: any = {
       type: "section",
       text: {
         type: "mrkdwn",
         text: `*${cred.name}*  ·  _${source}_ (${permLabel})${expiryText}`,
       },
-      accessory: {
+    };
+    if (overflowOptions.length > 0) {
+      section.accessory = {
         type: "overflow",
         action_id: `api_credential_overflow_${cred.id}`,
         options: overflowOptions,
-      },
-    });
+      };
+    }
+    blocks.push(section);
   }
 
   return blocks;
@@ -270,80 +280,197 @@ async function buildUserCredentialBlocks(userId: string): Promise<any[]> {
 
 // ── User Credential Modals ──────────────────────────────────────────────────
 
-export function buildAddCredentialBlocks(credType: "token" | "oauth_client" = "token"): any[] {
-  const typeBlock = {
+
+function buildAuthSchemeBlock(authScheme: AuthScheme) {
+  return {
     type: "input",
-    block_id: "cred_type_block",
+    block_id: "cred_auth_scheme_block",
     dispatch_action: true,
-    label: { type: "plain_text", text: "Type" },
+    label: { type: "plain_text", text: "Auth Scheme" },
     element: {
       type: "static_select",
-      action_id: "cred_type",
+      action_id: "cred_auth_scheme",
       options: [
-        { text: { type: "plain_text", text: "Token" }, value: "token" },
+        { text: { type: "plain_text", text: "Bearer" }, value: "bearer" },
+        { text: { type: "plain_text", text: "Basic" }, value: "basic" },
+        { text: { type: "plain_text", text: "Header" }, value: "header" },
+        { text: { type: "plain_text", text: "Query" }, value: "query" },
         { text: { type: "plain_text", text: "OAuth Client" }, value: "oauth_client" },
+        { text: { type: "plain_text", text: "Google Service Account" }, value: "google_service_account" },
       ],
-      initial_option: credType === "oauth_client"
-        ? { text: { type: "plain_text", text: "OAuth Client" }, value: "oauth_client" }
-        : { text: { type: "plain_text", text: "Token" }, value: "token" },
+      initial_option: (() => {
+        const labels: Record<AuthScheme, string> = {
+          bearer: "Bearer",
+          basic: "Basic",
+          header: "Header",
+          query: "Query",
+          oauth_client: "OAuth Client",
+          google_service_account: "Google Service Account",
+        };
+        return { text: { type: "plain_text", text: labels[authScheme] }, value: authScheme };
+      })(),
     },
   };
+}
 
-  const valueBlocks = credType === "oauth_client"
-    ? [
-        {
-          type: "input",
-          block_id: "cred_client_id_block",
-          label: { type: "plain_text", text: "Client ID" },
-          element: {
-            type: "plain_text_input",
-            action_id: "cred_client_id",
-            placeholder: { type: "plain_text", text: "Paste client ID" },
+function buildCredentialValueBlocks(authScheme: AuthScheme): any[] {
+  if (authScheme === "oauth_client") {
+    return [
+      {
+        type: "input",
+        block_id: "cred_client_id_block",
+        label: { type: "plain_text", text: "Client ID" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_client_id",
+          placeholder: { type: "plain_text", text: "Paste client ID" },
+        },
+      },
+      {
+        type: "input",
+        block_id: "cred_client_secret_block",
+        label: { type: "plain_text", text: "Client Secret" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_client_secret",
+          placeholder: { type: "plain_text", text: "Paste client secret" },
+        },
+      },
+      {
+        type: "input",
+        block_id: "cred_token_url_block",
+        label: { type: "plain_text", text: "Token URL" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_token_url",
+          placeholder: {
+            type: "plain_text",
+            text: "https://cloud.airbyte.com/api/v1/applications/token",
           },
         },
-        {
-          type: "input",
-          block_id: "cred_client_secret_block",
-          label: { type: "plain_text", text: "Client Secret" },
-          element: {
-            type: "plain_text_input",
-            action_id: "cred_client_secret",
-            placeholder: { type: "plain_text", text: "Paste client secret" },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Credentials will be automatically exchanged for an access token when retrieved.",
+          },
+        ],
+      },
+    ];
+  }
+
+  if (authScheme === "google_service_account") {
+    return [
+      {
+        type: "input",
+        block_id: "cred_gsa_json_block",
+        label: { type: "plain_text", text: "Service Account JSON Key" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_gsa_json",
+          multiline: true,
+          placeholder: { type: "plain_text", text: "Paste the full JSON key file contents" },
+        },
+      },
+      {
+        type: "input",
+        block_id: "cred_gsa_scopes_block",
+        optional: true,
+        label: { type: "plain_text", text: "Scopes (optional)" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_gsa_scopes",
+          placeholder: {
+            type: "plain_text",
+            text: "e.g. https://www.googleapis.com/auth/bigquery.readonly",
           },
         },
-        {
-          type: "input",
-          block_id: "cred_token_url_block",
-          optional: true,
-          label: { type: "plain_text", text: "Token URL (optional)" },
-          element: {
-            type: "plain_text_input",
-            action_id: "cred_token_url",
-            placeholder: { type: "plain_text", text: "https://cloud.airbyte.com/api/v1/applications/token" },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Defaults to `cloud-platform` scope. Comma-separate multiple scopes. The JSON key is encrypted at rest and used server-side to mint short-lived OAuth2 tokens via JWT exchange.",
           },
+        ],
+      },
+    ];
+  }
+
+  if (authScheme === "header" || authScheme === "query") {
+    const keyLabel = authScheme === "header" ? "Header Name" : "Query Key";
+    const keyPlaceholder =
+      authScheme === "header" ? "e.g. x-api-key" : "e.g. api_key";
+    return [
+      {
+        type: "input",
+        block_id: "cred_key_block",
+        label: { type: "plain_text", text: keyLabel },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_key",
+          placeholder: { type: "plain_text", text: keyPlaceholder },
         },
-        {
-          type: "context",
-          elements: [
-            {
-              type: "mrkdwn",
-              text: "If provided, credentials will be automatically exchanged for an access token when retrieved.",
-            },
-          ],
+      },
+      {
+        type: "input",
+        block_id: "cred_secret_block",
+        label: { type: "plain_text", text: "Secret" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_secret",
+          placeholder: { type: "plain_text", text: "Paste secret value" },
         },
-      ]
-    : [
-        {
-          type: "input",
-          block_id: "cred_value_block",
-          label: { type: "plain_text", text: "Value" },
-          element: {
-            type: "plain_text_input",
-            action_id: "cred_value",
-            placeholder: { type: "plain_text", text: "Paste your API token or key" },
-          },
+      },
+    ];
+  }
+
+  if (authScheme === "basic") {
+    return [
+      {
+        type: "input",
+        block_id: "cred_username_block",
+        label: { type: "plain_text", text: "Username" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_username",
+          placeholder: { type: "plain_text", text: "e.g. admin or user@example.com" },
         },
-      ];
+      },
+      {
+        type: "input",
+        block_id: "cred_password_block",
+        optional: true,
+        label: { type: "plain_text", text: "Password (optional)" },
+        element: {
+          type: "plain_text_input",
+          action_id: "cred_password",
+          placeholder: { type: "plain_text", text: "Leave empty if API key is the username" },
+        },
+      },
+    ];
+  }
+
+  return [
+    {
+      type: "input",
+      block_id: "cred_value_block",
+      label: { type: "plain_text", text: "Value" },
+      element: {
+        type: "plain_text_input",
+        action_id: "cred_value",
+        placeholder: { type: "plain_text", text: "Paste your API token or key" },
+      },
+    },
+  ];
+}
+
+export function buildAddCredentialBlocks(authScheme: AuthScheme = "bearer"): any[] {
+  const authSchemeBlock = buildAuthSchemeBlock(authScheme);
+  const valueBlocks = buildCredentialValueBlocks(authScheme);
 
   return [
     {
@@ -360,7 +487,7 @@ export function buildAddCredentialBlocks(credType: "token" | "oauth_client" = "t
         text: "Lowercase, a-z, 0-9, underscores. e.g. airbyte_api_token",
       },
     },
-    typeBlock,
+    authSchemeBlock,
     ...valueBlocks,
     {
       type: "input",
@@ -376,6 +503,13 @@ export function buildAddCredentialBlocks(credType: "token" | "oauth_client" = "t
   ];
 }
 
+export function buildUpdateCredentialBlocks(authScheme: AuthScheme = "bearer"): any[] {
+  const authSchemeBlock = buildAuthSchemeBlock(authScheme);
+  const valueBlocks = buildCredentialValueBlocks(authScheme);
+
+  return [authSchemeBlock, ...valueBlocks];
+}
+
 export async function openAddCredentialModal(
   client: WebClient,
   triggerId: string,
@@ -388,7 +522,7 @@ export async function openAddCredentialModal(
       title: { type: "plain_text", text: "Add API Credential" },
       submit: { type: "plain_text", text: "Save" },
       close: { type: "plain_text", text: "Cancel" },
-      blocks: buildAddCredentialBlocks("token"),
+      blocks: buildAddCredentialBlocks("bearer"),
     },
   });
 }
@@ -398,6 +532,7 @@ export async function openUpdateCredentialModal(
   triggerId: string,
   credentialId: string,
   credentialName: string,
+  authScheme: AuthScheme,
 ): Promise<void> {
   await client.views.open({
     trigger_id: triggerId,
@@ -409,19 +544,7 @@ export async function openUpdateCredentialModal(
       submit: { type: "plain_text", text: "Save" },
       close: { type: "plain_text", text: "Cancel" },
       blocks: [
-        {
-          type: "input",
-          block_id: "cred_value_block",
-          label: { type: "plain_text", text: "New Value" },
-          element: {
-            type: "plain_text_input",
-            action_id: "cred_value",
-            placeholder: {
-              type: "plain_text",
-              text: "Paste the new token value",
-            },
-          },
-        },
+        ...buildUpdateCredentialBlocks(authScheme),
         {
           type: "context",
           elements: [
@@ -700,7 +823,7 @@ export async function publishHomeTab(
       );
     }
 
-    const userCredBlocks = await buildUserCredentialBlocks(userId);
+    const userCredBlocks = await buildUserCredentialBlocks(userId, admin);
     blocks.push(...userCredBlocks);
 
     if (admin) {

--- a/src/tools/credentials.ts
+++ b/src/tools/credentials.ts
@@ -12,7 +12,7 @@ export function createCredentialTools(context?: ScheduleContext) {
   return {
     get_credential: defineTool({
       description:
-        "Retrieve a stored API credential by name. Returns the decrypted value for 'token' type credentials. For 'oauth_client' type with a configured token_url, automatically exchanges client credentials for a fresh access token and returns it ready to use. If no token_url is set, returns parsed client_id + client_secret. Permission checks and audit logging are automatic. Use this when a job or workflow needs an API key, token, or OAuth client credentials that the user has stored via the App Home.",
+        "Retrieve a stored API credential by name. Returns the decrypted value based on auth_scheme (bearer, basic, header, query, oauth_client). For oauth_client, automatically exchanges client credentials for a fresh access token using token_url stored inside the credential value. Permission checks and audit logging are automatic. Use this when a job or workflow needs an API key, token, or OAuth client credentials that the user has stored via the App Home.",
       inputSchema: z.object({
         name: z
           .string()
@@ -49,34 +49,17 @@ export function createCredentialTools(context?: ScheduleContext) {
             };
           }
 
-          if (result.type === "oauth_client") {
-            if (result.access_token) {
-              return {
-                ok: true,
-                type: "oauth_client" as const,
-                value: result.access_token,
-                ...(result.expires_in != null && { expires_in: result.expires_in }),
-              };
-            }
-            try {
-              const parsed = JSON.parse(result.value);
-              return {
-                ok: true,
-                type: "oauth_client" as const,
-                client_id: parsed.client_id,
-                client_secret: parsed.client_secret,
-              };
-            } catch {
-              return {
-                ok: false,
-                error: `Credential "${name}" has type oauth_client but its value is not valid JSON.`,
-              };
-            }
+          if (result.authScheme === "oauth_client") {
+            return {
+              ok: true,
+              auth_scheme: "oauth_client" as const,
+              value: result.value,
+            };
           }
 
           return {
             ok: true,
-            type: "token" as const,
+            auth_scheme: result.authScheme,
             value: result.value,
           };
         } catch (error: any) {

--- a/src/tools/http-request.ts
+++ b/src/tools/http-request.ts
@@ -76,6 +76,7 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           }
 
           const headers: Record<string, string> = { ...input.headers };
+          let requestUrl = input.url;
 
           if (input.credential_name) {
             const owner = input.credential_owner ?? context?.userId;
@@ -102,7 +103,99 @@ export function createHttpRequestTool(context?: ScheduleContext) {
               };
             }
 
-            headers["Authorization"] = `Bearer ${credResult.value}`;
+            switch (credResult.authScheme) {
+              case "bearer":
+              case "oauth_client":
+              case "google_service_account": {
+                headers["Authorization"] = `Bearer ${credResult.value}`;
+                break;
+              }
+              case "basic": {
+                let basicParsed: { username: string; password: string };
+                try {
+                  basicParsed = JSON.parse(credResult.value);
+                } catch {
+                  return {
+                    ok: false as const,
+                    error: "basic credential value must be JSON {username, password}",
+                  };
+                }
+                const encoded = Buffer.from(
+                  `${basicParsed.username}:${basicParsed.password ?? ""}`
+                ).toString("base64");
+                headers["Authorization"] = `Basic ${encoded}`;
+                break;
+              }
+              case "header": {
+                let parsed: { key: string; secret: string };
+                try {
+                  parsed = JSON.parse(credResult.value);
+                } catch {
+                  return {
+                    ok: false as const,
+                    error: `Credential "${input.credential_name}" has auth_scheme header but its value is not valid JSON`,
+                  };
+                }
+                if (!parsed.key || !parsed.secret) {
+                  return {
+                    ok: false as const,
+                    error: `Credential "${input.credential_name}" must include key and secret for header auth`,
+                  };
+                }
+                if (!/^[a-zA-Z0-9\-_]+$/.test(parsed.key)) {
+                  return {
+                    ok: false as const,
+                    error: `Invalid header name "${parsed.key}": must contain only alphanumeric characters, hyphens, and underscores`,
+                  };
+                }
+                const blockedHeaders = ["authorization"];
+                if (blockedHeaders.includes(parsed.key.toLowerCase())) {
+                  return {
+                    ok: false as const,
+                    error: `Header name "${parsed.key}" is blocked -- use bearer or basic auth_scheme for Authorization headers`,
+                  };
+                }
+                headers[parsed.key] = parsed.secret;
+                break;
+              }
+              case "query": {
+                // ⚠️ SECURITY WARNING: Query parameter authentication exposes secrets in URLs.
+                // Secrets will appear in:
+                // - Server access logs
+                // - Browser history
+                // - CDN/proxy logs
+                // - Referer headers when navigating away
+                // Use query auth only when required by the API and no better option exists.
+                let parsed: { key: string; secret: string };
+                try {
+                  parsed = JSON.parse(credResult.value);
+                } catch {
+                  return {
+                    ok: false as const,
+                    error: `Credential "${input.credential_name}" has auth_scheme query but its value is not valid JSON`,
+                  };
+                }
+                if (!parsed.key || !parsed.secret) {
+                  return {
+                    ok: false as const,
+                    error: `Credential "${input.credential_name}" must include key and secret for query auth`,
+                  };
+                }
+                logger.warn("Using query parameter auth - secrets will be exposed in URL", {
+                  credential: input.credential_name,
+                  url: input.url,
+                });
+                const urlObj = new URL(requestUrl);
+                urlObj.searchParams.set(parsed.key, parsed.secret);
+                requestUrl = urlObj.toString();
+                break;
+              }
+              default:
+                return {
+                  ok: false as const,
+                  error: `Unsupported auth scheme for credential "${input.credential_name}"`,
+                };
+            }
           }
 
           if (
@@ -120,10 +213,12 @@ export function createHttpRequestTool(context?: ScheduleContext) {
             hasCredential: !!input.credential_name,
           });
 
-          const response = await fetch(input.url, {
+          const response = await fetch(requestUrl, {
             method: input.method,
             headers,
-            body: input.body ? JSON.stringify(input.body) : undefined,
+            body: input.body
+              ? (typeof input.body === "string" ? input.body : JSON.stringify(input.body))
+              : undefined,
             redirect: "manual",
             signal: AbortSignal.timeout(input.timeout_ms),
           });


### PR DESCRIPTION
## Problem
The existing credential model only supports two types: 'token' (raw API key) and 'oauth_client' (client_id + client_secret + token_url). This doesn't cover common auth patterns like basic auth, custom headers (x-api-key), query parameter auth, or Google service accounts.

## Solution
Replace the 'type' + 'token_url' model with a single 'auth_scheme' column supporting 6 authentication methods:

- **bearer** (default): Raw token -> Authorization: Bearer <token>
- **basic**: JSON {username, password?} -> Authorization: Basic <b64>
- **header**: JSON {key, secret} -> Custom header injection (e.g. x-api-key: <secret>). 'authorization' header blocked -- use bearer/basic instead.
- **query**: JSON {key, secret} -> Appended as URL query parameter
- **oauth_client**: JSON {client_id, client_secret, token_url} ->
  Auto-exchanges for access token via client_credentials grant
- **google_service_account**: Service account JSON key -> JWT signed and exchanged for Google access token

## Database changes
- Migration 0034: Adds auth_scheme column with default 'bearer', runs idempotent runtime migration to convert existing credentials (type='token' -> auth_scheme='bearer', type='oauth_client' -> auth_scheme='oauth_client' with token_url folded into value JSON)
- Migration 0035: Adds 'google_service_account' to the check constraint

## UI changes (App Home)
- Add/Update credential modals now show a dropdown for auth_scheme
- Dynamic form fields swap based on selected scheme (e.g. basic shows username + password fields, header shows key + secret)
- Admin gate on credential creation (non-admins can't add credentials)
- DM error feedback when credential save fails

## http_request changes
- Auth injection logic handles all 6 schemes
- Header auth validates key name format and blocks 'authorization'
- Basic auth handles missing password gracefully (encodes as 'user:')
- Validation moved to storeApiCredential for consistent enforcement

## get_credential tool
- Returns auth_scheme instead of type
- oauth_client auto-exchange simplified (handled in api-credentials.ts)

## Security
- Header scheme blocks 'authorization' to prevent auth confusion
- All credential values encrypted at rest (existing behavior)
- Admin-only creation gate prevents unauthorized credential storage
- View submission returns proper JSON responses (prevents Slack modal timeouts on permission errors)