### PR TITLE
docs: update pipeline section to reflect usage stats injection

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -58,9 +58,9 @@ Slack Event → Vercel Function → Hono Router → Message Pipeline → Claude 
 When a Slack message arrives:
 
 1. **Event deduplication** — Slack sometimes sends duplicate events. The `event_locks` table prevents double-processing.
-2. **Context loading** — Recent conversation history, relevant memories, user profile, notes index, and channel context are loaded in parallel.
+2. **Context loading** — Recent conversation history, relevant memories, user profile, notes index, channel context, and usage stats are loaded in parallel.
 3. **Memory retrieval** — Hybrid search (vector + full-text) finds relevant memories from past conversations.
-4. **Prompt assembly** — System prompt is built from personality, self-directive, notes index, memories, and user profile.
+4. **Prompt assembly** — System prompt is built from personality, self-directive, notes index, memories, user profile, and dynamic context (current time, active model, usage stats).
 5. **LLM reasoning** — Claude processes the message with full context and available tools. Extended thinking captures the reasoning trace.
 6. **Response streaming** — The response streams back to Slack in real-time via the Vercel AI SDK.
 7. **Conversation persistence** — The full conversation trace (messages, tool calls, reasoning, token usage) is stored with cost tracking.


### PR DESCRIPTION
Updates the Message Pipeline section in  to reflect PR #777 (usage stats injection):

- **Context loading step**: now includes usage stats in the parallel-loaded context
- **Prompt assembly step**: now mentions dynamic context (current time, active model, usage stats) as part of prompt construction

Small accuracy fix to keep docs aligned with the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the message pipeline description to match current runtime behavior (usage stats/dynamic context injection).
> 
> **Overview**
> Updates the `Message Pipeline` section in `content/docs/architecture.mdx` to reflect that **usage stats are loaded during context loading** and that **prompt assembly now incorporates dynamic context** (current time, active model, usage stats) alongside existing inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68891176320abc8b5d925cecf84245b2d7fac8e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->