### PR TITLE
fix: remove -o allow_other from gcsfuse mount (breaks non-root FUSE)

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -147,7 +147,7 @@ async function setupSandboxFilesystem(
     }
 
     const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=$(id -u) --gid=$(id -g) -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=$(id -u) --gid=$(id -g) aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
       { timeoutMs: 30_000, envs },
     );
     if (mountResult.exitCode !== 0) {


### PR DESCRIPTION
## Summary

The bugbot autofix in #804 re-added `-o allow_other` after the cursor bot correctly removed it. This flag requires `user_allow_other` in `/etc/fuse.conf`, which the sandbox image doesn't configure. `fusermount3` rejects the mount entirely, causing `setupSandboxFilesystem` to fail silently — which is why the GCS mount never works at startup despite gcsfuse, the SA key, and the directory all being present.

Removes `-o allow_other`. `--uid` and `--gid` alone handle file ownership correctly.

## Test plan

- [ ] After merge + sandbox reset, verify `/mnt/aura-files` is mounted automatically at startup
- [ ] Verify regular user can read AND write (no sudo needed)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d142c167caa015f250a56d928f25659f32079b7c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->