### PR TITLE
docs: round 2 — 3 new tool pages, fix stale deployment/memory/API docs

### DIFF
--- a/content/docs/api-reference/overview.mdx
+++ b/content/docs/api-reference/overview.mdx
@@ -17,22 +17,53 @@ Or your custom deployment URL.
 
 ## Authentication
 
-- **Slack events** are verified using the Slack signing secret
+- **Slack events** are verified using the Slack signing secret (`SLACK_SIGNING_SECRET`)
 - **Cron endpoints** are protected by Vercel's `CRON_SECRET` header
 - **Health check** is unauthenticated
+- **Dashboard API** uses session-based auth via OAuth
 
-## Endpoints
+## Core Endpoints
 
-See the [OpenAPI specification](/openapi.yaml) for full request/response schemas.
+### `POST /api/slack/events`
 
-<Card title="Slack Events" icon="slack" href="/api-reference/slack-events">
-  Webhook endpoint for Slack event subscriptions.
-</Card>
+Webhook endpoint for Slack event subscriptions. Receives all Slack events (messages, app mentions, reactions, etc.) and routes them to the appropriate handler.
 
-<Card title="Health Check" icon="heart-pulse" href="/api-reference/health">
-  Simple health check returning system status.
-</Card>
+**Auth:** Slack signing secret verification on every request.
 
-<Card title="Cron: Heartbeat" icon="clock" href="/api-reference/cron-heartbeat">
-  Periodic job execution trigger (runs every 30 minutes).
-</Card>
+### `GET /api/health`
+
+Simple health check. Returns `200 OK` with basic system status.
+
+**Auth:** None.
+
+### `GET /api/cron/heartbeat`
+
+Periodic job execution trigger. Evaluates all pending and recurring jobs, executes what's due. Runs every 30 minutes via Vercel Cron.
+
+**Auth:** `CRON_SECRET` header.
+
+### `GET /api/cron/consolidate`
+
+Nightly memory consolidation. Decays old memories, merges duplicates, and cleans up stale data. Runs daily at 4 AM UTC.
+
+**Auth:** `CRON_SECRET` header.
+
+### `POST /api/chat`
+
+Streaming chat endpoint for the dashboard's AI Elements chat interface. Accepts messages and returns streamed AI responses.
+
+**Auth:** Dashboard session cookie.
+
+### `POST /api/cursor/webhook`
+
+Webhook endpoint for Cursor Cloud Agent completion notifications. Receives results when dispatched agents finish their work.
+
+**Auth:** Webhook signature verification.
+
+## Dashboard API
+
+The admin dashboard (`apps/dashboard`) has its own API routes for authentication:
+
+- `GET /api/auth/login` — Initiate OAuth login
+- `GET /api/auth/callback` — OAuth callback handler
+- `POST /api/auth/logout` — End session

--- a/content/docs/deployment/one-click-deploy.mdx
+++ b/content/docs/deployment/one-click-deploy.mdx
@@ -9,7 +9,7 @@ Deploy your own instance of Aura with Vercel's one-click deploy button.
 
 ## Deploy
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Frealadvisor%2Faura&env=DATABASE_URL,ANTHROPIC_API_KEY,SLACK_BOT_TOKEN,SLACK_SIGNING_SECRET&envDescription=Required%20environment%20variables%20for%20Aura&project-name=aura&repository-name=aura)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FAuraHQ-ai%2Faura&env=DATABASE_URL,ANTHROPIC_API_KEY,SLACK_BOT_TOKEN,SLACK_SIGNING_SECRET&envDescription=Required%20environment%20variables%20for%20Aura&project-name=aura&repository-name=aura)
 
 ## What This Sets Up
 
@@ -41,7 +41,7 @@ See [Environment Variables](/deployment/environment-variables) for the full list
 Since the one-click deploy forks the repository, you can pull upstream changes:
 
 ```bash
-git remote add upstream https://github.com/realadvisor/aura.git
+git remote add upstream https://github.com/AuraHQ-ai/aura.git
 git pull upstream main
 git push origin main
 ```

--- a/content/docs/deployment/vercel.mdx
+++ b/content/docs/deployment/vercel.mdx
@@ -7,12 +7,30 @@ description: "How Aura runs on Vercel serverless functions with automatic deploy
 
 Aura's backend runs on Vercel serverless functions. Merging to `main` triggers an automatic production deploy.
 
