### PR TITLE
fix(tools): edit_canvas replace without section_id for full-canvas replacement (#498)

### DIFF
--- a/apps/api/src/tools/slack.ts
+++ b/apps/api/src/tools/slack.ts
@@ -1973,7 +1973,7 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
 
     edit_canvas: defineTool({
       description:
-        "Edit an existing Slack Canvas. Supports inserting content at start/end or before/after a section, replacing or deleting a section, or renaming the canvas.",
+        "Edit an existing Slack Canvas. Supports: insert at start/end, insert before/after a section, replace a section (with section_id) or the entire canvas (without section_id), delete a section, or rename.",
       inputSchema: z.object({
         canvas_id: z.string().describe("The ID of the Canvas to edit"),
         operation: z
@@ -1997,7 +1997,7 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
           .string()
           .optional()
           .describe(
-            "Section ID (required for replace, delete, insert_before, insert_after). Use read_canvas to find section IDs.",
+            "Section ID (required for delete, insert_before, insert_after; optional for replace — omit to replace entire canvas). Use read_canvas to find section IDs.",
           ),
       }),
       execute: async ({ canvas_id, operation, content, section_id }) => {
@@ -2022,8 +2022,19 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
               };
             }
             changes = [{ operation: "delete", section_id }];
+          } else if (operation === "replace") {
+            if (!content) {
+              return { ok: false, error: "Content is required for replace operations." };
+            }
+            // section_id is optional for replace: with it, replaces a section; without, replaces entire canvas
+            changes = [
+              {
+                operation: "replace",
+                ...(section_id ? { section_id } : {}),
+                document_content: { type: "markdown", markdown: content },
+              },
+            ];
           } else if (
-            operation === "replace" ||
             operation === "insert_before" ||
             operation === "insert_after"
           ) {


### PR DESCRIPTION
## Problem

The `edit_canvas` tool required a `section_id` for `replace` operations, but the Slack `canvases.edit` API actually supports `replace` **without** a `section_id` to replace the entire canvas content in one call.

This caused painful 30-50 tool-call loops when trying to rewrite a canvas -- each section had to be individually replaced or deleted, often crashing mid-operation and leaving the canvas in a worse state (happened 3x in one day per the issue).

## Fix

Separate `replace` from `insert_before`/`insert_after` in the conditional chain:
- **With `section_id`**: replaces that specific section (existing behavior, unchanged)
- **Without `section_id`**: replaces the entire canvas content (new behavior)

Also updated the tool description and `section_id` parameter description to document the new capability.

## Changes
- `apps/api/src/tools/slack.ts`: Split `replace` into its own branch (+14/-3 lines)

## Testing
- `replace` + `section_id` → same as before (section replacement)
- `replace` without `section_id` → full canvas replacement via Slack API
- `insert_before`/`insert_after` still require `section_id` (unchanged)
- `delete` still requires `section_id` (unchanged)

Closes #498

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes write behavior for Slack canvases and makes omitting `section_id` on `replace` overwrite the entire canvas, which could cause unintended content loss if misused.
> 
> **Overview**
> Enables full-canvas rewrites via `edit_canvas` by allowing the `replace` operation to be called *without* a `section_id`, passing a `canvases.edit` change that replaces the entire document content.
> 
> Updates the tool and parameter descriptions to document that `section_id` remains required for `delete`/`insert_before`/`insert_after`, while `replace` now supports both section-level and full-canvas replacement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e6e5ca941c32c1d4840f3278b2bdd4508be5db2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->