### PR TITLE
fix: resolve calling user from execution context in hasRole() permission checks

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -287,6 +287,7 @@ app.post("/api/slack/events", async (c) => {
       {
         triggeredBy: userId,
         triggerType: "user_message",
+        callingUserId: event.user || undefined,
         channelId: event.channel || undefined,
         threadTs: event.thread_ts || event.ts || undefined,
       },

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -206,6 +206,7 @@ export async function executeJob(
       {
         triggeredBy: job.requestedBy,
         triggerType: "scheduled_job",
+        callingUserId: job.requestedBy,
         jobId: job.id,
       },
       () => agent.generate({ prompt }),

--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -1,6 +1,8 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { userProfiles } from "@aura/db/schema";
+import { executionContext } from "./tool.js";
+import { logger } from "./logger.js";
 
 const ROLE_HIERARCHY = {
   member: 0,
@@ -12,22 +14,51 @@ const ROLE_HIERARCHY = {
 type Role = keyof typeof ROLE_HIERARCHY;
 
 /**
+ * Resolve the calling user's Slack ID.
+ *
+ * Primary source: `executionContext` (AsyncLocalStorage), set once at
+ * the Slack event / job entry point from `event.user` or `job.requestedBy`.
+ * Fallback: the explicitly passed `userId` (for contexts without
+ * AsyncLocalStorage, e.g. the dashboard).
+ */
+function resolveCallingUserId(passedUserId: string | undefined): string | undefined {
+  const ctx = executionContext.getStore();
+  if (ctx?.callingUserId) return ctx.callingUserId;
+  return passedUserId;
+}
+
+/**
  * Check whether a user has at least the specified role.
  * Falls back to AURA_ADMIN_USER_IDS env var during migration period.
+ *
+ * The userId is resolved via resolveCallingUserId(): the execution
+ * context's callingUserId takes priority over the passed parameter so
+ * that permission checks always use the human caller's ID, not the
+ * bot's.
  */
 export async function hasRole(
   userId: string | undefined,
   minimumRole: Role = "admin"
 ): Promise<boolean> {
-  if (!userId) return false;
+  const effectiveUserId = resolveCallingUserId(userId);
 
-  if (userId === "aura") return true;
+  if (!effectiveUserId) return false;
+
+  if (effectiveUserId === "aura") return true;
+
+  if (effectiveUserId !== userId && userId) {
+    logger.warn("hasRole: overriding userId from execution context", {
+      passed: userId,
+      effective: effectiveUserId,
+      minimumRole,
+    });
+  }
 
   try {
     const profile = await db
       .select({ role: userProfiles.role })
       .from(userProfiles)
-      .where(eq(userProfiles.slackUserId, userId))
+      .where(eq(userProfiles.slackUserId, effectiveUserId))
       .limit(1);
 
     if (profile.length > 0 && profile[0].role) {
@@ -43,7 +74,7 @@ export async function hasRole(
     .split(",")
     .map((id) => id.trim())
     .filter(Boolean);
-  if (adminIds.includes(userId)) {
+  if (adminIds.includes(effectiveUserId)) {
     const requiredLevel = ROLE_HIERARCHY[minimumRole];
     return ROLE_HIERARCHY.admin >= requiredLevel;
   }

--- a/apps/api/src/lib/tool.ts
+++ b/apps/api/src/lib/tool.ts
@@ -12,6 +12,7 @@ import { logger } from "./logger.js";
 export interface ExecutionContext {
   triggeredBy: string;
   triggerType: "user_message" | "scheduled_job" | "autonomous";
+  callingUserId?: string;
   jobId?: string;
   channelId?: string;
   threadTs?: string;

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -14,6 +14,7 @@ import { getMainModel, getMainModelId, withAnthropicFallback, type WrappableMode
 import { buildCorePrompt } from "../../pipeline/core-prompt.js";
 import { createAgenticStream } from "../../pipeline/generate.js";
 import { createCoreTools } from "../../tools/core.js";
+import { executionContext } from "../../lib/tool.js";
 import { extractMemories } from "../../memory/extract.js";
 import {
   createConversationTrace,
@@ -269,37 +270,40 @@ dashboardChatApp.post("/", async (c) => {
 
     const modelMessages = await convertToModelMessages(messages);
 
-    const result = createAgenticStream({
-      model,
-      modelId,
-      tools,
-      stablePrefix: prompt.stablePrefix,
-      conversationContext: prompt.conversationContext,
-      dynamicContext: prompt.dynamicContext,
-      messages: modelMessages,
-      maxSteps: 20,
-      channelId: "dashboard",
-      threadTs: threadId ?? undefined,
-      userId,
-      onFinish: ({ steps, totalUsage, text }) => {
-        logger.info("Dashboard chat onFinish fired", { threadId, userId, messageId, textLen: text.length });
-        waitUntil(
-          persistDashboardConversation({
-            userId,
-            messageId,
-            modelId,
-            threadId,
-            userMessage: messageText,
-            assistantText: text,
-            systemPrompt: prompt.stablePrefix,
-            steps,
-            totalUsage,
-          }).catch((err) => {
-            logger.error("persistDashboardConversation rejected", { error: String(err) });
-          }),
-        );
-      },
-    });
+    const result = executionContext.run(
+      { triggeredBy: userId, triggerType: "user_message", callingUserId: userId, channelId: "dashboard" },
+      () => createAgenticStream({
+        model,
+        modelId,
+        tools,
+        stablePrefix: prompt.stablePrefix,
+        conversationContext: prompt.conversationContext,
+        dynamicContext: prompt.dynamicContext,
+        messages: modelMessages,
+        maxSteps: 20,
+        channelId: "dashboard",
+        threadTs: threadId ?? undefined,
+        userId,
+        onFinish: ({ steps, totalUsage, text }) => {
+          logger.info("Dashboard chat onFinish fired", { threadId, userId, messageId, textLen: text.length });
+          waitUntil(
+            persistDashboardConversation({
+              userId,
+              messageId,
+              modelId,
+              threadId,
+              userMessage: messageText,
+              assistantText: text,
+              systemPrompt: prompt.stablePrefix,
+              steps,
+              totalUsage,
+            }).catch((err) => {
+              logger.error("persistDashboardConversation rejected", { error: String(err) });
+            }),
+          );
+        },
+      }),
+    );
 
     return result.toUIMessageStreamResponse({
       originalMessages: messages,


### PR DESCRIPTION
## Summary

- **Fixes** permission checks using the bot's user ID instead of the calling user's Slack ID, causing "Only power users and above can..." errors even for workspace owners.
- `hasRole()` now resolves the effective user ID from `executionContext` (AsyncLocalStorage) — set once at the Slack event / job entry point from `event.user` or `job.requestedBy` — instead of relying solely on `ScheduleContext.userId` threaded through a deep closure chain.
- All three entry points (Slack events, headless jobs, dashboard chat) now set `callingUserId` in the execution context. A warning is logged when the execution context overrides a divergent passed ID, aiding diagnosis of any remaining wiring issues.

## Changes

| File | What |
|------|------|
| `apps/api/src/lib/tool.ts` | Add `callingUserId` to `ExecutionContext` |
| `apps/api/src/lib/permissions.ts` | `hasRole()` resolves user via `resolveCallingUserId()` (execution context → passed param) |
| `apps/api/src/app.ts` | Set `callingUserId: event.user` at Slack event entry point |
| `apps/api/src/cron/execute-job.ts` | Set `callingUserId: job.requestedBy` at headless job entry point |
| `apps/api/src/routes/dashboard/chat.ts` | Wrap `createAgenticStream` in `executionContext.run()` with dashboard userId |

## Test plan

- [ ] Verify that user U0678NQJ2 (role=owner) can trigger `run_command`, `browse`, `dispatch_cursor_agent`, and other power_user-gated tools without permission errors
- [ ] Verify that non-elevated users (role=member) are still correctly blocked from power_user/admin-gated tools
- [ ] Verify headless job executions respect the `requestedBy` user's role
- [ ] Verify dashboard chat tool calls work with the new execution context wrapping
- [ ] Check logs for any "hasRole: overriding userId from execution context" warnings — these indicate the closure chain was passing a different ID than the execution context


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization/role enforcement by changing how `hasRole()` determines the effective Slack user ID (favoring AsyncLocalStorage context), which could inadvertently grant/deny access if context is missing or mis-set.
> 
> **Overview**
> Fixes role-based permission checks to use the *human caller’s* Slack ID rather than a propagated/bot ID by adding `callingUserId` to `ExecutionContext` and resolving it inside `hasRole()`.
> 
> Updates all entry points that run agent/tool pipelines (Slack events, scheduled jobs, and dashboard chat) to set `callingUserId` in `executionContext`, and logs a warning when the context overrides a divergent passed `userId` to help detect remaining wiring issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79a62015a52181ee6edb15f5e8fa22b22cf53c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->