### PR TITLE
fix: use literal uid/gid 1000 in gcsfuse mount

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -147,7 +147,7 @@ async function setupSandboxFilesystem(
     }
 
     const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=$(id -u) --gid=$(id -g) aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
       { timeoutMs: 30_000, envs },
     );
     if (mountResult.exitCode !== 0) {


### PR DESCRIPTION
## Summary

`sandbox.commands.run()` executes as root (uid 0), so `$(id -u)` in the gcsfuse mount command evaluates to `0`, making all files root-owned. The sandbox user (uid 1000) can read but not write.

Replaces `--uid=$(id -u) --gid=$(id -g)` with `--uid=1000 --gid=1000`.

## Test plan

- [ ] After merge + sandbox reset, `/mnt/aura-files` auto-mounts at startup
- [ ] `touch /mnt/aura-files/test` works without sudo

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to the gcsfuse mount command that only affects file ownership/permissions on the mounted GCS filesystem.
> 
> **Overview**
> Fixes ownership of files in the sandbox-mounted GCS bucket by changing the `gcsfuse` mount options from dynamic `$(id -u)`/`$(id -g)` to literal `--uid=1000 --gid=1000`, ensuring the non-root sandbox user can write to `/mnt/aura-files`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d5b14780da89c68105d4633508e8e2b298d7b62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->