### PR TITLE
fix: gcsfuse mount ownership and inject SLACK_USER_ID into sandbox

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -147,7 +147,7 @@ async function setupSandboxFilesystem(
     }
 
     const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=$(id -u) --gid=$(id -g) -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
       { timeoutMs: 30_000, envs },
     );
     if (mountResult.exitCode !== 0) {

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -74,7 +74,7 @@ export function createSandboxTools(context?: ScheduleContext) {
           const result = await sandbox.commands.run(command, {
             cwd: workdir || userHome,
             timeoutMs: timeout_seconds * 1000,
-            envs: { ...envs, USER_HOME: userHome, PERSISTENT_HOME: userHome },
+            envs: { ...envs, USER_HOME: userHome, PERSISTENT_HOME: userHome, SLACK_USER_ID: userId },
           });
 
           const stdout = truncateOutput(result.stdout || "", 4000);


### PR DESCRIPTION
## Summary

These fixes were in #802 but got dropped during merge.

- **gcsfuse mount ownership**: Add `--uid=$(id -u) --gid=$(id -g) -o allow_other` so the mount is owned by sandbox user, not root. Without this, writes require sudo.
- **SLACK_USER_ID**: Inject into sandbox env vars so Aura knows who's talking. Needed for per-user home directory creation.

## Test plan

- [ ] `touch /mnt/aura-files/test` works without sudo
- [ ] `echo $SLACK_USER_ID` returns the caller's Slack user ID

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the shared GCS bucket is mounted and adjusts environment variables passed to all sandbox commands, which can affect filesystem permissions and downstream tooling behavior.
> 
> **Overview**
> Fixes sandbox GCS mounting so `/mnt/aura-files` is mounted with the sandbox user’s ownership by adding `--uid/--gid` and `-o allow_other` to the `gcsfuse` invocation, avoiding root-owned mounts that require `sudo` for writes.
> 
> Also injects `SLACK_USER_ID` into the `run_command` tool’s per-command environment, enabling downstream sandbox processes to identify the calling Slack user.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24f7b50c38541c36acaae67049d5c3df44b31802. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->