### PR TITLE
feat: Add Role dropdown to dashboard user detail page

### DIFF
--- a/apps/api/src/routes/dashboard/users.ts
+++ b/apps/api/src/routes/dashboard/users.ts
@@ -99,6 +99,37 @@ dashboardUsersApp.get("/:slackUserId", async (c) => {
   }
 });
 
+const VALID_ROLES = ["owner", "admin", "power_user", "member"] as const;
+
+dashboardUsersApp.patch("/:slackUserId/role", async (c) => {
+  try {
+    const slackUserId = c.req.param("slackUserId");
+    const body = await c.req.json<{ role: string }>();
+
+    if (!VALID_ROLES.includes(body.role as (typeof VALID_ROLES)[number])) {
+      return c.json(
+        { error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}` },
+        400,
+      );
+    }
+
+    const result = await db
+      .update(userProfiles)
+      .set({ role: body.role, updatedAt: new Date() })
+      .where(eq(userProfiles.slackUserId, slackUserId))
+      .returning();
+
+    if (result.length === 0) {
+      return c.json({ error: "User not found" }, 404);
+    }
+
+    return c.json(result[0]);
+  } catch (error) {
+    logger.error("Failed to update user role", { error: String(error) });
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
 dashboardUsersApp.patch("/person/:personId", async (c) => {
   try {
     const personId = c.req.param("personId");

--- a/apps/dashboard/src/app/users/[slackUserId]/user-detail.tsx
+++ b/apps/dashboard/src/app/users/[slackUserId]/user-detail.tsx
@@ -8,7 +8,14 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { updatePerson } from "../actions";
+import { updatePerson, updateUserRole } from "../actions";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ArrowLeft, Save } from "lucide-react";
 import { formatDate, truncate } from "@/lib/utils";
 import type { UserProfile, Person, Memory } from "@schema";
@@ -26,7 +33,23 @@ export function UserDetail({ data }: { data: UserData }) {
   const [preferredLanguage, setPreferredLanguage] = useState(person?.preferredLanguage || "");
   const [gender, setGender] = useState(person?.gender || "");
   const [notes, setNotes] = useState(person?.notes || "");
+  const [role, setRole] = useState(profile.role || "member");
   const [saving, setSaving] = useState(false);
+  const [savingRole, setSavingRole] = useState(false);
+
+  const roleOptions = [
+    { value: "owner", label: "Owner" },
+    { value: "admin", label: "Admin" },
+    { value: "power_user", label: "Power User" },
+    { value: "member", label: "Member" },
+  ] as const;
+
+  async function handleSaveRole() {
+    setSavingRole(true);
+    await updateUserRole(profile.slackUserId, role);
+    setSavingRole(false);
+    router.refresh();
+  }
 
   async function handleSave() {
     if (!person?.id) return;
@@ -86,6 +109,31 @@ export function UserDetail({ data }: { data: UserData }) {
         </TabsList>
 
         <TabsContent value="profile">
+          <Card className="mb-3">
+            <CardContent className="pt-4 space-y-3">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="text-sm font-medium">Role</label>
+                  <Select value={role} onValueChange={setRole}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {roleOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <Button onClick={handleSaveRole} disabled={savingRole} size="sm">
+                <Save className="h-4 w-4" /> {savingRole ? "Saving..." : "Save Role"}
+              </Button>
+            </CardContent>
+          </Card>
+
           {person ? (
             <Card>
               <CardContent className="pt-4 space-y-3">

--- a/apps/dashboard/src/app/users/actions.ts
+++ b/apps/dashboard/src/app/users/actions.ts
@@ -15,6 +15,11 @@ export async function getUser(slackUserId: string) {
   return apiGetOrNull<any>(`/users/${slackUserId}`);
 }
 
+export async function updateUserRole(slackUserId: string, role: string) {
+  await apiPatch(`/users/${slackUserId}/role`, { role });
+  revalidatePath("/users");
+}
+
 export async function updatePerson(
   personId: string,
   data: { jobTitle?: string; preferredLanguage?: string; gender?: string; notes?: string },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Role select dropdown to the dashboard user detail page so admins can update user roles (`owner`, `admin`, `power_user`, `member`) from the UI instead of needing raw SQL.

Closes #793

## Changes

### API (`apps/api/src/routes/dashboard/users.ts`)
- Added `PATCH /:slackUserId/role` endpoint
- Validates role is one of the four allowed values, returns 400 otherwise
- Updates `role` and `updatedAt` on the `user_profiles` table
- Returns the updated profile or 404 if user not found

### Dashboard server action (`apps/dashboard/src/app/users/actions.ts`)
- Added `updateUserRole(slackUserId, role)` server action
- Calls `apiPatch(/users/${slackUserId}/role, { role })` and revalidates `/users`

### Dashboard UI (`apps/dashboard/src/app/users/[slackUserId]/user-detail.tsx`)
- Added `role` state initialized from `profile.role`
- Added a Role card with shadcn/ui `Select` component in the Profile tab (above the Person fields card)
- Options: Owner, Admin, Power User, Member (with nice display labels)
- Separate "Save Role" button since role lives on `user_profiles`, not `people`

## Testing
- `tsc --noEmit` passes on `apps/dashboard` (no new errors)
- `tsc --noEmit` on `apps/api` has 1 pre-existing error in `src/tools/people.ts` (unrelated)
- No new dependencies added
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a862953e-1808-45a2-be9d-4047423f2f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a862953e-1808-45a2-be9d-4047423f2f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

