### PR TITLE
fix(db): harden workspace_id not-null migration against race inserts

### DIFF
--- a/packages/db/drizzle/0043_add_workspace_id.sql
+++ b/packages/db/drizzle/0043_add_workspace_id.sql
@@ -99,24 +99,34 @@ ALTER TABLE "oauth_tokens" ALTER COLUMN "workspace_id" SET NOT NULL;--> statemen
 ALTER TABLE "emails_raw" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
 ALTER TABLE "emails_raw" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "event_locks" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "event_locks" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "event_locks" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "feedback" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "feedback" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "feedback" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "error_events" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "error_events" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "error_events" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "model_pricing" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "model_pricing" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "model_pricing" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "conversation_traces" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "conversation_traces" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "conversation_traces" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "conversation_messages" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "conversation_messages" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "conversation_messages" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "conversation_parts" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "conversation_parts" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "conversation_parts" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "conversation_locks" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "conversation_locks" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "conversation_locks" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "action_log" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "action_log" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "action_log" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "approval_policies" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "approval_policies" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "approval_policies" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 
 -- 6. Add foreign key constraints referencing workspaces(id)

--- a/packages/db/drizzle/0043_add_workspace_id.sql
+++ b/packages/db/drizzle/0043_add_workspace_id.sql
@@ -208,6 +208,42 @@ ALTER TABLE "feedback" DROP CONSTRAINT IF EXISTS "feedback_unique_vote";--> stat
 ALTER TABLE "model_pricing" DROP CONSTRAINT IF EXISTS "model_pricing_model_token_date_unique";--> statement-breakpoint
 ALTER TABLE "action_log" DROP CONSTRAINT IF EXISTS "action_log_idempotency_key_unique";--> statement-breakpoint
 
+-- 8b. Normalize legacy credential column names before workspace-scoped unique constraints.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'credentials' AND column_name = 'owner_id'
+  ) THEN
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'credentials' AND column_name = 'user_id'
+    ) THEN
+      ALTER TABLE "credentials" RENAME COLUMN "user_id" TO "owner_id";
+    ELSE
+      ALTER TABLE "credentials" ADD COLUMN "owner_id" text;
+    END IF;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'credential_grants' AND column_name = 'grantee_id'
+  ) THEN
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'credential_grants' AND column_name = 'user_id'
+    ) THEN
+      ALTER TABLE "credential_grants" RENAME COLUMN "user_id" TO "grantee_id";
+    ELSE
+      ALTER TABLE "credential_grants" ADD COLUMN "grantee_id" text;
+    END IF;
+  END IF;
+END $$;--> statement-breakpoint
+
 -- 9. Create new workspace-scoped composite unique indexes
 CREATE UNIQUE INDEX IF NOT EXISTS "notes_workspace_topic_idx" ON "notes" USING btree ("workspace_id", "topic");--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "jobs_workspace_name_idx" ON "jobs" USING btree ("workspace_id", "name");--> statement-breakpoint

--- a/packages/db/drizzle/0043_add_workspace_id.sql
+++ b/packages/db/drizzle/0043_add_workspace_id.sql
@@ -69,34 +69,49 @@ UPDATE "approval_policies" SET "workspace_id" = 'default' WHERE "workspace_id" I
 
 -- 5. Set DEFAULT and NOT NULL on all workspace_id columns (DEFAULT first to avoid NOT NULL violations from concurrent inserts)
 ALTER TABLE "messages" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "messages" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "messages" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "memories" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "memories" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "memories" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "notes" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "notes" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "notes" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "people" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "people" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "people" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "addresses" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "addresses" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "addresses" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "user_profiles" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "user_profiles" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "user_profiles" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "channels" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "channels" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "channels" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "settings" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "settings" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "settings" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "jobs" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "jobs" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "jobs" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "job_executions" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "job_executions" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "job_executions" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "credentials" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "credentials" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "credentials" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "credential_grants" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "credential_grants" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "credential_grants" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "credential_audit_log" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "credential_audit_log" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "credential_audit_log" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "oauth_tokens" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "oauth_tokens" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "oauth_tokens" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "emails_raw" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
+UPDATE "emails_raw" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "emails_raw" ALTER COLUMN "workspace_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "event_locks" ALTER COLUMN "workspace_id" SET DEFAULT 'default';--> statement-breakpoint
 UPDATE "event_locks" SET "workspace_id" = 'default' WHERE "workspace_id" IS NULL;--> statement-breakpoint

