### PR TITLE
Fix credential detail page crash + replace raw ID input with user picker

### DIFF
--- a/apps/dashboard/src/app/credentials/[id]/credential-detail.tsx
+++ b/apps/dashboard/src/app/credentials/[id]/credential-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -10,31 +10,47 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { Dialog, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import {
   updateCredentialValue,
   grantCredentialAccess,
   revokeCredentialAccess,
   deleteCredential,
 } from "../actions";
-import { ArrowLeft, Trash2, UserPlus } from "lucide-react";
-import { formatDate } from "@/lib/utils";
+import { ArrowLeft, Trash2, UserPlus, Check, ChevronsUpDown } from "lucide-react";
+import { cn, formatDate } from "@/lib/utils";
 import type { Credential, CredentialGrant, CredentialAuditEntry } from "@schema";
+
+interface GrantWithName extends CredentialGrant {
+  granteeName: string | null;
+}
 
 interface CredentialData extends Credential {
   maskedValue: string;
   ownerName: string;
-  grants: CredentialGrant[];
-  granteeNames: Record<string, string>;
+  grants: GrantWithName[];
   auditLog: CredentialAuditEntry[];
 }
 
-export function CredentialDetail({ data }: { data: CredentialData }) {
+export interface WorkspaceUser {
+  slackUserId: string;
+  displayName: string | null;
+}
+
+export function CredentialDetail({ data, users }: { data: CredentialData; users: WorkspaceUser[] }) {
   const router = useRouter();
   const [showUpdateValue, setShowUpdateValue] = useState(false);
   const [newValue, setNewValue] = useState("");
   const [showGrant, setShowGrant] = useState(false);
   const [granteeId, setGranteeId] = useState("");
   const [permission, setPermission] = useState("read");
+  const [userPickerOpen, setUserPickerOpen] = useState(false);
+
+  const selectedUser = useMemo(
+    () => users.find((u) => u.slackUserId === granteeId),
+    [users, granteeId],
+  );
 
   async function handleUpdateValue() {
     if (!newValue) return;
@@ -126,7 +142,7 @@ export function CredentialDetail({ data }: { data: CredentialData }) {
               <TableBody>
                 {data.grants.map((g) => (
                   <TableRow key={g.id}>
-                    <TableCell className="font-medium">{data.granteeNames[g.granteeId] || g.granteeId}</TableCell>
+                    <TableCell className="font-medium">{g.granteeName || g.granteeId}</TableCell>
                     <TableCell><Badge variant="outline">{g.permission}</Badge></TableCell>
                     <TableCell className="text-sm">{g.grantedBy}</TableCell>
                     <TableCell className="text-sm text-muted-foreground">{formatDate(g.grantedAt)}</TableCell>
@@ -203,7 +219,50 @@ export function CredentialDetail({ data }: { data: CredentialData }) {
           <DialogTitle>Grant Access</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
-          <Input placeholder="Grantee Slack User ID" value={granteeId} onChange={(e) => setGranteeId(e.target.value)} />
+          <Popover open={userPickerOpen} onOpenChange={setUserPickerOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={userPickerOpen}
+                className="w-full justify-between font-normal"
+              >
+                {selectedUser
+                  ? selectedUser.displayName || selectedUser.slackUserId
+                  : "Select a user…"}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search users…" />
+                <CommandList>
+                  <CommandEmpty>No users found.</CommandEmpty>
+                  <CommandGroup>
+                    {users.map((user) => (
+                      <CommandItem
+                        key={user.slackUserId}
+                        value={`${user.displayName ?? ""} ${user.slackUserId}`}
+                        onSelect={() => {
+                          setGranteeId(user.slackUserId);
+                          setUserPickerOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            granteeId === user.slackUserId ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span>{user.displayName || user.slackUserId}</span>
+                        <span className="ml-auto text-xs text-muted-foreground">{user.slackUserId}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
           <select
             value={permission}
             onChange={(e) => setPermission(e.target.value)}

--- a/apps/dashboard/src/app/credentials/[id]/page.tsx
+++ b/apps/dashboard/src/app/credentials/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getCredential } from "../actions";
+import { getUsers } from "../../users/actions";
 import { notFound } from "next/navigation";
 import { CredentialDetail } from "./credential-detail";
 
@@ -6,12 +7,20 @@ export const dynamic = "force-dynamic";
 
 export default async function CredentialDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const data = await getCredential(id);
+  const [data, usersResult] = await Promise.all([
+    getCredential(id),
+    getUsers(undefined, 1, 100),
+  ]);
   if (!data) return notFound();
+
+  const users = usersResult.items.map((u: { slackUserId: string; displayName: string | null }) => ({
+    slackUserId: u.slackUserId,
+    displayName: u.displayName,
+  }));
 
   return (
     <div className="space-y-4">
-      <CredentialDetail data={data} />
+      <CredentialDetail data={data} users={users} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #797

### Bug fix: TypeError crash on credential detail page

The `CredentialDetail` client component expected a top-level `granteeNames: Record<string, string>` map on the API response, but the API (`/api/dashboard/credentials/:id`) returns `granteeName` as a field on each grant object. This caused `data.granteeNames` to be `undefined`, and accessing `undefined['U0678NQJ2']` threw a `TypeError`.

**Changes:**
- Removed the `granteeNames` field from the `CredentialData` interface
- Added a `GrantWithName` interface that extends `CredentialGrant` with the `granteeName` field returned by the API
- Changed the grantee name display from `data.granteeNames[g.granteeId]` to `g.granteeName || g.granteeId`

### UX improvement: User picker dropdown replaces raw Slack user ID input

The "Grant Access" dialog previously required users to manually type a raw Slack user ID (e.g., `U0678NQJ2`). This has been replaced with a searchable combobox dropdown that lists workspace users by display name.

**Changes:**
- Added a `Popover` + `Command` (cmdk) based user picker combobox to the Grant Access dialog
- The page now fetches the user list via the existing `/api/dashboard/users` endpoint in parallel with the credential data
- Users can search by display name or Slack user ID
- Each option shows the display name with the Slack user ID as a secondary label

### Files changed
- `apps/dashboard/src/app/credentials/[id]/credential-detail.tsx` — fixed crash, replaced input with user picker
- `apps/dashboard/src/app/credentials/[id]/page.tsx` — fetches users list and passes to component

### Verification
- `npx tsc --noEmit` passes with no errors in `apps/dashboard`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50194ccf-40dd-4cb6-adaf-912b79fb445b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50194ccf-40dd-4cb6-adaf-912b79fb445b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

