### PR TITLE
fix: add enabled check to atomic job claim, closing cancellation race (issue #6)

### DIFF
--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -79,11 +79,11 @@ export async function executeJob(
   const claimed = await db
     .update(jobs)
     .set({ status: "running", updatedAt: new Date() })
-    .where(and(eq(jobs.id, jobId), eq(jobs.status, "pending")))
+    .where(and(eq(jobs.id, jobId), eq(jobs.status, "pending"), eq(jobs.enabled, 1)))
     .returning({ id: jobs.id });
 
   if (claimed.length === 0) {
-    logger.info("executeJob: job already claimed, skipping", { jobId, jobName: job.name });
+    logger.info("executeJob: job already claimed or disabled, skipping", { jobId, jobName: job.name });
     return false;
   }
 


### PR DESCRIPTION
## Problem

When `cancel_job` disables a recurring job (sets `enabled = 0`), there's a TOCTOU race condition: if the heartbeat had already loaded the job into memory before the cancellation, `executeJob`'s atomic claim would still succeed because it only checked `status = 'pending'`, not `enabled = 1`.

This means a disabled recurring job could still fire once after being cancelled.

## Fix

Add `eq(jobs.enabled, 1)` to the WHERE clause of the atomic claim in `executeJob()`. This ensures disabled jobs cannot be claimed for execution, even if they were loaded before being disabled.

Two-line change:
- Line 82: Added `eq(jobs.enabled, 1)` to the atomic claim WHERE clause
- Line 86: Updated log message to indicate possible disabled state

## Context

- PR #607 had the same fix but went stale (conflicting for 2+ weeks). Closed and re-dispatched fresh.
- The heartbeat already filters by `enabled = 1` (heartbeat.ts:103), but the atomic claim in `executeJob` was the gap.
- All callers of `executeJob` (heartbeat, dispatch, continuation) are now protected.

Closes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change to the job-claiming WHERE clause; main impact is avoiding an edge-case race where a disabled recurring job could still run once.
> 
> **Overview**
> Prevents disabled jobs from being atomically claimed for execution by adding an `enabled = 1` condition to the `executeJob` update/claim query.
> 
> Updates the skip log message to reflect that a job may be skipped because it was already claimed *or* is disabled, closing a cancellation race where a disabled recurring job could still run once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21c6e11f8cb321e3ba1670cdce3c82567cfae27c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->