### PR TITLE
docs: fix wrong env var names, add 20+ missing vars, document auth proxy

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -93,9 +93,18 @@ Configure instance behavior:
 - Model selection
 - Feature flags
 
-## Access
+## Access & Authentication
 
-The dashboard is protected by authentication. Only users listed in `AURA_ADMIN_USER_IDS` can access it. The dashboard communicates with the API via internal routes.
+The dashboard uses Slack OAuth for login. Only users listed in `AURA_ADMIN_USER_IDS` can access it.
+
+### Auth Proxy
+
+Preview and branch deployments authenticate via an auth proxy flow. The production instance acts as the OAuth provider, and preview deployments redirect through it to obtain session tokens. This avoids needing to register separate OAuth redirect URLs for every preview deploy.
+
+The flow uses HMAC-SHA256 origin verification (via `DASHBOARD_SESSION_SECRET`) to ensure only legitimate deployments can request authentication. Short-lived transfer tokens (60s expiry) are used to pass credentials between origins, with strict validation to prevent token reuse as session tokens.
+
+**Required env vars:** `DASHBOARD_SESSION_SECRET`, `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`.
+
 
 ## Chat
 

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -15,6 +15,9 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude models |
 | `SLACK_BOT_TOKEN` | Slack bot token (`xoxb-...`) |
 | `SLACK_SIGNING_SECRET` | Slack app signing secret for request verification |
+| `DASHBOARD_SESSION_SECRET` | Secret for signing dashboard session JWTs and HMAC origin verification. Required for the dashboard to function. |
+| `DASHBOARD_API_SECRET` | Shared secret between the dashboard and API for authenticated internal requests (chat, data queries). |
+| `CRON_SECRET` | Secret for authenticating cron invocations (heartbeat, memory consolidation). Set in Vercel cron config. |
 
 ## Recommended
 
@@ -24,27 +27,62 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `GITHUB_TOKEN` | GitHub PAT for reading source code and opening PRs |
 | `AURA_ADMIN_USER_IDS` | Comma-separated Slack user IDs with admin access |
 | `E2B_API_KEY` | E2B API key for sandbox access |
+| `OPENAI_API_KEY` | OpenAI API key for embeddings and audio transcription |
+| `AURA_BOT_USER_ID` | Aura's own Slack bot user ID |
 
 ## Optional Integrations
 
 | Variable | Description |
 |----------|-------------|
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID (for Gmail, Calendar, Drive) |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
-| `GOOGLE_SA_KEY_JSON` | Google service account key JSON (for BigQuery) |
+| `GOOGLE_EMAIL_CLIENT_ID` | Google OAuth client ID (for Gmail integration) |
+| `GOOGLE_EMAIL_CLIENT_SECRET` | Google OAuth client secret (for Gmail integration) |
+| `GOOGLE_BQ_CREDENTIALS` | Base64-encoded Google service account key JSON (for BigQuery) |
+| `GOOGLE_SERVICE_ACCOUNT_KEY` | Google service account key JSON (alternative to `GOOGLE_BQ_CREDENTIALS`) |
 | `TAVILY_API_KEY` | Tavily API key for web search |
