### PR TITLE
docs: fix architecture page accuracy — usage stats, multi-model, defineTool

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -43,7 +43,7 @@ aura/
 ## System Overview
 
 ```
-Slack Event → Vercel Function → Hono Router → Message Pipeline → Claude (Vercel AI SDK)
+Slack Event → Vercel Function → Hono Router → Message Pipeline → LLM (Vercel AI SDK)
                                                       ↕
                                               PostgreSQL + pgvector
                                       (memories, messages, conversations, notes, jobs)
@@ -60,8 +60,8 @@ When a Slack message arrives:
 1. **Event deduplication** — Slack sometimes sends duplicate events. The `event_locks` table prevents double-processing.
 2. **Context loading** — Recent conversation history, relevant memories, user profile, notes index, and channel context are loaded in parallel.
 3. **Memory retrieval** — Hybrid search (vector + full-text) finds relevant memories from past conversations.
-4. **Prompt assembly** — System prompt is built from personality, self-directive, notes index, memories, and user profile.
-5. **LLM reasoning** — Claude processes the message with full context and available tools. Extended thinking captures the reasoning trace.
+4. **Prompt assembly** — System prompt is built in two layers: a stable prefix (personality, self-directive, notes index, memories, user profile) and a dynamic context (current time, active model, channel, and usage stats).
+5. **LLM reasoning** — The selected model processes the message with full context and available tools. Extended thinking captures the reasoning trace.
 6. **Response streaming** — The response streams back to Slack in real-time via the Vercel AI SDK.
 7. **Conversation persistence** — The full conversation trace (messages, tool calls, reasoning, token usage) is stored with cost tracking.
 8. **Memory extraction** — Facts, decisions, and sentiments are extracted from the conversation and stored as new memories.
@@ -80,7 +80,7 @@ The [Dashboard](/dashboard) provides a UI for browsing conversation traces, filt
 
 ## Tool System
 
-Tools are defined using the Vercel AI SDK `tool()` function with Zod schemas. Aura has **23 tool modules** organized by domain:
+Tools are defined using `defineTool()`, a wrapper around the Vercel AI SDK's `tool()` that adds audit logging and approval policies. Aura has **23 tool modules** organized by domain:
 
 | Category | Tools | Description |
 |----------|-------|-------------|


### PR DESCRIPTION
## What

Fixes 4 accuracy issues in `content/docs/architecture.mdx` found during docs maintenance audit:

1. **Pipeline step 4** — Prompt assembly now has two layers (stable prefix + dynamic context). The dynamic context includes usage stats injection (added in #777). Docs only mentioned the stable prefix components.

2. **Pipeline step 5** — Said "Claude processes the message" but Grok is also supported via Vercel AI SDK. Changed to "The selected model".

3. **System overview diagram** — Referenced "Claude" specifically; updated to "LLM".

4. **Tool system description** — Said tools use raw `tool()` from AI SDK, but they actually use `defineTool()`, a wrapper that adds audit logging and approval policies.

## Priority
P0 (factually inaccurate) + P2 (stale after recent multi-model and usage stats PRs).

## Context
Daily docs maintenance job. Cross-referenced recent commits (#777, #774, #765) against existing documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits that clarify existing behavior (multi-model LLM selection, prompt context composition, and `defineTool()` usage) without changing runtime code.
> 
> **Overview**
> Updates `content/docs/architecture.mdx` to reflect current architecture: the system diagram and pipeline steps now describe a generic **LLM** (not Claude-only) and note that prompt assembly includes both a stable prefix and **dynamic context** (time/model/channel/usage stats).
> 
> Clarifies the tool system to state tools are created via `defineTool()` (a wrapper around the AI SDK’s `tool()`) to include audit logging and approval policies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae96f07fc500cc37d6cb82e996e8b83d17a5c5a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->