--- a/packages/db/drizzle/0043_add_workspace_id.sql
+++ b/packages/db/drizzle/0043_add_workspace_id.sql
@@ -223,39 +223,56 @@ ALTER TABLE "feedback" DROP CONSTRAINT IF EXISTS "feedback_unique_vote";--> stat
 ALTER TABLE "model_pricing" DROP CONSTRAINT IF EXISTS "model_pricing_model_token_date_unique";--> statement-breakpoint
 ALTER TABLE "action_log" DROP CONSTRAINT IF EXISTS "action_log_idempotency_key_unique";--> statement-breakpoint
 
--- 8b. Normalize legacy credential column names before workspace-scoped unique constraints.
+-- 8b. Ensure all columns referenced by workspace-scoped unique constraints exist.
+-- The credentials / credential_grants tables may predate migration 0027 or have
+-- a divergent schema on prod, so we defensively add every missing column.
 DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM information_schema.columns
-    WHERE table_schema = 'public' AND table_name = 'credentials' AND column_name = 'owner_id'
-  ) THEN
-    IF EXISTS (
-      SELECT 1
-      FROM information_schema.columns
-      WHERE table_schema = 'public' AND table_name = 'credentials' AND column_name = 'user_id'
-    ) THEN
+  -- credentials: needs owner_id, name for UNIQUE(workspace_id, owner_id, name)
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='owner_id') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='user_id') THEN
       ALTER TABLE "credentials" RENAME COLUMN "user_id" TO "owner_id";
     ELSE
       ALTER TABLE "credentials" ADD COLUMN "owner_id" text;
     END IF;
   END IF;
-END $$;--> statement-breakpoint
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    FROM information_schema.columns
-    WHERE table_schema = 'public' AND table_name = 'credential_grants' AND column_name = 'grantee_id'
-  ) THEN
-    IF EXISTS (
-      SELECT 1
-      FROM information_schema.columns
-      WHERE table_schema = 'public' AND table_name = 'credential_grants' AND column_name = 'user_id'
-    ) THEN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='name') THEN
+    ALTER TABLE "credentials" ADD COLUMN "name" text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='value') THEN
+    ALTER TABLE "credentials" ADD COLUMN "value" text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='key_version') THEN
+    ALTER TABLE "credentials" ADD COLUMN "key_version" integer DEFAULT 1;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='expires_at') THEN
+    ALTER TABLE "credentials" ADD COLUMN "expires_at" timestamptz;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='type') THEN
+    ALTER TABLE "credentials" ADD COLUMN "type" text DEFAULT 'token';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='token_url') THEN
+    ALTER TABLE "credentials" ADD COLUMN "token_url" text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credentials' AND column_name='sandbox_env_name') THEN
+    ALTER TABLE "credentials" ADD COLUMN "sandbox_env_name" text;
+  END IF;
+
+  -- credential_grants: needs grantee_id, credential_id for UNIQUE(workspace_id, credential_id, grantee_id)
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credential_grants' AND column_name='grantee_id') THEN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credential_grants' AND column_name='user_id') THEN
       ALTER TABLE "credential_grants" RENAME COLUMN "user_id" TO "grantee_id";
     ELSE
       ALTER TABLE "credential_grants" ADD COLUMN "grantee_id" text;
     END IF;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credential_grants' AND column_name='credential_id') THEN
+    ALTER TABLE "credential_grants" ADD COLUMN "credential_id" uuid;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credential_grants' AND column_name='permission') THEN
+    ALTER TABLE "credential_grants" ADD COLUMN "permission" text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='credential_grants' AND column_name='granted_by') THEN
+    ALTER TABLE "credential_grants" ADD COLUMN "granted_by" text;
   END IF;
 END $$;--> statement-breakpoint
 


### PR DESCRIPTION
Backfill NULL workspace_id values immediately before late SET NOT NULL steps so production migrations succeed even if concurrent writes occur during migration execution.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration changes are production-impacting and touch many tables; added defensive DDL reduces failures but introduces more moving parts (conditional renames/add-columns) that must match real prod state.
> 
> **Overview**
> Hardens the `0043_add_workspace_id.sql` migration by **re-backfilling `workspace_id` to `'default'` immediately before each `SET NOT NULL`**, reducing failures from concurrent inserts during the migration.
> 
> Adds a defensive `DO $$` block to **ensure `credentials` and `credential_grants` have all columns needed for workspace-scoped unique constraints** (including conditional `user_id`→`owner_id`/`grantee_id` renames and adding missing columns) so the migration can run against divergent production schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d0274ea743b76dbce974c2d5db0cf92c08f4a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->