### PR TITLE
fix: use pnpm override to pin e2b's chalk to 4.1.2

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,6 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "vercel-build": "pnpm --filter @aura/db db:migrate",
-    "postinstall": "rm -rf node_modules/e2b/node_modules/chalk 2>/dev/null; true",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",

--- a/package.json
+++ b/package.json
@@ -6,5 +6,10 @@
     "db:migrate": "pnpm --filter @aura/db db:migrate",
     "db:push": "pnpm --filter @aura/db db:push",
     "db:studio": "pnpm --filter @aura/db db:studio"
+  },
+  "pnpm": {
+    "overrides": {
+      "e2b>chalk": "4.1.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  e2b>chalk: 4.1.2
+
 importers:
 
   .: {}
@@ -1921,10 +1924,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -5046,8 +5045,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2: {}
-
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -5221,7 +5218,7 @@ snapshots:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)
       '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0))
-      chalk: 5.6.2
+      chalk: 4.1.2
       compare-versions: 6.1.1
       dockerfile-ast: 0.7.1
       glob: 11.1.0


### PR DESCRIPTION
## Summary

- **Fix e2b/chalk ESM crash:** `e2b` depends on `chalk@5` (ESM-only) but `require()`s it at runtime, crashing in Vercel's CJS context. The old `postinstall` hack (`rm -rf node_modules/e2b/node_modules/chalk`) no longer works with pnpm's flat store layout in the monorepo. Replaced with a proper `pnpm.overrides` in the root `package.json`.
- `chalk@5.6.2` is fully removed from the lockfile; `e2b` now resolves to `chalk@4.1.2` (CJS-compatible).

## Test plan

- [ ] Deploy and run a sandbox command via Aura to confirm e2b works without the chalk crash

Made with [Cursor](https://cursor.com)