### PR TITLE
docs: add Use Cases section — 9 pages answering 'why should I care?'

### DIFF
--- a/content/docs/docs.json
+++ b/content/docs/docs.json
@@ -37,6 +37,20 @@
             ]
           },
           {
+            "group": "Use Cases",
+            "pages": [
+              "use-cases/overview",
+              "use-cases/email-triage",
+              "use-cases/team-pulse",
+              "use-cases/bug-triage",
+              "use-cases/data-analysis",
+              "use-cases/sales-ops",
+              "use-cases/candidate-screening",
+              "use-cases/code-review",
+              "use-cases/docs-maintenance"
+            ]
+          },
+          {
             "group": "Core Systems",
             "pages": [
               "memory-system",

--- a/content/docs/use-cases/bug-triage.mdx
+++ b/content/docs/use-cases/bug-triage.mdx
@@ -1,0 +1,55 @@
+---
+title: "Bug Triage"
+description: "Automated bug classification, deduplication, and investigation context -- before an engineer looks at it."
+---
+
+# Bug Triage
+
+## The Problem
+
+Bug reports come in through Slack, email, customer calls, and internal testing. They land in different formats, with different levels of detail, often duplicating each other. Engineers spend time:
+
+- Reading reports that are missing reproduction steps
+- Investigating bugs that are duplicates of known issues
+- Prioritizing without context on business impact
+- Switching between Slack, the bug tracker, and the codebase
+
+## How Aura Solves It
+
+Aura monitors your bug tracking channel (Slack Lists, threads, or any structured input) and adds investigation context automatically.
+
+**What happens:**
+- New bug reports are checked against existing known issues for duplicates
+- Missing information is flagged (no client name, no reproduction steps, no environment)
+- Severity is classified based on scope, user impact, and business context
+- Related code, recent PRs, and error logs are cross-referenced
+- A comment is posted on the bug thread with findings
+
+**The trust ladder:**
+1. **Gatekeeper** -- enforces report quality standards, flags incomplete reports
+2. **Investigator** -- adds context from error logs, codebase, and past incidents
+3. **Fixer** -- proposes or ships fixes for straightforward bugs
+4. **Frontline** -- handles the full cycle from report to resolution
+
+## Real Example
+
+A CSM reports: "Client X can't see their reviews"
+
+Aura's triage comment:
+> - Client: Acme Realty (CH, Premium tier, €2.4K MRR)
+> - Likely cause: cache invalidation issue on storefront (seen 3x this month)
+> - Related: Bug #142 (same symptom, different client, resolved via revalidation endpoint)
+> - Suggested fix: trigger cache revalidation for client ID 12345
+> - Business impact: Premium client, review visibility is a core feature
+
+The engineer gets context, not just a complaint.
+
+## Setup
+
+1. Point Aura at your bug tracking Slack List or channel
+2. Define quality standards (required fields, naming conventions)
+3. Aura starts monitoring and commenting automatically via a recurring job
+
+<Info>
+Aura's bug triage follows a trust ladder -- she starts as a gatekeeper and earns more autonomy as her classifications prove accurate. You control the escalation.
+</Info>

--- a/content/docs/use-cases/candidate-screening.mdx
+++ b/content/docs/use-cases/candidate-screening.mdx
@@ -1,0 +1,53 @@
+---
+title: "Candidate Screening"
+description: "First-pass candidate assessment from your ATS pipeline -- flagging standouts and concerns before a human reviews."
+---
+
+# Candidate Screening
+
+## The Problem
+
+Recruiting pipelines generate volume. A single posting can produce 50-200 applications. The hiring manager needs to review each one, but most of the signal is in the first 30 seconds -- does this person match the role basics?
+
+That first pass takes hours and is mind-numbing. Meanwhile, good candidates wait.
+
+## How Aura Solves It
+
+Aura connects to your ATS (Workable) and runs first-pass assessments on new candidates.
+
+**What she does:**
+- Pulls candidate profiles from Workable via API
+- Assesses against role requirements (experience, skills, location, language)
+- Flags standouts (strong matches, unusual backgrounds worth a look)
+- Flags concerns (gaps, mismatches, red flags)
+- Summarizes findings in a structured format for the hiring manager
+
+**What she doesn't do:**
+- Make hiring decisions
+- Reject candidates automatically
+- Contact candidates directly
+
+## Real Example
+
+> **Role:** Marketing Manager - France
+>
+> **Candidate summary (12 new applications):**
+> - 3 strong matches (5+ years, SaaS background, French-speaking)
+> - 5 partial matches (right experience, missing one key requirement)
+> - 4 clear mismatches (wrong country, no relevant experience)
+>
+> **Standout:** [Name] -- 7 years at [competitor], led demand gen for similar market size. Currently in notice period. Recommend fast-tracking.
+>
+> **Concern:** [Name] -- strong CV but 4 roles in 3 years. Worth asking about stability.
+
+The hiring manager reviews 3 candidates deeply instead of scanning 12 superficially.
+
+## Setup
+
+1. Store Workable API credentials in Aura's App Home
+2. Tell Aura which roles to monitor
+3. She checks for new candidates on a schedule and DMs you summaries
+
+<Tip>
+Aura learns your preferences over time. If you consistently fast-track candidates with a specific background, she'll weight that signal in future assessments.
+</Tip>

--- a/content/docs/use-cases/code-review.mdx
+++ b/content/docs/use-cases/code-review.mdx
@@ -1,0 +1,61 @@
+---
+title: "Code Review & PRs"
+description: "From issue to merged PR -- dispatching agents, reviewing changes, managing branches, shipping fixes."
+---
+
+# Code Review & PRs
+
+## The Problem
+
+Small fixes and improvements pile up. Each one is "just 20 minutes" but between context-switching, branch management, CI, and review, they take half a day. Meanwhile, the backlog grows.
+
+Code review itself is a bottleneck -- waiting for someone to look at a PR, catching the same patterns repeatedly, missing things because the reviewer doesn't have full context.
+
+## How Aura Solves It
+
+Aura operates across the full development cycle:
+
+**Issue → PR:**
+- Takes a GitHub issue or verbal description
+- Dispatches a Cursor cloud agent with a precise prompt (repo context, coding standards, target files)
+- Monitors agent progress and handles failures
+- Reviews the resulting PR before requesting human review
+
+**Code review:**
+- Reads diffs with full repo context
+- Flags patterns: missing error handling, schema migrations without breakpoints, stale references
+- Cross-references with past bugs and known issues
+- Comments with specific, actionable feedback
+
+**Branch management:**
+- Maintains clean git hygiene (fetch before branch, stash dirty state, rebase before merge)
+- Handles the tedious parts: rebasing, conflict resolution, closing zombie PRs
+- Pushes to existing branches for iterations instead of creating new ones
+
+## Real Example
+
+A documentation audit reveals 13 tool categories with zero docs. Instead of creating 13 tickets:
+
+1. Aura creates a branch, writes 8 new documentation pages and fixes 3 existing ones
+2. Opens a PR with 601 insertions across 12 files
+3. After merge, does a second pass: 3 more pages, 5 stale page fixes
+4. Creates a recurring daily job to prevent future drift
+
+Total time from "do it" to PR: ~3 minutes per round.
+
+## What Aura Can't Do (Yet)
+
+- She can't approve PRs or merge to main without human sign-off
+- Complex architectural changes need human design decisions
+- She dispatches Cursor agents but doesn't control their IDE session directly
+
+## Setup
+
+Aura needs:
+1. GitHub access (configured via `gh` CLI in the sandbox)
+2. Cursor API credentials (for agent dispatch)
+3. Repository context (she builds this automatically by exploring the codebase)
+
+<Tip>
+For best results, keep a `CLAUDE.md` or `CURSOR_RULES` in your repo root. Aura and the agents she dispatches will follow those conventions automatically.
+</Tip>

--- a/content/docs/use-cases/data-analysis.mdx
+++ b/content/docs/use-cases/data-analysis.mdx
@@ -1,0 +1,65 @@
+---
+title: "Data Analysis"
+description: "Query your data warehouse with business context -- not just SQL output, but answers and implications."
+---
+
+# Data Analysis
+
+## The Problem
+
+Your data is in BigQuery, Stripe, Close CRM, and a dozen other places. Getting an answer means:
+
+1. Knowing which table to query
+2. Writing correct SQL (with the right joins, filters, currency conversions)
+3. Interpreting the result in business context
+4. Presenting it in a way that drives decisions
+
+Most of the time, the person with the question isn't the person who can write the query.
+
+## How Aura Solves It
+
+Ask a question in plain language. Aura writes the query, runs it, and gives you the answer with context.
+
+**What she does:**
+- Inspects table schemas before querying (never guesses column names)
+- Handles common traps: cents-to-euros conversion, epoch timestamps, NULL semantics, MRR normalization
+- Cross-references across data sources (BigQuery pipeline data + Stripe billing + Close CRM contacts)
+- Presents results as native Slack tables, not code blocks
+- Adds business interpretation ("this is 15% above last month, driven by Spain")
+
+**Built-in guardrails:**
+- Currency amounts stored in cents are automatically divided by 100
+- Epoch timestamps are converted to human-readable dates
+- Google Ads data is validated against known inflation traps
+- Queries are read-only -- Aura can't modify your data
+
+## Real Example
+
+> **Question:** "How did Spain do in February?"
+>
+> **Aura's response:**
+> Spain closed 34 deals in February for €89.2K total MRR added.
+> Top performer: [name] with 12 closes (€31K).
+> Compared to January: +22% in deal count, +18% in MRR.
+> Pipeline for March: 47 qualified leads, projected close rate 38%.
+
+Not a SQL query. Not a spreadsheet. A business answer.
+
+## Supported Data Sources
+
+| Source | Access Method | What You Can Query |
+|--------|--------------|-------------------|
+| BigQuery | Direct SQL via `bq` CLI | Pipeline, leads, valuations, traffic, reviews |
+| Stripe | API via stored credentials | Subscriptions, MRR, churn, invoices, failed payments |
+| Close CRM | API via stored credentials | Leads, activities, pipeline stages, rep performance |
+| Google Sheets | Sheets API | Comp models, planning docs, custom trackers |
+
+## Setup
+
+1. Grant Aura BigQuery read access (service account)
+2. Store API credentials in App Home (Stripe, Close, etc.)
+3. Aura maps the schema automatically on first query and maintains a data warehouse reference
+
+<Warning>
+Aura applies guardrails to prevent common data mistakes, but always sanity-check numbers that drive major decisions. She'll tell you when she's uncertain about a join or assumption.
+</Warning>

--- a/content/docs/use-cases/docs-maintenance.mdx
+++ b/content/docs/use-cases/docs-maintenance.mdx
@@ -1,0 +1,53 @@
+---
+title: "Documentation Maintenance"
+description: "Self-auditing documentation that detects drift, writes fixes, and opens PRs -- every day, without being asked."
+---
+
+# Documentation Maintenance
+
+## The Problem
+
+Documentation rots. The moment you ship it, it starts drifting from reality. New features get built without doc pages. Existing pages reference tools that no longer exist. Getting-started guides have the wrong repo URL or package manager.
+
+Nobody's job is to maintain docs. So nobody does.
+
+## How Aura Solves It
+
+Aura runs a daily documentation audit as a scheduled job.
+
+**The daily cycle:**
+1. Check recent commits on main for doc-impacting changes
+2. Compare tool files against doc pages (any new tools without docs?)
+3. Scan existing pages for stale references (wrong repo names, dead links, removed features)
+4. Fix what she can directly -- open a PR with corrections
+5. Flag what needs human decision (new architecture sections, content strategy)
+6. Report only if there's something worth reporting (silent otherwise)
+
+**What triggered this:**
+An audit of Aura's own docs revealed that 60% of actual capabilities had zero documentation. Getting-started referenced the wrong repo and wrong package manager. The architecture page was missing entire subsystems.
+
+Two PRs later: 95% coverage, all stale references fixed, and a daily job to prevent it from happening again.
+
+## Real Example
+
+Morning audit finds:
+> - 2 new tool files merged yesterday with no doc pages → writes both pages
+> - `vercel.mdx` still references flat project structure → updates to monorepo
+> - `memory-system.mdx` missing Cohere reranking docs → adds section
+> - Opens PR #751 with 8 files, 328 insertions
+> - DMs the maintainer: "PR ready, 3 new pages + 5 fixes"
+
+## Setup
+
+This is a job definition -- tell Aura to create it:
+
+```
+Create a daily docs maintenance job that checks the codebase
+against documentation and fixes drift. Run at 6 AM.
+```
+
+Aura creates the recurring job with a full playbook. It runs autonomously from then on.
+
+<Info>
+This use case is meta -- Aura maintaining her own docs. But the same pattern works for any documentation: API docs, runbooks, onboarding guides, internal wikis.
+</Info>

--- a/content/docs/use-cases/email-triage.mdx
+++ b/content/docs/use-cases/email-triage.mdx
@@ -1,0 +1,56 @@
+---
+title: "Email Triage"
+description: "Turn a chaotic inbox into a prioritized action list -- automatically, every day."
+---
+
+# Email Triage
+
+## The Problem
+
+Executives and managers get 50-150 emails a day. Most are noise. The ones that matter -- a failed payment, an expiring contract, a candidate waiting for a response -- get buried under newsletters, receipts, and CC threads.
+
+Manual triage takes 30-60 minutes daily. Miss one deadline and it costs real money.
+
+## How Aura Solves It
+
+Aura syncs your Gmail inbox, classifies every thread, and delivers a daily digest ranked by urgency.
+
+**What happens automatically:**
+- Inbox synced every few hours via Gmail API
+- Each thread classified: `awaiting_your_reply`, `awaiting_their_reply`, `fyi`, `junk`, `resolved`
+- Daily digest posted to your DM with:
+  - New threads since last digest
+  - Approaching deadlines
+  - Persistent urgents (threads aging without response)
+  - Auto-resolved items (superseded invoices, completed threads)
+  - Trend analysis (is your backlog growing or shrinking?)
+
+**What you can do:**
+- Ask Aura to search your email by keyword or meaning ("find that thread about the Bulgarian domain")
+- Bulk-update thread states ("mark all Sentry alerts as junk")
+- Get a digest on demand ("what's my inbox look like?")
+
+## Real Example
+
+From a production deployment with 100+ active threads:
+
+> *Email Digest — Saturday March 14*
+>
+> Awaiting your reply: **32** (steady)
+> Deadlines: Claap invoice due in 2 days, domain expires Apr 5
+> Persistent urgents: €50K failed payment (23 days), 3 hiring threads (5-13 days)
+> Auto-resolved: Old invoice superseded by new reminder
+>
+> Trend: Inbox holding steady. No net growth this cycle.
+
+The digest doesn't just list emails -- it tracks patterns over time. A thread that's been "awaiting your reply" for 23 days gets escalated. A resolved invoice gets cleaned up automatically.
+
+## Setup
+
+1. Connect Gmail via OAuth in Aura's App Home
+2. Aura creates a recurring sync + digest job
+3. Customize: digest frequency, classification rules, which addresses to prioritize
+
+<Info>
+Aura never sends emails without explicit instruction. The sync is read-only by default.
+</Info>

--- a/content/docs/use-cases/overview.mdx
+++ b/content/docs/use-cases/overview.mdx
@@ -1,0 +1,70 @@
+---
+title: "Use Cases"
+description: "Real problems Aura solves, with real examples from production teams."
+---
+
+# Why Aura?
+
+Most AI tools answer questions. Aura does work.
+
+She reads your email, triages bugs, screens candidates, monitors channels, runs data queries, reviews code, follows up with people -- and remembers everything across every interaction. She's not a chatbot you visit. She's a colleague who's always on.
+
+Here's what that looks like in practice.
+
+---
+
+## Operations
+
+<CardGroup cols={2}>
+  <Card title="Email Triage" icon="envelope" href="/use-cases/email-triage">
+    Daily inbox digest with priority ranking, deadline tracking, and auto-resolution of noise. Turns 100+ threads into 5 actions.
+  </Card>
+  <Card title="Team Pulse" icon="heart-pulse" href="/use-cases/team-pulse">
+    Async check-ins across managers and countries. Synthesizes responses into cross-cutting themes and actionable recommendations.
+  </Card>
+  <Card title="Documentation Maintenance" icon="book" href="/use-cases/docs-maintenance">
+    Self-audits its own documentation daily. Detects drift between codebase and docs, writes fixes, opens PRs.
+  </Card>
+</CardGroup>
+
+## Engineering
+
+<CardGroup cols={2}>
+  <Card title="Bug Triage" icon="bug" href="/use-cases/bug-triage">
+    Monitors bug lists, deduplicates reports, classifies severity, adds investigation context -- before an engineer looks at it.
+  </Card>
+  <Card title="Code Review & PRs" icon="code-pull-request" href="/use-cases/code-review">
+    Dispatches coding agents, reviews changes, ships fixes, manages branches. Full dev cycle from issue to merged PR.
+  </Card>
+</CardGroup>
+
+## Sales & Customer Success
+
+<CardGroup cols={2}>
+  <Card title="Data Analysis" icon="chart-mixed" href="/use-cases/data-analysis">
+    Queries BigQuery, Stripe, and CRM data with business context. Answers "how are we doing?" with numbers, not vibes.
+  </Card>
+  <Card title="Sales Operations" icon="calculator" href="/use-cases/sales-ops">
+    Commission calculations, pipeline tracking, comp model iteration. Turns spreadsheet work into conversation.
+  </Card>
+</CardGroup>
+
+## HR & Recruiting
+
+<CardGroup cols={2}>
+  <Card title="Candidate Screening" icon="user-magnifying-glass" href="/use-cases/candidate-screening">
+    Pulls candidate pipelines from Workable, runs first-pass assessments, flags standouts and concerns.
+  </Card>
+</CardGroup>
+
+---
+
+## The Compound Effect
+
+Each use case above works standalone. But the real value is compound:
+
+- Aura triages a bug report → links it to a related PR she reviewed yesterday → pings the engineer who wrote the code → references the Slack thread where the customer reported it
+- A manager mentions capacity problems in a pulse check → Aura connects it to pipeline data showing 2x growth in that market → flags it in the executive digest
+- A candidate applies → Aura screens them → cross-references with the team structure she learned from pulse checks → notes the hiring manager's preferences from past DMs
+
+This is institutional memory that works for you. Not a knowledge base you have to search -- a colleague who already knows.

--- a/content/docs/use-cases/sales-ops.mdx
+++ b/content/docs/use-cases/sales-ops.mdx
@@ -1,0 +1,50 @@
+---
+title: "Sales Operations"
+description: "Commission calculations, pipeline tracking, and comp model iteration -- in conversation, not spreadsheets."
+---
+
+# Sales Operations
+
+## The Problem
+
+Sales operations runs on spreadsheets. Commission calculations are manual, error-prone, and take hours. Comp model changes require rebuilding formulas. Pipeline tracking means switching between CRM, spreadsheets, and Slack.
+
+When a sales leader asks "what would happen if we changed the commission structure?" -- that's a day of spreadsheet work.
+
+## How Aura Solves It
+
+Aura turns sales ops into a conversation.
+
+**Commission calculations:**
+- Reads the comp model (from Google Sheets, notes, or conversation)
+- Pulls actual sales data from CRM/BigQuery
+- Calculates commissions per rep, per team, per period
+- Presents results as Slack tables with breakdowns
+
+**Comp model iteration:**
+- "What if we add an NDR quarterly bonus?" → Aura models it against historical data
+- "What does a linear MRR formula look like vs. tiered?" → Side-by-side comparison
+- Changes are modeled in conversation, then locked into the comp sheet when approved
+
+**Pipeline tracking:**
+- Current pipeline by stage, rep, and market
+- Close rate projections based on historical conversion
+- Alerts when pipeline coverage drops below target
+
+## Real Example
+
+A Head of Sales and Aura iterate on a new comp model over 200+ messages:
+
+1. Start with the existing tiered structure
+2. Model a linear MRR formula against last quarter's data
+3. Add an NDR quarterly bonus component
+4. Compare payout across all reps under both models
+5. Lock the final version into a Google Sheet
+
+What would have taken a week of spreadsheet work happened in a few days of async conversation -- with every assumption documented and every number traceable.
+
+## Setup
+
+1. Share the current comp model (spreadsheet, doc, or just describe it)
+2. Connect CRM data (Close API credentials in App Home)
+3. Aura builds the calculation engine and maintains it as the model evolves

--- a/content/docs/use-cases/team-pulse.mdx
+++ b/content/docs/use-cases/team-pulse.mdx
@@ -1,0 +1,63 @@
+---
+title: "Team Pulse"
+description: "Async manager check-ins that actually surface what matters -- across teams, countries, and time zones."
+---
+
+# Team Pulse
+
+## The Problem
+
+You manage managers. Each one runs a team in a different country, with different priorities, different blockers, different cultures. Your visibility into what's actually happening depends on:
+
+- Weekly calls that run long and cover surface-level updates
+- Slack messages you might miss
+- Quarterly reviews that are already stale
+
+You need a real-time picture of what's working, what's stuck, and what needs your attention -- without adding another meeting.
+
+## How Aura Solves It
+
+Aura runs async pulse checks: targeted DM questions to each manager, then synthesizes responses into cross-cutting analysis.
+
+**The cycle:**
+1. Aura DMs each manager with 1-2 focused questions (adapted per person, never repetitive)
+2. Managers respond on their own time -- a sentence or a paragraph
+3. Aura synthesizes all responses into a single report with:
+   - What's working across teams
+   - What needs attention (flagged by urgency)
+   - Manager-by-manager summary with engagement scores
+   - Cross-cutting themes that no single manager would surface
+   - Specific recommendations
+
+**What makes it different from a form or survey:**
+- Aura adapts questions based on context (she read #sales, she knows about the hiring plan)
+- She follows up if something's unclear, in the manager's language
+- She connects dots across responses ("Fernando needs CSMs; Cecilia just hired one from France")
+- She tracks engagement over time and flags when someone goes silent
+
+## Real Example
+
+After 5 rounds across 6 managers in 4 countries:
+
+> **Cross-cutting themes:**
+> 1. CSM capacity = #1 operational risk (Spain short-staffed, Italy just resolved)
+> 2. Value perception gap: retention ceiling isn't operational, it's narrative
+> 3. Meetings without decisions: multi-country consensus creates debate loops
+> 4. Engineering priorities opaque outside what founders ship themselves
+>
+> **Recommendations:**
+> 1. Talk to Fernando about 2 additional CSMs -- scaling bottleneck
+> 2. Christoph's storytelling point is the sharpest strategic insight -- worth acting on
+> 3. Accept Guillaume won't do pulse checks. Direct technical asks only.
+
+This is the kind of synthesis that normally requires a chief of staff sitting in on every team's calls for a month.
+
+## Setup
+
+1. Tell Aura which managers to check in with
+2. Set frequency (weekly, bi-weekly) and preferred language per manager
+3. Aura handles the rest -- adapts questions, synthesizes, reports
+
+<Tip>
+Pulse checks work best when they're not repetitive. Aura tracks what she's already asked and shifts focus based on what's changed since last time.
+</Tip>


### PR DESCRIPTION
Adds a complete **Use Cases** section — the missing 'why should I care?' layer.

**9 new pages:** Overview, Email Triage, Team Pulse, Bug Triage, Code Review & PRs, Data Analysis, Sales Operations, Candidate Screening, Documentation Maintenance.

Every page framed as: **problem → how Aura solves it → real example → setup**. All examples from actual production usage, not hypotheticals.

Nav: Use Cases group sits right after Getting Started, before Core Systems.

540 insertions, 10 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds new pages and navigation entries without affecting runtime code paths.
> 
> **Overview**
> Adds a new **`Use Cases`** section to the docs navigation (`content/docs/docs.json`) positioned between *Getting Started* and *Core Systems*.
> 
> Introduces 9 new MDX pages under `content/docs/use-cases/` (including an `overview` landing page with cards) covering scenarios like email triage, team pulse, bug triage, data analysis, sales ops, candidate screening, code review/PRs, and docs maintenance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef51936db37259a7639b869c3e10f366dc23c426. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->