+## Monorepo Structure
+
+Aura is a pnpm monorepo with multiple packages:
+
+```
+aura/
+├── apps/
+│   ├── api/          # Backend API (Hono, serverless functions)
+│   ├── dashboard/    # Admin dashboard (Next.js)
+│   └── web/          # Landing page + blog (Next.js)
+├── packages/
+│   └── db/           # Shared database schema (Drizzle ORM)
+└── content/
+    └── docs/         # Documentation (Mintlify)
+```
+
+Each `apps/*` project deploys as a separate Vercel project.
+
 ## Architecture
 
 - **Runtime:** Node.js serverless functions
 - **Framework:** Hono for HTTP routing
-- **Entry point:** `api/index.ts` → routes all requests through the Hono app
-- **Build:** `tsc` compiles TypeScript, then `tsx src/db/migrate.ts` runs pending migrations
+- **Entry point:** `apps/api/src/app.ts` exports the Hono app; `apps/api/api/index.ts` is the Vercel handler
+- **Build:** `tsc` compiles TypeScript, then `pnpm --filter @aura/db db:migrate` runs pending Drizzle migrations
 
 ## Deployment Flow
 
@@ -20,12 +38,12 @@ Aura's backend runs on Vercel serverless functions. Merging to `main` triggers a
 Push to main → Vercel Build → tsc → Run Migrations → Deploy
 ```
 
-The `vercel-build` script in `package.json` handles both compilation and migrations:
+The `vercel-build` script in `apps/api/package.json`:
 
 ```json
 {
   "scripts": {
-    "vercel-build": "tsc && tsx src/db/migrate.ts"
+    "vercel-build": "pnpm --filter @aura/db db:migrate"
   }
 }
 ```
@@ -34,28 +52,29 @@ The `vercel-build` script in `package.json` handles both compilation and migrati
 
 1. **Never push directly to `main`.** Vercel auto-deploys, so any push goes straight to production. Always use feature branches and PRs.
 2. **Migrations run on every deploy.** Drizzle handles idempotency — running the same migration twice is safe.
-3. **Serverless = stateless.** In-memory state only lasts for one request. Don't rely on module-level caches persisting.
+3. **Drizzle migration format:** Always include `-->statement-breakpoint` between SQL statements in migration files.
+4. **Serverless = stateless.** In-memory state only lasts for one request. Don't rely on module-level caches persisting.
+5. **Function timeout:** 800 seconds max. Plan long-running tasks accordingly.
+
+## Multiple Projects
+
+| Project | Domain | Contents |
+|---------|--------|----------|
+| `aura` | `api.aurahq.ai` | Backend API, Slack events, cron |
+| `aura-dashboard` | Dashboard domain | Admin UI (conversations, memories, credentials, errors) |
+| `aurahq-web` | `aurahq.ai` | Landing page + blog (Next.js) |
+| Mintlify | `docs.aurahq.ai` | Documentation |
 
 ## Monitoring
 
 ### Runtime Logs
 
 ```bash
-npx --yes vercel@50.13.2 logs aura-alpha-five.vercel.app --scope realadvisor
+npx --yes vercel@latest logs <deployment-url> --scope <your-scope>
 ```
 
 ### Build Logs
 
 ```bash
-npx --yes vercel@50.13.2 inspect <deployment-url> --logs --scope realadvisor
+npx --yes vercel@latest inspect <deployment-url> --logs --scope <your-scope>
 ```
-
-## Multiple Projects
-
-The recommended setup uses separate Vercel projects:
-
-| Project | Domain | Contents |
-|---------|--------|----------|
-| `aura` (existing) | `api.aurahq.ai` | Backend API, Slack events, cron |
-| `aurahq-web` (new) | `aurahq.ai` | Landing page + blog (Next.js) |
-| Mintlify | `docs.aurahq.ai` | Documentation |

--- a/content/docs/docs.json
+++ b/content/docs/docs.json
@@ -60,7 +60,10 @@
               "tools/lists",
               "tools/tables",
               "tools/subagents",
-              "tools/voice"
+              "tools/voice",
+              "tools/cursor-agent",
+              "tools/resources",
+              "tools/conversations"
             ]
           },
           {

--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -43,13 +43,33 @@ CREATE TABLE memories (
 );
 ```
 
