### PR TITLE
User profile prompt reduction

### DIFF
--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -316,11 +316,8 @@ function formatUserProfile(profile: UserProfile, interlocutor?: PersonProfile): 
   if (facts) {
     if (facts.role) parts.push(`Role: ${facts.role}`);
     if (facts.team) parts.push(`Team: ${facts.team}`);
-    if (facts.interests && facts.interests.length > 0) {
-      parts.push(`Interests: ${facts.interests.join(", ")}`);
-    }
     if (facts.personalDetails && facts.personalDetails.length > 0) {
-      parts.push(`Personal: ${facts.personalDetails.join("; ")}`);
+      parts.push(`Personal: ${facts.personalDetails.slice(-10).join("; ")}`);
     }
   }
 

--- a/apps/api/src/users/profiles.ts
+++ b/apps/api/src/users/profiles.ts
@@ -238,9 +238,9 @@ export async function getProfile(
 // ── Profile Consolidation ─────────────────────────────────────────────────
 
 const CAPS = {
-  interests: 100,
+  interests: 30,
   preferences: 100,
-  personalDetails: 50,
+  personalDetails: 20,
 } as const;
 
 const consolidatedSchema = z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reduces user profile bloat in the system prompt by removing interests, capping personal details to 10 items, and lowering profile consolidation caps for both.

<div><a href="https://cursor.com/agents/bc-09ac6b5d-2733-410b-9e16-41b9d7ab377f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09ac6b5d-2733-410b-9e16-41b9d7ab377f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->