### PR TITLE
docs: add missing update_job tool to jobs page

### DIFF
--- a/content/docs/tools/jobs.mdx
+++ b/content/docs/tools/jobs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jobs & Scheduling Tools"
-description: "One-shot reminders, recurring cron jobs, headless execution, and background tasks — 5 tools."
+description: "One-shot reminders, recurring cron jobs, headless execution, and background tasks — 6 tools."
 ---
 
 # Jobs & Scheduling Tools
@@ -53,6 +53,28 @@ Cancel a pending one-shot job, or disable a recurring job (preserves its definit
 |-------|------|----------|-------------|
 | `job_id` | string | conditional | UUID of the job to cancel |
 | `name` | string | conditional | Name of the job to cancel (alternative to `job_id`) |
+---
+
+## `update_job`
+
+Update an existing job's configuration without recreating it. Preserves job ID and execution history. Use to change playbook, schedule, description, or re-enable a disabled job.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `job_id` | string | conditional | UUID of the job to update |
+| `name` | string | conditional | Name of the job to update (alternative to `job_id`) |
+| `updates` | object | **yes** | Fields to update (only provided fields are changed) |
+| `updates.description` | string | no | New job description |
+| `updates.playbook` | string | no | New execution playbook |
+| `updates.recurring` | string | no | New cron expression, e.g. `0 9 * * 1-5` |
+| `updates.timezone` | string | no | New IANA timezone for cron schedule |
+| `updates.channel_name` | string | no | New channel to post results in |
+| `updates.priority` | enum | no | `high`, `normal`, or `low` |
+| `updates.enabled` | boolean | no | Re-enable a disabled job by setting to `true` |
+| `updates.max_per_day` | number | no | New max executions per day |
+| `updates.min_interval_hours` | number | no | New minimum hours between executions |
+
+When a cron schedule or timezone is updated, the next execution time is automatically recalculated. Setting `enabled: true` on a cancelled recurring job re-enables it with a fresh next execution time.
 
 ---
 


### PR DESCRIPTION
PR #759 added `update_job` but the docs page wasn't updated.

**Changes:**
- Add full `update_job` section with all parameters documented
- Fix tool count in page description: 5 → 6
- Document auto-recalculation of `executeAt` on schedule/timezone changes
- Document re-enable behavior for disabled recurring jobs

Found by automated docs maintenance audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Updates `content/docs/tools/jobs.mdx` to reflect **6** jobs/scheduling tools and adds a full `update_job` section documenting supported update fields (e.g., schedule/timezone, playbook, channel, priority, enable/disable, and rate limits).
> 
> Also notes that changing cron/timezone recalculates the next execution time and that setting `enabled: true` re-enables a cancelled recurring job with a fresh next run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31e5d506cef1e96f9173fca093df68c0b59ac0fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->