### PR TITLE
docs: add multi-tenancy section, update model references

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -5,7 +5,7 @@ description: "How Aura's message pipeline, memory system, tools, and self-improv
 
 # Architecture
 
-Aura is a Hono-based application deployed on Vercel serverless functions. She processes Slack events, maintains long-term memory in PostgreSQL, and uses Claude models for reasoning.
+Aura is a Hono-based application deployed on Vercel serverless functions. She processes Slack events, maintains long-term memory in PostgreSQL, and uses LLMs (Claude, Grok) for reasoning via the Vercel AI SDK.
 
 ## Monorepo Structure
 
@@ -118,6 +118,16 @@ Aura uses Claude's extended thinking capability, which captures the model's reas
 - Stored alongside conversation messages
 - Visible in the dashboard for debugging
 - Useful for understanding why Aura made specific decisions or tool calls
+
+## Multi-Tenancy
+
+Aura's database schema is workspace-scoped. A central `workspaces` table (keyed by Slack team ID) owns all data, and every major table includes a `workspace_id` foreign key:
+
+- **Workspace isolation** -- Memories, messages, conversations, notes, jobs, credentials, user profiles, and settings are all scoped to a workspace ID. Unique constraints are composite (workspace_id + original key) so multiple workspaces can coexist in a single database.
+- **Backwards compatibility** -- Existing single-workspace deployments use a `'default'` workspace ID, seeded automatically by the migration. No configuration changes needed.
+- **Schema enforcement** -- `workspace_id` is `NOT NULL` with a default value and foreign key constraint on all scoped tables. The `workspaceId()` helper in the schema ensures consistent column definitions.
+
+This is Phase 1 (schema + migration). Query-level filtering by workspace is not yet enforced at the application layer.
 
 ## Credential System
 

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -26,7 +26,7 @@ Filter by user, channel, date range, or search by content.
 Track token usage and costs over time:
 
 - Daily/weekly/monthly cost charts
-- Breakdown by model (Claude Opus, Sonnet, Haiku)
+- Breakdown by model (Claude, Grok, etc.)
 - Per-user consumption
 - Token type distribution (input vs output vs cache)
 


### PR DESCRIPTION
## What

- Adds a **Multi-Tenancy** section to `architecture.mdx` documenting the workspace_id scoping introduced in PR #772 (Phase 1: schema + migration)
- Updates model references from Claude-specific to model-agnostic (Claude, Grok) after PR #765 added Grok model support
- Fixes dashboard.mdx model breakdown list

## Why

PR #772 is a significant architectural change (workspace_id on 25 tables) with zero documentation. PR #765 added Grok models but docs still said 'Claude models' exclusively.

## Changes

- `content/docs/architecture.mdx`: New Multi-Tenancy section, updated intro line
- `content/docs/dashboard.mdx`: Updated model breakdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime behavior changes, with the main risk being minor confusion if the described multi-tenancy phase/status diverges from implementation.
> 
> **Overview**
> Updates docs to be model-agnostic by referencing multiple LLM providers (e.g., Claude and Grok) in the architecture overview and dashboard consumption section.
> 
> Adds a new **Multi-Tenancy** section to `content/docs/architecture.mdx` documenting workspace-scoped data via `workspace_id`, including isolation/constraints, a `'default'` workspace for backward compatibility, and noting that application-layer filtering is not yet enforced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9af1997adebf8f333954359e9cea5862995b970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->