-| `SENDGRID_API_KEY` | SendGrid API key for outbound email |
+| `BROWSERBASE_API_KEY` | Browserbase API key for browser automation |
+| `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `ELEVENLABS_API_KEY` | ElevenLabs API key for voice calls |
+| `ELEVENLABS_AGENT_ID` | ElevenLabs conversational AI agent ID |
+| `ELEVENLABS_FROM_NUMBER` | Phone number for outbound voice calls |
+| `ELEVENLABS_WEBHOOK_SECRET` | Secret for verifying ElevenLabs webhook payloads |
+| `CURSOR_API_KEY` | Cursor API key for dispatching Cursor cloud agents |
+| `CURSOR_WEBHOOK_SECRET` | Secret for verifying Cursor agent webhook callbacks |
+| `COHERE_API_KEY` | Cohere API key for reranking search results |
+| `VERCEL_TOKEN` | Vercel token (injected into sandbox for deployments) |
+
+## Dashboard
+
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_APP_URL` | Dashboard base URL (defaults to `http://localhost:3000`) |
+| `SLACK_CLIENT_ID` | Slack OAuth client ID for dashboard login |
+| `SLACK_CLIENT_SECRET` | Slack OAuth client secret for dashboard login |
+
+## Branding / Identity
+
+| Variable | Description |
+|----------|-------------|
+| `COMPANY_NAME` | Company name used in email signatures |
+| `AURA_WEBSITE_URL` | Website URL used in email signatures |
+| `AURA_EMAIL_ADDRESS` | Aura's email address for outbound email |
 
 ## Model Configuration
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MAIN_MODEL` | Primary model ID | `claude-sonnet-4-20250514` |
-| `FAST_MODEL` | Fast model for simple tasks | `claude-haiku-3-20250709` |
-| `EMBEDDING_MODEL` | Embedding model ID | `text-embedding-3-large` |
+| `MODEL_MAIN` | Primary model ID (Vercel AI Gateway format) | `anthropic/claude-sonnet-4-20250514` |
+| `MODEL_FAST` | Fast model for simple tasks | `anthropic/claude-haiku-4-5` |
+| `MODEL_EMBEDDING` | Embedding model ID | `openai/text-embedding-3-small` |
+| `MODEL_ESCALATION` | Escalation model for complex reasoning | `anthropic/claude-opus-4-6` |
 
 Models can also be configured via the `settings` table in the database, which takes precedence over environment variables.
+
+## Debugging
+
+| Variable | Description |
+|----------|-------------|
+| `LOG_LEVEL` | Logging verbosity |
+| `SHOW_REASONING_IN_SLACK` | Set to `"true"` to post extended thinking traces as thread replies |
 
 ## Adding Variables via CLI
 


### PR DESCRIPTION
## What

Comprehensive accuracy fix for the environment variables documentation page, plus auth proxy documentation in dashboard.mdx.

## P0 Fixes (factually wrong)

- **Model env vars had wrong names**: `MAIN_MODEL` → `MODEL_MAIN`, `FAST_MODEL` → `MODEL_FAST`, `EMBEDDING_MODEL` → `MODEL_EMBEDDING`
- **Model defaults were wrong**: e.g. `claude-haiku-3-20250709` → `anthropic/claude-haiku-4-5`, `text-embedding-3-large` → `openai/text-embedding-3-small`
- **Google vars had wrong names**: `GOOGLE_CLIENT_ID` → `GOOGLE_EMAIL_CLIENT_ID`, `GOOGLE_SA_KEY_JSON` → `GOOGLE_BQ_CREDENTIALS`
- **`SENDGRID_API_KEY`** was documented but doesn't exist in codebase — removed

## Missing vars added

### Critical (app breaks without them):
- `DASHBOARD_SESSION_SECRET` — dashboard auth + HMAC origin verification
- `DASHBOARD_API_SECRET` — dashboard-to-API authenticated requests
- `CRON_SECRET` — heartbeat and memory consolidation auth

### Important:
- `OPENAI_API_KEY`, `AURA_BOT_USER_ID`, `MODEL_ESCALATION`
- Browserbase, Cursor, Cohere, ElevenLabs (expanded), Vercel token
- Dashboard section (`NEXT_PUBLIC_APP_URL`, Slack OAuth)
- Branding section (`COMPANY_NAME`, `AURA_WEBSITE_URL`, `AURA_EMAIL_ADDRESS`)
- Debugging section (`LOG_LEVEL`, `SHOW_REASONING_IN_SLACK`)

## Method
`grep -roh 'process.env.X' apps/ packages/` across the full codebase, cross-referenced against existing docs.

## dashboard.mdx
Added auth proxy documentation covering the HMAC-based origin verification flow from PR #753.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change, but incorrect guidance could still break deployments if env vars are followed verbatim.
> 
> **Overview**
> Updates the docs to **correct and expand** the environment variable reference, including newly documented required secrets (e.g. `DASHBOARD_SESSION_SECRET`, `DASHBOARD_API_SECRET`, `CRON_SECRET`), additional optional integration keys, and new sections for dashboard/branding/debugging.
> 
> Clarifies dashboard access by renaming the section to `Access & Authentication` and documenting the **Slack OAuth + auth proxy** flow for preview/branch deployments, including HMAC origin verification and short-lived transfer tokens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16742c7c7d5bf95586adaef6ccafa53c38f77278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->