### PR TITLE
fix: restore API runtime + dashboard auth returnTo

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,4 +1,6 @@
 {
+  "framework": null,
+  "buildCommand": "pnpm --filter @aura/db build && pnpm --filter @aura/db db:migrate && mkdir -p public && echo '{}' > public/.keep",
   "regions": [
     "fra1"
   ],

--- a/apps/dashboard/src/app/api/auth/callback/route.ts
+++ b/apps/dashboard/src/app/api/auth/callback/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createSession, getSessionCookieName } from "@/lib/auth";
+import {
+  buildAppRedirectUrl,
+  getSafeReturnTo,
+  OAUTH_RETURN_TO_COOKIE,
+} from "@/lib/auth-redirect";
 import { isAdmin } from "@/lib/permissions";
 
 export async function GET(request: NextRequest) {
@@ -11,6 +16,9 @@ export async function GET(request: NextRequest) {
 
   const cookieStore = await cookies();
   const savedState = cookieStore.get("oauth_state")?.value;
+  const returnTo = getSafeReturnTo(
+    cookieStore.get(OAUTH_RETURN_TO_COOKIE)?.value,
+  );
 
   if (!code || !state || state !== savedState) {
     return NextResponse.redirect(`${appUrl}/unauthorized?reason=invalid_state`);
@@ -60,6 +68,7 @@ export async function GET(request: NextRequest) {
     maxAge: 7 * 24 * 60 * 60,
     path: "/",
   });
+  cookieStore.delete(OAUTH_RETURN_TO_COOKIE);
 
-  return NextResponse.redirect(appUrl);
+  return NextResponse.redirect(buildAppRedirectUrl(appUrl, returnTo));
 }

--- a/apps/dashboard/src/app/api/auth/login/route.ts
+++ b/apps/dashboard/src/app/api/auth/login/route.ts
@@ -1,10 +1,29 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import crypto from "node:crypto";
 import { cookies } from "next/headers";
 import { createSession, getSessionCookieName } from "@/lib/auth";
+import {
+  buildAppRedirectUrl,
+  getSafeReturnTo,
+  OAUTH_RETURN_TO_COOKIE,
+} from "@/lib/auth-redirect";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  const returnTo = getSafeReturnTo(request.nextUrl.searchParams.get("returnTo"));
+  const cookieStore = await cookies();
+
+  if (returnTo) {
+    cookieStore.set(OAUTH_RETURN_TO_COOKIE, returnTo, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV !== "development",
+      sameSite: "lax",
+      maxAge: 300,
+      path: "/",
+    });
+  } else {
+    cookieStore.delete(OAUTH_RETURN_TO_COOKIE);
+  }
 
   // In local dev, skip Slack OAuth and create a session directly
   if (process.env.NODE_ENV === "development") {
@@ -14,7 +33,6 @@ export async function GET() {
       name: "Dev Admin",
       picture: "",
     });
-    const cookieStore = await cookies();
     cookieStore.set(getSessionCookieName(), jwt, {
       httpOnly: true,
       secure: false,
@@ -22,12 +40,10 @@ export async function GET() {
       maxAge: 7 * 24 * 60 * 60,
       path: "/",
     });
-    return NextResponse.redirect(appUrl);
+    return NextResponse.redirect(buildAppRedirectUrl(appUrl, returnTo));
   }
 
   const state = crypto.randomBytes(16).toString("hex");
-
-  const cookieStore = await cookies();
   cookieStore.set("oauth_state", state, {
     httpOnly: true,
     secure: true,

--- a/apps/dashboard/src/lib/auth-redirect.ts
+++ b/apps/dashboard/src/lib/auth-redirect.ts
@@ -1,0 +1,25 @@
+export const OAUTH_RETURN_TO_COOKIE = "oauth_return_to";
+
+export function getSafeReturnTo(returnTo: string | null | undefined) {
+  if (!returnTo || !returnTo.startsWith("/")) {
+    return null;
+  }
+
+  // Reject protocol-relative URLs like //evil.com.
+  if (returnTo.startsWith("//")) {
+    return null;
+  }
+
+  if (returnTo.startsWith("/api/auth")) {
+    return null;
+  }
+
+  return returnTo;
+}
+
+export function buildAppRedirectUrl(
+  appUrl: string,
+  returnTo: string | null | undefined,
+) {
+  return new URL(getSafeReturnTo(returnTo) || "/", appUrl);
+}

--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -11,7 +11,7 @@ function getSecret() {
 }
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+  const { pathname, search } = request.nextUrl;
 
   if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
     return NextResponse.next();
@@ -19,7 +19,9 @@ export async function middleware(request: NextRequest) {
 
   const token = request.cookies.get("aura_session")?.value;
   if (!token) {
-    return NextResponse.redirect(new URL("/api/auth/login", request.url));
+    const loginUrl = new URL("/api/auth/login", request.url);
+    loginUrl.searchParams.set("returnTo", `${pathname}${search}`);
+    return NextResponse.redirect(loginUrl);
   }
 
   try {
@@ -30,7 +32,9 @@ export async function middleware(request: NextRequest) {
     response.headers.set("x-user-picture", payload.picture as string);
     return response;
   } catch {
-    return NextResponse.redirect(new URL("/api/auth/login", request.url));
+    const loginUrl = new URL("/api/auth/login", request.url);
+    loginUrl.searchParams.set("returnTo", `${pathname}${search}`);
+    return NextResponse.redirect(loginUrl);
   }
 }
 

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,3 +1,6 @@
 {
+  "regions": [
+    "fra1"
+  ],
   "framework": "nextjs"
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,10 +4,17 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./schema": "./src/schema.ts"
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./schema": {
+      "types": "./src/schema.ts",
+      "default": "./dist/schema.js"
+    }
   },
   "scripts": {
+    "build": "tsc",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/migrate.ts",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary

- **Fix API crash (production was down):** The monorepo migration switched the Vercel project to the Hono framework preset, which bundled raw `.ts` files from the `@aura/db` workspace package without compiling them — Node.js crashed at cold start. Fixed by adding a `build` step to `@aura/db` (exports now point to compiled `dist/*.js`) and overriding the preset with `"framework": null` in `vercel.json`.
- **Dashboard auth returnTo:** After Slack OAuth, users now land back on the page they were visiting instead of always going to `/`. Uses a short-lived cookie with open-redirect protection.
- **Dashboard region:** Pin to `fra1` for consistency with the API.

## Test plan

- [x] `curl https://aura-alpha-five.vercel.app/` returns `{"name":"Aura","version":"0.1.0","status":"alive"}` (already deployed and verified)
- [x] `/api/slack/events` returns 401 (signature check working, not 500)
- [ ] Send Aura a message on Slack and confirm she responds
- [ ] Dashboard login redirects back to the original page after OAuth

Made with [Cursor](https://cursor.com)