### PR TITLE
System prompt context filtering

### DIFF
--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -354,24 +354,40 @@ function formatMentionedPeople(people: PersonProfile[]): string {
 function formatConversations(conversations: ConversationThread[]): string {
   if (conversations.length === 0) return "";
 
-  const MAX_THREAD_MESSAGES = 50;
+  const MAX_THREAD_MESSAGES = 20;
+  const MAX_TOTAL_CHARS = 12_000;
+
+  let totalChars = 0;
 
   const formatted = conversations
     .map((thread) => {
-      const allMsgs = thread.messages;
+      const humanMsgs = thread.messages.filter((m) => m.role !== "tool");
       const capped =
-        allMsgs.length <= MAX_THREAD_MESSAGES
-          ? allMsgs
-          : [allMsgs[0], ...allMsgs.slice(-MAX_THREAD_MESSAGES + 1)];
+        humanMsgs.length <= MAX_THREAD_MESSAGES
+          ? humanMsgs
+          : [humanMsgs[0], ...humanMsgs.slice(-MAX_THREAD_MESSAGES + 1)];
       const msgs = capped
         .map((m) => {
           const timeAgo = relativeTime(new Date(m.createdAt));
           const speaker = m.role === "assistant" ? "Aura" : m.userId;
-          return `  ${speaker} (${timeAgo}): ${m.content.length > 800 ? m.content.substring(0, 800) + "…" : m.content}`;
+          const content = m.content.length > 500 ? m.content.substring(0, 500) + "…" : m.content;
+          return `  ${speaker} (${timeAgo}): ${content}`;
         })
         .join("\n");
-      return `Thread in ${thread.channelId} (similarity: ${thread.bestSimilarity.toFixed(2)}):\n${msgs}`;
+      const threadBlock = `Thread in ${thread.channelId} (similarity: ${thread.bestSimilarity.toFixed(2)}):\n${msgs}`;
+
+      if (totalChars + threadBlock.length > MAX_TOTAL_CHARS) {
+        if (totalChars === 0) {
+          const truncated = threadBlock.substring(0, MAX_TOTAL_CHARS);
+          totalChars += truncated.length;
+          return truncated + "\n  [truncated]";
+        }
+        return null;
+      }
+      totalChars += threadBlock.length;
+      return threadBlock;
     })
+    .filter(Boolean)
     .join("\n\n");
 
   return `\n## Relevant past conversations\n\nThese are past conversation threads retrieved from your message history. Use them for context if relevant — reference specific things people said.\n\n${formatted}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix system prompt bloat by filtering tool messages and applying stricter length limits to conversation history.

The system prompt was reaching 88,501 characters, largely due to `role: "tool"` messages (command outputs, search results, git diffs) being included, adding significant noise (~24K chars) to the context window. This PR addresses the issue by filtering these messages and introducing hard caps on message and thread lengths to improve context window efficiency.

<div><a href="https://cursor.com/agents/bc-35c14bda-b399-489d-9752-ee6fa25ee9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35c14bda-b399-489d-9752-ee6fa25ee9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->