### PR TITLE
fix: promote run_command, list_slack_list_items, get_slack_list_item to eager tools

### DIFF
--- a/src/tools/slack.ts
+++ b/src/tools/slack.ts
@@ -3041,16 +3041,16 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
       "check_calendar", "create_event", "update_event", "delete_event", "find_available_slot",
       // Canvas
       "read_canvas", "create_canvas", "edit_canvas", "delete_canvas", "share_canvas", "list_canvases",
-      // Slack Lists
-      "list_slack_list_items", "get_slack_list_item", "create_slack_list_item", "update_slack_list_item", "delete_slack_list_item",
+      // Slack Lists (list + get are eager -- used in every bug triage session)
+      "create_slack_list_item", "update_slack_list_item", "delete_slack_list_item",
       // Email
       "send_email", "reply_to_email",
       // Email triage (per-user Gmail)
       "sync_emails", "email_digest", "update_email_thread",
       "read_user_emails", "read_user_email",
       "generate_gmail_auth_url", "create_gmail_draft", "list_gmail_drafts", "delete_gmail_draft",
-      // Dev / Code
-      "run_command", "dispatch_headless", "read_job_trace",
+      // Dev / Code (run_command is eager -- used reflexively in most sessions)
+      "dispatch_headless", "read_job_trace",
       "dispatch_cursor_agent", "check_cursor_agent", "followup_cursor_agent",
       "stop_cursor_agent", "get_cursor_conversation", "list_cursor_agents",
       // Browser


### PR DESCRIPTION
## What

Removes 3 high-frequency tools from `DEFERRED_TOOLS`, making them eager (always in context):

- `run_command` -- used reflexively in almost every technical session. Deferring it means a BM25 search roundtrip before I can run a shell command. This was the root cause of today's "I don't have run_command" confusion.
- `list_slack_list_items` -- called in every bug triage session to read the bugs list
- `get_slack_list_item` -- called immediately after listing, to get item detail + thread_ts

## Why not the others?

`create/update/delete_slack_list_item` stay deferred -- write ops are situational.
All Cursor agent tools (`dispatch_cursor_agent`, etc.) stay deferred -- only needed when explicitly asked to dispatch code work.

## Schema token impact

Moving 3 tools from deferred to eager adds ~150-200 tokens to every invocation. That's well worth it for tools I reach for every session.