### PR TITLE
chore: bump sandbox to 4 CPU / 4GB RAM

### DIFF
--- a/sandbox/build.ts
+++ b/sandbox/build.ts
@@ -27,8 +27,8 @@ async function main() {
   console.log("This will take 5-10 minutes...\n");
 
   const result = await Template.build(template, tag, {
-    cpuCount: 2,
-    memoryMB: 2048,
+    cpuCount: 4,
+    memoryMB: 4096,
     onBuildLogs: defaultBuildLogger(),
   });
 


### PR DESCRIPTION
## Summary

Bumps the E2B sandbox template from 2 CPU / 2GB to 4 CPU / 4GB.

- TypeScript compilation (`tsc`) was hitting OOM on the 2GB sandbox
- 4 CPU helps with concurrent users sharing the same VM

One-line change in `sandbox/build.ts`. CI will automatically rebuild the template on merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to sandbox build configuration, though it may increase template build/runtime resource usage and cost.
> 
> **Overview**
> Updates `sandbox/build.ts` to build the E2B sandbox template with **4 vCPUs** and **4096MB RAM** (up from 2 vCPUs/2048MB), improving headroom for TypeScript compilation and heavier concurrent workloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257ff0399923364254b925778c1e5046c01fd9fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->