### PR TITLE
fix: show cumulative tokens instead of last-step tokens

### DIFF
--- a/apps/api/src/cron/persist-conversation.ts
+++ b/apps/api/src/cron/persist-conversation.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { conversationTraces, conversationMessages, conversationParts, type DetailedTokenUsage } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
-import { computeConversationCost, type StepUsage } from "../lib/cost-calculator.js";
+import { computeConversationCost, sumStepUsages, type StepUsage } from "../lib/cost-calculator.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -277,6 +277,14 @@ export async function updateConversationTraceUsage(
 ): Promise<void> {
   try {
     let costUsd: string | null = null;
+
+    // Use cumulative tokens from stepUsages when available (the SDK's
+    // tokenUsage is just the *last* step, not the sum of all steps).
+    const cumulativeUsage =
+      stepUsages && stepUsages.length > 0
+        ? sumStepUsages(stepUsages)
+        : tokenUsage;
+
     if (stepUsages && stepUsages.length > 0) {
       try {
         const cost = await computeConversationCost(stepUsages);
@@ -292,7 +300,7 @@ export async function updateConversationTraceUsage(
     await db
       .update(conversationTraces)
       .set({
-        tokenUsage,
+        tokenUsage: cumulativeUsage,
         ...(costUsd != null && { costUsd }),
       })
       .where(eq(conversationTraces.id, conversationId));

--- a/apps/api/src/lib/cost-calculator.ts
+++ b/apps/api/src/lib/cost-calculator.ts
@@ -171,3 +171,53 @@ export async function computeConversationCost(
 
   return totalCost;
 }
+
+/**
+ * Sum per-step usages into a single cumulative DetailedTokenUsage.
+ * Use this instead of the SDK's top-level usage (which is just the last step).
+ */
+export function sumStepUsages(steps: StepUsage[]): DetailedTokenUsage {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let noCacheTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  let textTokens = 0;
+  let reasoningTokens = 0;
+  let hasInputDetails = false;
+  let hasOutputDetails = false;
+
+  for (const step of steps) {
+    inputTokens += step.usage.inputTokens ?? 0;
+    outputTokens += step.usage.outputTokens ?? 0;
+    totalTokens += step.usage.totalTokens ?? 0;
+
+    const id = step.usage.inputTokenDetails;
+    if (id) {
+      hasInputDetails = true;
+      noCacheTokens += id.noCacheTokens ?? 0;
+      cacheReadTokens += id.cacheReadTokens ?? 0;
+      cacheWriteTokens += id.cacheWriteTokens ?? 0;
+    }
+
+    const od = step.usage.outputTokenDetails;
+    if (od) {
+      hasOutputDetails = true;
+      textTokens += od.textTokens ?? 0;
+      reasoningTokens += od.reasoningTokens ?? 0;
+    }
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    ...(hasInputDetails && {
+      inputTokenDetails: { noCacheTokens, cacheReadTokens, cacheWriteTokens },
+    }),
+    ...(hasOutputDetails && {
+      outputTokenDetails: { textTokens, reasoningTokens },
+    }),
+  };
+}

--- a/apps/dashboard/src/app/conversations/actions.ts
+++ b/apps/dashboard/src/app/conversations/actions.ts
@@ -47,17 +47,26 @@ export async function getConversations(
   const traceIds = traces.map((t) => t.id);
 
   let messageCounts: Record<string, number> = {};
+  let cumulativeTokens: Record<string, { inputTokens: number; outputTokens: number; totalTokens: number }> = {};
   if (traceIds.length > 0) {
     const rows = await db
       .select({
         conversationId: conversationMessages.conversationId,
         count: sql<number>`count(*)::int`,
+        inputTokens: sql<number>`coalesce(sum((token_usage->>'inputTokens')::int), 0)::int`,
+        outputTokens: sql<number>`coalesce(sum((token_usage->>'outputTokens')::int), 0)::int`,
+        totalTokens: sql<number>`coalesce(sum((token_usage->>'totalTokens')::int), 0)::int`,
       })
       .from(conversationMessages)
       .where(sql`${conversationMessages.conversationId} IN ${traceIds}`)
       .groupBy(conversationMessages.conversationId);
 
     messageCounts = Object.fromEntries(rows.map((r) => [r.conversationId, r.count]));
+    cumulativeTokens = Object.fromEntries(rows.map((r) => [r.conversationId, {
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      totalTokens: r.totalTokens,
+    }]));
   }
 
   const jobExecIds = traces
@@ -79,11 +88,18 @@ export async function getConversations(
   }
 
   const items = traces.map((trace) => {
-    const tokenUsage = trace.tokenUsage as {
+    const traceTokenUsage = trace.tokenUsage as {
       inputTokens?: number;
       outputTokens?: number;
       totalTokens?: number;
     } | null;
+
+    // Prefer cumulative tokens from conversation_messages (sum of all steps)
+    // over trace-level tokens (which may only reflect the last step for older conversations).
+    const cumulative = cumulativeTokens[trace.id];
+    const tokenUsage = cumulative && cumulative.totalTokens > 0
+      ? cumulative
+      : traceTokenUsage;
 
     let sourceLabel: string;
     if (trace.sourceType === "job_execution" && trace.jobExecutionId) {
@@ -113,6 +129,27 @@ export async function getConversation(id: string) {
   if (!trace) return null;
 
   const conversation = await fetchConversationWithParts(trace.id);
+
+  // Compute cumulative tokens from all assistant messages (sum of all steps).
+  // The trace-level tokenUsage may only reflect the last step for older conversations.
+  const [cumulative] = await db
+    .select({
+      inputTokens: sql<number>`coalesce(sum((token_usage->>'inputTokens')::int), 0)::int`,
+      outputTokens: sql<number>`coalesce(sum((token_usage->>'outputTokens')::int), 0)::int`,
+      totalTokens: sql<number>`coalesce(sum((token_usage->>'totalTokens')::int), 0)::int`,
+    })
+    .from(conversationMessages)
+    .where(eq(conversationMessages.conversationId, id));
+
+  // Override trace tokenUsage with cumulative if available
+  if (cumulative && cumulative.totalTokens > 0) {
+    (trace as any).tokenUsage = {
+      ...((trace.tokenUsage as any) ?? {}),
+      inputTokens: cumulative.inputTokens,
+      outputTokens: cumulative.outputTokens,
+      totalTokens: cumulative.totalTokens,
+    };
+  }
 
   let jobName: string | null = null;
   let jobId: string | null = null;


### PR DESCRIPTION
## Problem

The SDK's top-level `tokenUsage` only reflects the **last** LLM call in a multi-step conversation, not the sum of all steps. A 24-step Opus conversation showed 110K input tokens on the dashboard instead of the actual 1.43M -- while the cost ($14.93) was correctly computed from per-step data.

This affected both the conversations list and conversation detail views.

## Fix

### Backend (source of truth for new conversations)
- **`sumStepUsages()`** -- new helper in `cost-calculator.ts` that aggregates all per-step token counts including cache read/write, reasoning, and text breakdown
- **`updateConversationTraceUsage`** -- now stores cumulative tokens from `stepUsages` instead of the SDK's misleading last-step `tokenUsage`

### Dashboard (retroactive fix for existing data)
- **Conversations list** -- computes cumulative tokens from `conversation_messages` as fallback for older traces with last-step-only data
- **Conversation detail** -- same cumulative computation, preserving cache and reasoning detail from the trace while correcting the totals

## Files changed
- `apps/api/src/lib/cost-calculator.ts` -- `sumStepUsages()` function
- `apps/api/src/cron/persist-conversation.ts` -- use cumulative in trace update
- `apps/dashboard/src/app/conversations/actions.ts` -- cumulative fallback for list + detail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how token totals are computed and persisted for conversations, affecting dashboard reporting and stored trace data; mistakes could skew token/cost visibility for both new and historical conversations.
> 
> **Overview**
> Fixes conversation token reporting to use **cumulative per-step usage** rather than the SDK’s last-step `tokenUsage`.
> 
> On the API side, adds `sumStepUsages()` and updates `updateConversationTraceUsage()` to persist aggregated `tokenUsage` (while still computing cost from step usages).
> 
> On the dashboard side, the conversations list and detail views now **fallback to summing `conversation_messages.token_usage`** to correct older traces, preferring message-level totals when available while preserving existing trace-level detail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d3d79ad82b4073812e6dbf2344709de33b8185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->