-## Retrieval: Hybrid Search
+## Retrieval: Hybrid Search + Reranking
 
-Aura uses hybrid search combining vector similarity and full-text search. This is critical — vector search alone fails for proper nouns and specific terms.
+Aura uses a three-stage retrieval pipeline to find the most relevant memories:
 
-1. **Vector search** finds semantically similar memories (cosine similarity via HNSW index)
-2. **Full-text search** finds lexically matching memories (GIN index on tsvector)
-3. Results are merged with configurable weighting (default: 70% vector, 30% text)
+### Stage 1: Hybrid Candidate Retrieval
+
+Two search strategies run in parallel and their results are fused using **Reciprocal Rank Fusion (RRF)**:
+
+1. **Vector search** — the user's message is embedded and compared against memory embeddings via cosine similarity (HNSW index). Finds semantically similar memories even when wording differs.
+
+2. **Full-text search** — up to 8 positional lexemes are extracted from the query using PostgreSQL's `to_tsvector`. Each lexeme is searched independently (per-term limit of 25 results) to catch exact mentions that vector search might miss — especially proper nouns, technical terms, and specific identifiers.
+
+RRF combines both ranked lists with a smoothing constant of 60, ensuring that memories appearing in both lists rank highest.
+
+### Stage 2: Cohere Reranking
+
+The top candidates from RRF are passed through [Cohere's `rerank-v3.5`](https://cohere.com/rerank) model. This cross-encoder evaluates each candidate against the full query and re-scores them for fine-grained relevance. This stage catches cases where a keyword match is topically irrelevant, or where a subtle semantic match deserves higher ranking.
+
+**Required env var:** `COHERE_API_KEY`
+
+### Stage 3: Privacy Filtering & Scoring
+
+After reranking, memories are filtered based on channel privacy rules and sorted by a composite score combining rerank relevance, original relevance score, and recency.
+
+## Conversation Retrieval
+
+In addition to discrete memory facts, Aura retrieves full conversation threads from her message history. The same query embedding is used to find relevant past messages via cosine similarity, then entire threads are reconstructed and scored with a recency boost (80% similarity, 20% recency within 30 days).
 
 ## Memory Extraction
 
@@ -62,11 +82,11 @@ After every conversation turn, Aura extracts new memories:
 
 ## Consolidation
 
-A nightly consolidation job maintains memory quality:
+A nightly consolidation job (4 AM UTC) maintains memory quality:
 
-- **Decay** — Old memories with low relevance scores are gradually deprioritized
-- **Merge** — Duplicate or near-duplicate memories are consolidated
-- **Strengthen** — Frequently accessed memories get relevance boosts
+- **Decay** — relevance scores decrease by 0.5% per day (~50% after 138 days)
+- **Merge** — memories with >95% cosine similarity are consolidated
+- **Strengthen** — frequently accessed memories get relevance boosts
 - **Expire** — `open_thread` memories are resolved or aged out
 
 ## Privacy
@@ -79,6 +99,12 @@ Memory respects channel boundaries:
 
 ## Notes: The Knowledge Graph
 
-Beyond extracted memories, Aura maintains a self-authored knowledge base in the `notes` table. These are longer-form documents on specific topics — team processes, technical decisions, project status.
+Beyond extracted memories, Aura maintains a self-authored knowledge base in the `notes` table. Notes use a three-tier hierarchy:
 
-Notes are cross-referenced via embeddings, creating a semantic graph where related knowledge is connected by meaning rather than explicit links.
+| Category | Purpose | Lifetime |
+|----------|---------|----------|
+| `skill` | Durable playbooks, protocols, checklists | Permanent |
+| `plan` | Work-in-progress, ephemeral context | Has expiry date |
+| `knowledge` | General reference, business context | Permanent (default) |
+
+Notes with `inject_in_context: true` appear in every prompt via the auto-generated notes index, ensuring critical operational knowledge is always available. Each note has an importance score (1-100) for sort order and a summary (max 250 chars) that powers the index.

--- a/content/docs/tools/conversations.mdx
+++ b/content/docs/tools/conversations.mdx
@@ -1,0 +1,37 @@
+---
+title: "Conversations"
+description: "Search Aura's stored message history across all channels and DMs — 1 tool."
+---
+
+# Conversations
+
+Every message Aura sends and receives is stored in PostgreSQL with vector embeddings. The conversations tool lets you search this history by keyword or meaning.
+
+---
+
+## `search_my_conversations`
+
+Search Aura's message database. Supports keyword search and semantic (meaning-based) search. Results are grouped by conversation thread with surrounding context.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | no | Search term or phrase. Required for semantic mode. |
+| `mode` | string | no | `text` (keyword, default) or `semantic` (vector similarity) |
+| `user_id` | string | no | Filter by Slack user ID |
+| `channel_id` | string | no | Filter by Slack channel ID |
+| `since` | string | no | Only messages after this ISO 8601 date |
+| `until` | string | no | Only messages before this ISO 8601 date |
+| `role` | string | no | Filter by `user` or `assistant` |
+| `limit` | number | no | Max messages (default 20, max 50) |
+| `offset` | number | no | Skip messages for pagination |
+
+**When to use this vs `search_messages`:**
+
+| Scenario | Use |
+|----------|-----|
+| DM conversations with Aura | `search_my_conversations` |
+| What someone said to Aura | `search_my_conversations` |
+| Workspace-wide message search | `search_messages` |
+| Messages in channels Aura hasn't joined | `search_messages` |
+
+`search_my_conversations` searches Aura's own database, so it has better coverage of her conversations than Slack's search index. Use `search_messages` for broader workspace searches.

--- a/content/docs/tools/cursor-agent.mdx
+++ b/content/docs/tools/cursor-agent.mdx
@@ -1,0 +1,96 @@
+---
+title: "Cursor Agents"
+description: "Dispatch async Cursor Cloud agents for complex multi-file code tasks — 6 tools."
+---
+
+# Cursor Agents
+
+Aura can dispatch [Cursor](https://cursor.sh) Cloud Agents for complex multi-file code changes that would take too long in the sandbox. Agents run asynchronously in the background (3-30 minutes), create a branch, make changes, and open a PR. Results arrive via webhook DM.
+
+**Required env vars:** `CURSOR_API_KEY`
+
+**Admin-only.** All Cursor agent tools require admin permissions.
+
+---
+
+## `dispatch_cursor_agent`
+
+Dispatch an async agent to work on a code task. Returns immediately with an agent ID — don't wait or poll.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `issue_description` | string | **yes** | Detailed description of the task |
+| `branch_prefix` | string | no | Branch prefix (default `cursor`) — agent creates `cursor/{slug}` |
+| `ref` | string | no | Git ref to base work on (default `main`) |
+| `key_files` | string[] | no | Key files for the agent to focus on |
+| `cursor_rules` | string | no | Additional `.cursor/rules` content injected for this task |
+| `repo` | string | no | GitHub repo (default: `AuraHQ-ai/aura`) |
+
+**Best practices:**
+- Always specify `key_files` to reduce agent wandering
+- Include `cursor_rules` for project-specific conventions (e.g. Drizzle migration breakpoints)
+- Say "create a PR" explicitly in the description — agents sometimes finish without opening one
+
+---
+
+## `check_cursor_agent`
+
+Check the status of a dispatched agent.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string | **yes** | Agent ID from `dispatch_cursor_agent` |
+
+Returns status (`running`, `completed`, `failed`), elapsed time, and result details including PR URL if completed.
+
+---
+
+## `followup_cursor_agent`
+
+Send a follow-up message to a running or completed agent — like a code review comment. The agent will continue working based on your feedback.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string | **yes** | Agent ID |
+| `message` | string | **yes** | Follow-up instruction or review feedback |
+
+---
+
+## `get_cursor_conversation`
+
+Retrieve the full conversation history of an agent session — useful for understanding what the agent did and why.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string | **yes** | Agent ID |
+
+---
+
+## `stop_cursor_agent`
+
+Stop a running agent.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string | **yes** | Agent ID |
+
+---
+
+## `list_cursor_agents`
+
+List recent Cursor agents. Optionally filter by PR URL.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pr_url` | string | no | Filter by PR URL |
+
+---
+
+## When to Use Cursor Agents vs Sandbox
+
+| Use Case | Tool |
+|----------|------|
+| Simple one-line fix, typo, config change | `run_command` (sandbox) |
+| Read code, explore repo, run tests | `run_command` (sandbox) |
+| Multi-file refactor, new feature, complex bug fix | `dispatch_cursor_agent` |
+| Changes requiring understanding of 5+ files | `dispatch_cursor_agent` |

--- a/content/docs/tools/resources.mdx
+++ b/content/docs/tools/resources.mdx
@@ -1,0 +1,73 @@
+---
+title: "Resources"
+description: "Ingest, search, and retrieve URLs, PDFs, YouTube transcripts, and other content — 4 tools."
+---
+
+# Resources
+
+Aura can ingest external content (web pages, PDFs, YouTube videos, Notion pages) into a searchable knowledge base. Ingested resources are stored with embeddings for semantic search.
+
+**Required env vars:** `TAVILY_API_KEY` (for enhanced extraction), `OPENAI_API_KEY` (for embeddings)
+
+---
+
+## `ingest_resource`
+
+Fetch a URL, extract its content, and store it in the resources database with embeddings.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | **yes** | URL to ingest (web page, PDF, YouTube, Notion, GitHub) |
+| `source` | string | no | Source type: `web`, `youtube`, `notion`, `github`, `pdf`, `docs`, `slack` |
+| `metadata` | object | no | Additional metadata to store with the resource |
+
+Supports:
+- **Web pages** — extracted via Tavily or HTML stripping
+- **YouTube** — transcript extraction
+- **PDFs** — text extraction
+- **Notion/GitHub** — fetched and converted to markdown
+
+Resources are deduplicated by URL hash. Re-ingesting updates the content.
+
+---
+
+## `search_resources`
+
+Search ingested resources by keyword or semantic similarity.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | **yes** | Search query |
+| `mode` | string | no | `text` (keyword, default) or `semantic` (vector similarity) |
+| `source` | string | no | Filter by source type |
+| `limit` | number | no | Max results (default 10) |
+
+---
+
+## `get_resource`
+
+Retrieve a specific resource by ID with its full content.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | **yes** | Resource UUID |
+
+---
+
+## `list_resources`
+
+List recently ingested resources.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | string | no | Filter by source type |
+| `limit` | number | no | Max results (default 20) |
+
+---
+
+## Use Cases
+
+- **Meeting prep** — ingest a company's website before a call
+- **Competitive analysis** — ingest competitor pages for comparison
+- **Documentation** — ingest external docs for reference during development
+- **Research** — build a searchable corpus from multiple sources


### PR DESCRIPTION
## Round 2 Documentation Update

### New pages (3)
- **tools/cursor-agent** — 6 tools for async Cursor Cloud Agent dispatch
- **tools/resources** — 4 tools for URL/PDF/YouTube ingestion  
- **tools/conversations** — search_my_conversations tool

### Fixed pages (5)
- **one-click-deploy** — realadvisor/aura → AuraHQ-ai/aura in deploy button + upstream remote
- **vercel** — added monorepo structure diagram, correct build scripts, Drizzle migration breakpoint note, function timeout
- **memory-system** — full rewrite of retrieval section: Cohere reranking, RRF hybrid search, conversation retrieval, notes hierarchy with inject_in_context
- **api-reference** — replaced dead Mintlify Card links with actual endpoint documentation
- **docs.json** — 3 new tool pages in navigation

### Coverage after this PR
18 tool pages covering all 23 tool files. Only datetime (trivial) and core (internal) lack dedicated pages.

8 files changed, 328 insertions, 43 deletions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new pages and corrections) with no runtime or security-impacting code modifications.
> 
> **Overview**
> Updates Mintlify docs to replace stale/placeholder content with concrete endpoint and system documentation.
> 
> Adds three new tool pages for `Cursor Agents`, `Resources`, and `Conversations`, and wires them into `docs.json` navigation.
> 
> Refreshes deployment and ops docs (Vercel monorepo/build/migrations guidance, updated repo links for one-click deploy) and expands the memory-system docs to describe the new retrieval pipeline (RRF hybrid search + Cohere reranking), conversation retrieval, and notes hierarchy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 876126dd1b0fd1db2353b285779f19afd823e698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->