### PR TITLE
feat: per-user persistent home folders via GCS mount

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -24,6 +24,7 @@ export function clearCachedSandbox(): void {
     });
     cachedSandbox = null;
   }
+  userHomeReady.clear();
 }
 
 /**
@@ -163,6 +164,67 @@ async function setupSandboxFilesystem(
 }
 
 /**
+ * Ensure per-user persistent home directory exists on the GCS mount.
+ * Creates directory structure and symlinks on first call per user per session.
+ * Falls back gracefully if GCS mount is unavailable.
+ */
+const userHomeReady = new Set<string>();
+
+export async function ensureUserHome(
+  sandbox: any,
+  userId: string,
+  envs: Record<string, string>,
+): Promise<string> {
+  const fallback = "/home/user";
+  if (!userId || userId === "aura") return fallback;
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(userId)) {
+    logger.warn("Invalid userId rejected by ensureUserHome", { userId });
+    return fallback;
+  }
+
+  if (userHomeReady.has(userId)) {
+    return `/mnt/aura-files/users/${userId}`;
+  }
+
+  try {
+    const mountCheck = await sandbox.commands.run(
+      "mountpoint -q /mnt/aura-files && echo mounted || echo not",
+      { timeoutMs: 5_000, envs },
+    );
+    if (mountCheck.stdout?.trim() !== "mounted") {
+      logger.info("GCS not mounted, falling back to /home/user", { userId });
+      return fallback;
+    }
+
+    const userHome = `/mnt/aura-files/users/${userId}`;
+
+    const mkdirResult = await sandbox.commands.run(
+      `mkdir -p "${userHome}"/{downloads,repos,projects}`,
+      { timeoutMs: 10_000, envs },
+    );
+    if (mkdirResult.exitCode !== 0) {
+      logger.warn("Failed to create per-user home directories", {
+        userId,
+        exitCode: mkdirResult.exitCode,
+        stderr: mkdirResult.stderr,
+      });
+      return fallback;
+    }
+
+    userHomeReady.add(userId);
+    logger.info("Per-user home ready", { userId, userHome });
+    return userHome;
+  } catch (error: any) {
+    logger.warn("Failed to set up per-user home, using fallback", {
+      userId,
+      error: error.message,
+    });
+    return fallback;
+  }
+}
+
+/**
  * Get or create a sandbox. Tries to resume a previously paused sandbox,
  * creates a new one if none exists or resume fails.
  */
@@ -175,6 +237,7 @@ export async function getOrCreateSandbox(): Promise<any> {
       return cachedSandbox;
     } catch {
       cachedSandbox = null;
+      userHomeReady.clear();
     }
   }
 
@@ -295,6 +358,7 @@ export async function pauseSandbox(): Promise<void> {
     throw error;
   } finally {
     cachedSandbox = null;
+    userHomeReady.clear();
   }
 }
 
@@ -307,9 +371,17 @@ export async function writeToSandbox(
   filename: string,
   data: Buffer,
   subdir: string = "downloads",
+  userId?: string,
 ): Promise<string> {
   const sandbox = await getOrCreateSandbox();
-  const dir = `/home/user/${subdir}`;
+
+  let base = "/home/user";
+  if (userId) {
+    const envs = await getSandboxEnvs();
+    base = await ensureUserHome(sandbox, userId, envs);
+  }
+
+  const dir = `${base}/${subdir}`;
   await sandbox.commands.run(`mkdir -p "${dir}"`, { timeoutMs: 5_000 });
   const safeName = nodePath.basename(filename);
   const path = `${dir}/${safeName}`;

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -4,6 +4,7 @@ import {
   getSandboxEnvs,
   truncateOutput,
   clearCachedSandbox,
+  ensureUserHome,
 } from "../lib/sandbox.js";
 import { hasRole } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
@@ -62,15 +63,18 @@ export function createSandboxTools(context?: ScheduleContext) {
           const sandbox = await getOrCreateSandbox();
           const envs = await getSandboxEnvs();
 
+          const userId = context?.userId || "aura";
+          const userHome = await ensureUserHome(sandbox, userId, envs);
+
           logger.info("run_command tool: executing", {
             command: command.substring(0, 100),
             workdir,
           });
 
           const result = await sandbox.commands.run(command, {
-            cwd: workdir || "/home/user",
+            cwd: workdir || userHome,
             timeoutMs: timeout_seconds * 1000,
-            envs,
+            envs: { ...envs, USER_HOME: userHome, PERSISTENT_HOME: userHome },
           });
 
           const stdout = truncateOutput(result.stdout || "", 4000);


### PR DESCRIPTION
## Summary

Cherry-pick of #791 which was merged into the feature branch after it had already landed on `main`, so the code never reached production.

- Adds `ensureUserHome()` to `sandbox.ts`: creates per-user directories at `/mnt/aura-files/users/{userId}` with `downloads/`, `repos/`, `projects/` subdirectories
- Falls back gracefully to `/home/user` when GCS mount is unavailable
- Updates `run_command` tool to call `ensureUserHome()` before execution, setting per-user workdir and injecting `USER_HOME`/`PERSISTENT_HOME` env vars
- Updates `writeToSandbox()` to accept optional `userId` for persistent storage
- Input sanitization: rejects userId with non-alphanumeric characters (except `-` and `_`)
- Per-invocation caching via `userHomeReady` Set, cleared on sandbox recreation/pause

Closes #790

## Prerequisites

- [x] gcsfuse installed in template (PR #799)
- [ ] `GOOGLE_SA_KEY_B64` must be added to Vercel env vars for GCS mount to work
- [ ] Old sandbox needs to be recycled to pick up new template

## Test plan

- [ ] Verify `ensureUserHome()` creates per-user dirs when GCS is mounted
- [ ] Verify fallback to `/home/user` when GCS is unavailable
- [ ] Verify `userHomeReady` cache clears on sandbox recreation

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default sandbox working directory and file-write locations to be user-specific, which could impact existing workflows and persistence behavior when the GCS mount is missing or misconfigured.
> 
> **Overview**
> Adds `ensureUserHome()` to create and reuse per-user directories under the GCS mount (`/mnt/aura-files/users/<userId>`) with a safe fallback to `/home/user` when the mount isn’t available.
> 
> Updates `run_command` to default `cwd` to the resolved per-user home and inject `USER_HOME`/`PERSISTENT_HOME` env vars, and updates `writeToSandbox()` to optionally write into the user’s persistent home. Clears the per-user home readiness cache whenever the sandbox is cleared, recreated, or paused.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a8f05663f01830165364df3107ba4b02312f3e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->