### PR TITLE
fix: chown /mnt/aura-files after mkdir so gcsfuse can mount

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -147,7 +147,7 @@ async function setupSandboxFilesystem(
     }
 
     const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
       { timeoutMs: 30_000, envs },
     );
     if (mountResult.exitCode !== 0) {


### PR DESCRIPTION
## Summary

Root cause of the persistent gcsfuse mount failure: `sudo mkdir -p /mnt/aura-files` creates the directory owned by root, but `gcsfuse` runs as uid 1000. `fusermount3` needs write access to the mount point to set up the FUSE mount — it fails with "permission denied" on a root-owned directory.

Adds `sudo chown 1000:1000 /mnt/aura-files` between mkdir and gcsfuse.

Aura confirmed this is the exact fix by reproducing manually in the sandbox.

No Dockerfile/template change — code only, deploys immediately on merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the sandbox GCS mount command that only adjusts mountpoint ownership to avoid permission errors; no API surface or data-handling logic changes.
> 
> **Overview**
> Fixes persistent `gcsfuse` mount failures in the sandbox by ensuring `/mnt/aura-files` is owned by uid/gid `1000:1000` after `mkdir` and before running `gcsfuse`.
> 
> This adds `sudo chown 1000:1000 /mnt/aura-files` to the mount command so the non-root `gcsfuse` process can mount successfully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92a2f9b653863901ed629d1b2990866dd54055b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->