### PR TITLE
fix: extract text from reasoning array instead of storing raw objects

### DIFF
--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -214,7 +214,7 @@ export async function executeJob(
     // Phase 2a: persist assistant steps now that generate succeeded
     const conversationSteps: ConversationStep[] = steps.map((step) => ({
       text: step.text,
-      reasoning: (step as any).reasoning,
+      reasoning: Array.isArray((step as any).reasoning) ? (step as any).reasoning : undefined,
       toolCalls: step.toolCalls?.map((tc) => ({
         toolCallId: tc.toolCallId,
         toolName: tc.toolName,

--- a/apps/api/src/cron/persist-conversation.ts
+++ b/apps/api/src/cron/persist-conversation.ts
@@ -17,9 +17,15 @@ interface ToolResult {
   output: unknown;
 }
 
+interface ReasoningPart {
+  type: "reasoning";
+  text: string;
+  providerMetadata?: Record<string, unknown>;
+}
+
 export interface Step {
   text: string;
-  reasoning?: string;
+  reasoning?: ReasoningPart[];
   toolCalls?: ToolCall[];
   toolResults?: ToolResult[];
   finishReason?: string;
@@ -105,8 +111,8 @@ function stepToParts(step: Step): PartRow[] {
 
   parts.push({ type: "step-start", orderIndex: idx++ });
 
-  if (step.reasoning) {
-    parts.push({ type: "reasoning", orderIndex: idx++, textValue: step.reasoning });
+  if (step.reasoning?.length) {
+    parts.push({ type: "reasoning", orderIndex: idx++, textValue: step.reasoning.map((r) => r.text).join('\n\n') });
   }
 
   if (step.toolCalls && step.toolCalls.length > 0) {

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -668,7 +668,7 @@ async function runBackgroundTasks(params: {
             const rawSteps = await stepsPromise;
             const conversationSteps: ConversationStep[] = rawSteps.map((step: any) => ({
               text: step.text,
-              reasoning: step.reasoning,
+              reasoning: Array.isArray(step.reasoning) ? step.reasoning : undefined,
               toolCalls: step.toolCalls?.map((tc: any) => ({
                 toolCallId: tc.toolCallId,
                 toolName: tc.toolName,


### PR DESCRIPTION
## Fixes #732

**Root cause:** `step.reasoning` in AI SDK v6 is `Array<ReasoningPart>` (each with `{ type, text, providerMetadata }`), not a string. Our persist layer was storing the raw array, which Drizzle coerced to escaped JSON strings -- producing the garbage seen in the dashboard.

**Changes (3 files):**

1. **`persist-conversation.ts`** -- Added `ReasoningPart` interface, updated `Step.reasoning` type from `string` to `ReasoningPart[]`, fixed `stepToParts()` to `.map(r => r.text).join('\n\n')`
2. **`pipeline/index.ts`** -- Guards `step.reasoning` with `Array.isArray()` before passing to `ConversationStep`
3. **`execute-job.ts`** -- Same `Array.isArray()` guard

**Result:** Reasoning text is stored as clean readable text, not serialized JSON objects. Dashboard rendering (already correct) will show properly formatted reasoning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how assistant step reasoning is typed and persisted, which can affect conversation trace storage and downstream dashboard rendering. Risk is limited to trace/debug data (no auth or critical business logic), but could alter stored output formatting.
> 
> **Overview**
> Fixes conversation trace persistence so `step.reasoning` from AI SDK v6 is treated as an array of reasoning parts rather than a string.
> 
> `persist-conversation` now types `reasoning` as `ReasoningPart[]` and stores only the joined `text` values, while both the job executor and interactive pipeline guard `reasoning` with `Array.isArray()` before persisting steps to avoid saving malformed/escaped JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c1f715b665279a02a398c6f73496e4fe8580061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->