### PR TITLE
Deterministic date time

### DIFF
--- a/apps/api/src/lib/temporal.ts
+++ b/apps/api/src/lib/temporal.ts
@@ -31,7 +31,30 @@ export function getCurrentTimeContext(timezone?: string): string {
     "EEEE, MMMM d, yyyy h:mm a",
   );
 
-  return `Current time: ${formatted} (${tz})`;
+  return `Current time: ${formatted} (${tz})\nThis week: ${getWeekCalendar(now, tz)}`;
+}
+
+/**
+ * Build a Mon–Sun mini-calendar string for the week containing `date`,
+ * with today marked by asterisks.  Example output:
+ *   "Mon 9 | Tue 10 | *Wed 11* | Thu 12 | Fri 13 | Sat 14 | Sun 15"
+ */
+export function getWeekCalendar(date: Date, timezone: string): string {
+  const dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+  const todayStr = formatInTimeZone(date, timezone, "yyyy-MM-dd");
+  const todayDow = Number(formatInTimeZone(date, timezone, "i")); // 1=Mon … 7=Sun
+
+  const parts: string[] = [];
+  for (let offset = 1; offset <= 7; offset++) {
+    const diff = offset - todayDow;
+    const d = new Date(date.getTime() + diff * 86_400_000);
+    const dayNum = formatInTimeZone(d, timezone, "d");
+    const dateStr = formatInTimeZone(d, timezone, "yyyy-MM-dd");
+    const label = `${dayNames[offset - 1]} ${dayNum}`;
+    parts.push(dateStr === todayStr ? `*${label}*` : label);
+  }
+  return parts.join(" | ");
 }
 
 /**

--- a/apps/api/src/tools/datetime.ts
+++ b/apps/api/src/tools/datetime.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { formatInTimeZone } from "date-fns-tz";
+import { defineTool } from "../lib/tool.js";
+import { getWeekCalendar } from "../lib/temporal.js";
+
+const DEFAULT_TZ = "Europe/Amsterdam";
+
+export function createDateTimeTools() {
+  return {
+    get_current_datetime: defineTool({
+      description:
+        "Return the current date, time, day-of-week, and a mini week calendar. " +
+        "Use this tool whenever the user asks about today's date, the current time, " +
+        "what day it is, or anything requiring an accurate real-time timestamp. " +
+        "Do NOT guess the date from memory — always call this tool for a deterministic answer.",
+      inputSchema: z.object({
+        timezone: z
+          .string()
+          .optional()
+          .describe(
+            "IANA timezone, e.g. 'Europe/Amsterdam' or 'America/New_York'. Defaults to Europe/Amsterdam.",
+          ),
+      }),
+      execute: async ({ timezone }) => {
+        const tz = timezone || DEFAULT_TZ;
+        const now = new Date();
+
+        const date = formatInTimeZone(now, tz, "yyyy-MM-dd");
+        const day = formatInTimeZone(now, tz, "EEEE");
+        const time = formatInTimeZone(now, tz, "HH:mm");
+        const iso = formatInTimeZone(now, tz, "yyyy-MM-dd'T'HH:mm:ssxxx");
+        const weekCalendar = getWeekCalendar(now, tz);
+
+        return {
+          ok: true as const,
+          date,
+          day,
+          time,
+          timezone: tz,
+          iso,
+          week_calendar: weekCalendar,
+        };
+      },
+      slack: { status: "Checking current date/time..." },
+    }),
+  };
+}

--- a/apps/api/src/tools/slack.ts
+++ b/apps/api/src/tools/slack.ts
@@ -23,6 +23,7 @@ import { createVoiceTools } from "./voice.js";
 import { createResourceTools } from "./resources.js";
 import { createCredentialTools } from "./credentials.js";
 import { createHttpRequestTool } from "./http-request.js";
+import { createDateTimeTools } from "./datetime.js";
 import type { ScheduleContext } from "@aura/db/schema";
 import { formatForSlack } from "../lib/format.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
@@ -542,6 +543,9 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
   }
 
   const tools: Record<string, any> = {
+    // ── Date/Time Tools (eager — always available) ───────────────────────
+    ...createDateTimeTools(),
+
     list_channels: defineTool({
       description:
         "List Slack channels that Aura is currently a member of (names, topics, member count). Important: this only shows channels Aura has already joined, NOT all public channels in the workspace. Many public channels exist that aren't listed here. To find or join others, use search_channels to fuzzy-search by name, or join_channel with the exact channel name.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `get_current_datetime` tool and injects a mini-calendar into the system prompt to fix LLM date hallucination.

LLMs can sometimes hallucinate current date and time information. This PR introduces a deterministic `get_current_datetime` tool for accurate date/time retrieval and embeds a dynamic mini-calendar directly into the system prompt, providing the model with an anchored, reliable reference for the current week.

<div><a href="https://cursor.com/agents/bc-914b9b6e-62dd-43c5-b885-92e80258d81f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-914b9b6e-62dd-43c5-b885-92e80258d81f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->