### PR TITLE
fix: attach slack card metadata to toolSearch (BM25) built-in tool

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -3017,7 +3017,18 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
 
   if (isAnthropic) {
     const { anthropic } = await import("@ai-sdk/anthropic");
-    tools.toolSearch = anthropic.tools.toolSearchBm25_20251119();
+    // TODO: toolSearchBm25_20251119() returns an Anthropic-native tool object that bypasses
+    // defineTool(), so it never gets the `slack` metadata we use for Slack action cards.
+    // Workaround: cast to any and attach the slack property manually so the pipeline
+    // renders a proper card (status + detail) instead of the fallback "Done" label.
+    // Long-term fix: Anthropic should expose a way to attach metadata to built-in tools,
+    // or we should wrap it in defineTool() once the SDK supports that pattern.
+    const _toolSearch = anthropic.tools.toolSearchBm25_20251119();
+    ((_toolSearch as unknown) as Record<string, unknown>).slack = {
+      status: "Searching tools...",
+      detail: (i: { query: string }) => i.query,
+    };
+    tools.toolSearch = _toolSearch;
 
     const DEFERRED_TOOLS = new Set([
       // BigQuery / Data


### PR DESCRIPTION
## Problem

`anthropic.tools.toolSearchBm25_20251119()` is an Anthropic-native built-in tool that bypasses `defineTool()`. All our custom tools get a `slack` property attached via `defineTool()` which the pipeline uses to render descriptive Slack action cards (status label + detail). `toolSearch` never goes through that path, so it renders as a bare **"Done"** label with no context.

## Workaround

After calling `toolSearchBm25_20251119()`, manually attach the `slack` metadata property via cast before assigning to the toolset:

```ts
const _toolSearch = anthropic.tools.toolSearchBm25_20251119();
((_toolSearch as unknown) as Record<string, unknown>).slack = {
  status: "Searching tools...",
  detail: (i: { query: string }) => i.query,
};
tools.toolSearch = _toolSearch;
```

The pipeline reads `.slack` via duck-typing (`getSlackMeta`), so this is sufficient.

## Result

`toolSearch` now renders as **"Searching tools... `<query>`"** in Slack instead of **"Done"**.

## TODO / Long-term fix

- [ ] If Anthropic exposes a way to attach metadata to built-in tools in the SDK, use that instead of the cast
- [ ] Alternatively, wrap `toolSearch` in `defineTool()` if the SDK makes that feasible
- [ ] Related: other Anthropic built-ins (if any) would have the same gap -- audit if we add more