### PR TITLE
fix invacations rendering

### DIFF
--- a/apps/dashboard/src/components/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard-shell.tsx
@@ -29,8 +29,68 @@ interface DashboardShellProps {
   children: React.ReactNode;
 }
 
+function Header({
+  session,
+  chatOpen,
+  toggleChat,
+}: {
+  session: Session | null;
+  chatOpen: boolean;
+  toggleChat: () => void;
+}) {
+  return (
+    <header className="flex h-12 items-center justify-between border-b px-4">
+      <div className="flex items-center gap-2">
+        <MobileNav />
+        <h2 className="text-[13px] font-medium text-muted-foreground hidden md:block">
+          Administration
+        </h2>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={toggleChat}
+          className={cn(
+            "flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] transition-colors cursor-pointer",
+            chatOpen
+              ? "bg-muted text-foreground"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+          )}
+          title={chatOpen ? "Close chat" : "Open chat"}
+        >
+          <MessageCircle className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Chat</span>
+        </button>
+        <ThemeToggle />
+        {session && (
+          <div className="flex items-center gap-2">
+            {session.picture && (
+              <img
+                src={session.picture}
+                alt={session.name}
+                className="h-6 w-6 rounded-full"
+                referrerPolicy="no-referrer"
+              />
+            )}
+            <span className="text-[13px] hidden sm:inline">
+              {session.name}
+            </span>
+            <a
+              href="/api/auth/logout"
+              className="p-1 hover:bg-muted rounded-md text-muted-foreground hover:text-foreground transition-colors"
+              title="Sign out"
+            >
+              <LogOut className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}
+
 export function DashboardShell({ session, children }: DashboardShellProps) {
   const chatPanelRef = usePanelRef();
+  const [mounted, setMounted] = useState(false);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "aura-dashboard-layout",
@@ -41,10 +101,14 @@ export function DashboardShell({ session, children }: DashboardShellProps) {
   const [chatOpen, setChatOpen] = useState(initiallyOpen);
 
   useEffect(() => {
-    if (!initiallyOpen && chatPanelRef.current) {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (mounted && !initiallyOpen && chatPanelRef.current) {
       chatPanelRef.current.collapse();
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [mounted]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleChat = useCallback(() => {
     const panel = chatPanelRef.current;
@@ -67,6 +131,21 @@ export function DashboardShell({ session, children }: DashboardShellProps) {
     [],
   );
 
+  const noop = () => {};
+
+  if (!mounted) {
+    return (
+      <div className="flex-1 overflow-hidden flex">
+        <div className="flex h-full w-full flex-col overflow-hidden">
+          <Header session={session} chatOpen={false} toggleChat={noop} />
+          <main className="flex-1 overflow-y-auto">
+            <div className="px-4 py-3 md:px-5 md:py-4">{children}</div>
+          </main>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Group
       orientation="horizontal"
@@ -76,52 +155,7 @@ export function DashboardShell({ session, children }: DashboardShellProps) {
     >
       <Panel id="content" minSize="50%">
         <div className="flex h-full flex-col overflow-hidden">
-          <header className="flex h-12 items-center justify-between border-b px-4">
-            <div className="flex items-center gap-2">
-              <MobileNav />
-              <h2 className="text-[13px] font-medium text-muted-foreground hidden md:block">
-                Administration
-              </h2>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={toggleChat}
-                className={cn(
-                  "flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] transition-colors cursor-pointer",
-                  chatOpen
-                    ? "bg-muted text-foreground"
-                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                )}
-                title={chatOpen ? "Close chat" : "Open chat"}
-              >
-                <MessageCircle className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">Chat</span>
-              </button>
-              <ThemeToggle />
-              {session && (
-                <div className="flex items-center gap-2">
-                  {session.picture && (
-                    <img
-                      src={session.picture}
-                      alt={session.name}
-                      className="h-6 w-6 rounded-full"
-                      referrerPolicy="no-referrer"
-                    />
-                  )}
-                  <span className="text-[13px] hidden sm:inline">
-                    {session.name}
-                  </span>
-                  <a
-                    href="/api/auth/logout"
-                    className="p-1 hover:bg-muted rounded-md text-muted-foreground hover:text-foreground transition-colors"
-                    title="Sign out"
-                  >
-                    <LogOut className="h-3.5 w-3.5" />
-                  </a>
-                </div>
-              )}
-            </div>
-          </header>
+          <Header session={session} chatOpen={chatOpen} toggleChat={toggleChat} />
           <main className="flex-1 overflow-y-auto">
             <div className="px-4 py-3 md:px-5 md:py-4">{children}</div>
           </main>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that delays chat panel collapse until after mount; main risk is minor layout flicker or chat open state briefly differing on first render.
> 
> **Overview**
> Refactors `DashboardShell` by extracting the top bar into a reusable `Header` component and adding a `mounted` gate to avoid running panel collapse logic before the client has mounted.
> 
> On the initial (pre-mount) render it now shows a simplified layout (header + main content) and only initializes the resizable panel group and chat collapse/expand behavior after mount, preventing incorrect initial rendering of the chat panel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe159574975a993d98b1d05070c2566896cefa6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->