### PR TITLE
docs: add permissions page, update stale admin references

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -95,7 +95,7 @@ Configure instance behavior:
 
 ## Access & Authentication
 
-The dashboard uses Slack OAuth for login. Only users listed in `AURA_ADMIN_USER_IDS` can access it.
+The dashboard uses Slack OAuth for login. Access requires an `admin` or `owner` role (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var serves as a fallback for users without a database role.
 
 ### Auth Proxy
 

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -25,7 +25,7 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 |----------|-------------|
 | `SLACK_USER_TOKEN` | Slack user token (`xoxp-...`) for message search |
 | `GITHUB_TOKEN` | GitHub PAT for reading source code and opening PRs |
-| `AURA_ADMIN_USER_IDS` | Comma-separated Slack user IDs with admin access |
+| `AURA_ADMIN_USER_IDS` | Comma-separated Slack user IDs with admin access. Fallback for users without a DB role — see [Permissions](/permissions) |
 | `E2B_API_KEY` | E2B API key for sandbox access |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings and audio transcription |
 | `AURA_BOT_USER_ID` | Aura's own Slack bot user ID |

--- a/content/docs/docs.json
+++ b/content/docs/docs.json
@@ -54,7 +54,8 @@
             "group": "Core Systems",
             "pages": [
               "memory-system",
-              "self-improvement"
+              "self-improvement",
+              "permissions"
             ]
           },
           {

--- a/content/docs/permissions.mdx
+++ b/content/docs/permissions.mdx
@@ -1,0 +1,100 @@
+---
+title: "Permissions"
+description: "Role-based access control: user roles, tool permissions, note scoping, and rate limits."
+---
+
+# Permissions
+
+Aura uses a four-tier role system to control access to tools, notes, and resources. Roles are stored in the database (`user_profiles.role`) with an env var fallback for backwards compatibility.
+
+## Roles
+
+| Role | Level | Description |
+|------|-------|-------------|
+| `member` | 0 | Default role. Can chat with Aura, use basic tools, see shared notes. |
+| `power_user` | 1 | Extended access: sandbox, browser, voice, Cursor agents, subagents. |
+| `admin` | 2 | Full access: cross-user email/Slack, system note editing, job management. |
+| `owner` | 3 | Everything. Reserved for workspace owners. |
+
+Roles are hierarchical — a user with `admin` automatically has all `power_user` and `member` permissions.
+
+## How Roles Are Checked
+
+The `hasRole(userId, minimumRole)` function in `apps/api/src/lib/permissions.ts` is the single source of truth:
+
+1. Look up `user_profiles.role` in the database
+2. If a DB role exists, compare it against the minimum required role and return the result
+3. If no DB profile exists (or query fails), fall back to `AURA_ADMIN_USER_IDS` env var — users listed there get `admin`-level access
+4. The system user `aura` always passes all role checks
+
+<Warning>
+If a user has an explicit role in the database, the env var is **not** consulted. A user demoted to `member` in the DB won't regain admin via the env var. This is intentional — the DB is authoritative once set.
+</Warning>
+
+## Tool Permissions
+
+Each tool category requires a minimum role:
+
+| Tool | Minimum Role |
+|------|-------------|
+| Sandbox (shell commands) | `power_user` |
+| Browser | `power_user` |
+| Cursor Agent | `power_user` |
+| Subagents | `power_user` |
+| Voice | `power_user` |
+| Cross-user email access | `admin` |
+| Cross-user Slack actions | `admin` |
+| Headless job dispatch | `admin` |
+| Job limit bypass | `admin` |
+| System note editing | `admin` |
+
+Members can still use Slack messaging, notes (their own + shared), web search, and basic tools.
+
+## Note Scoping
+
+Notes have `owner_id` and `visibility` fields:
+
+- **`shared`** — Visible to all users (default for user-created notes)
+- **`system`** — Protected notes like `self-directive`, `business-map`, `gaps-log`, and all skill notes. Only admins can create, edit, or delete these.
+- **Private notes** — Scoped by `owner_id`. Users see shared notes, system notes, and their own private notes.
+
+System topics (`self-directive`, `business-map`, `gaps-log`) are always protected regardless of their visibility column value.
+
+## Rate Limits
+
+Default rate limits are seeded per role:
+
+| Resource | Member | Power User | Admin |
+|----------|--------|------------|-------|
+| Active jobs | 5 | 20 | 100 |
+| Notes | 20 | 50 | 200 |
+| Sandbox calls/day | 0 | 50 | 200 |
+| Cursor agents/day | 0 | 3 | 10 |
+| Subagent calls/day | 0 | 10 | 50 |
+
+Rate limits are stored in the `rate_limits` table and are workspace-scoped, so different workspaces can have different limits.
+
+<Note>
+Owners have no seeded rate limits — they're unlimited by default.
+</Note>
+
+## Managing Roles
+
+Roles can be set in two ways:
+
+1. **Dashboard** — Navigate to Users → select a user → Profile tab → Role dropdown. Requires admin access.
+2. **Database** — Update `user_profiles.role` directly.
+
+## Migration from `AURA_ADMIN_USER_IDS`
+
+The env var still works as a fallback for users without a DB profile. For new deployments, set roles via the dashboard instead. The env var will be deprecated in a future release.
+
+## Database Schema
+
+The permission system adds these tables:
+
+- **`user_profiles.role`** — `text NOT NULL DEFAULT 'member'` on the existing user profiles table
+- **`tool_definitions`** — Per-tool minimum role configuration (workspace-scoped)
+- **`tool_credential_slots`** — Credential requirements per tool
+- **`rate_limits`** — Per-role resource limits (workspace-scoped, unique on `workspace_id + role + resource`)
+- **`notes.owner_id`** / **`notes.visibility`** — User scoping for notes

--- a/content/docs/self-improvement.mdx
+++ b/content/docs/self-improvement.mdx
@@ -71,7 +71,7 @@ Examples of self-identified and self-fixed issues:
 - All code changes go through pull requests
 - PRs require human approval before merging
 - Self-edits to the system prompt are flagged explicitly in the PR
-- The `AURA_ADMIN_USER_IDS` setting controls who can approve changes
+- User roles control who can approve changes (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var is a fallback
 - Vercel auto-deploys from `main`, so merging = deploying
 
 ## The Compounding Effect


### PR DESCRIPTION
## What

New documentation page for the multi-tier permission system introduced in #787.

### Changes

- **New page**: `content/docs/permissions.mdx` — covers roles (member/power_user/admin/owner), tool permissions, note scoping, rate limits, and migration from `AURA_ADMIN_USER_IDS`
- **Nav**: Added to Core Systems group in `docs.json`
- **dashboard.mdx**: Updated access section to reference the role system instead of env-var-only
- **environment-variables.mdx**: Noted `AURA_ADMIN_USER_IDS` is now a fallback
- **self-improvement.mdx**: Updated admin reference to link to permissions page

### Why

PR #787 landed a full role-based permission system but had zero documentation coverage. Three existing pages still described the old binary admin model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify role-based access control and the `AURA_ADMIN_USER_IDS` fallback; no runtime behavior is modified.
> 
> **Overview**
> Adds a new **`Permissions`** documentation page describing the role hierarchy (`member`→`owner`), how roles are evaluated (DB role with `AURA_ADMIN_USER_IDS` fallback), and the resulting tool/note/rate-limit rules.
> 
> Updates existing docs to replace the old env-var-only admin model with role-based wording (dashboard access, self-improvement approvals) and clarifies in environment variable docs that `AURA_ADMIN_USER_IDS` is now a fallback. The new page is added to the docs navigation under *Core Systems*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5688918ce42f724c611f296bcd4ce9878e1f34f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->