### PR TITLE
fix: run gcsfuse with sudo (/dev/fuse is 600 root-only)

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -147,7 +147,7 @@ async function setupSandboxFilesystem(
     }
 
     const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && sudo gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
       { timeoutMs: 30_000, envs },
     );
     if (mountResult.exitCode !== 0) {


### PR DESCRIPTION
## Summary

`/dev/fuse` has permissions `600` (owner: root only). `gcsfuse` running as uid 1000 can't open it — `fusermount3` fails with "Permission denied" before it even gets to the mount.

Adds `sudo` before `gcsfuse`. The `--uid=1000 --gid=1000 -o allow_other` flags still make files appear as the sandbox user, so no sudo needed for reads/writes after mounting.

This is the actual root cause Aura found by tracing the exact error. The `chown` fix in #808 was necessary but not sufficient — the mount process itself needs root to access `/dev/fuse`.

Code only, no template rebuild. Deploys on merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sandbox GCS mount step to invoke `gcsfuse` as root, which affects filesystem mounting behavior and increases reliance on privileged execution if misconfigured.
> 
> **Overview**
> Fixes sandbox GCS bucket mounting by running `gcsfuse` under `sudo` in `setupSandboxFilesystem`, addressing failures when `/dev/fuse` is root-only.
> 
> Mount ownership/visibility remains mapped to uid/gid `1000` via existing flags, so post-mount file access behavior for the sandbox user should be unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a4e8550aae58e529a542657f6ba43314772a46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->