### PR TITLE
fix: dashboard role dropdown 500 error (#811)

### DIFF
--- a/apps/api/src/routes/dashboard/users.ts
+++ b/apps/api/src/routes/dashboard/users.ts
@@ -23,6 +23,7 @@ dashboardUsersApp.get("/", async (c) => {
           id: userProfiles.id,
           slackUserId: userProfiles.slackUserId,
           displayName: userProfiles.displayName,
+          role: userProfiles.role,
           interactionCount: userProfiles.interactionCount,
           lastInteractionAt: userProfiles.lastInteractionAt,
           createdAt: userProfiles.createdAt,
@@ -43,7 +44,7 @@ dashboardUsersApp.get("/", async (c) => {
 
     return c.json({ items, total: countResult[0]?.count ?? 0 });
   } catch (error) {
-    logger.error("Failed to list users", { error: String(error) });
+    logger.error("Failed to list users", { error: error instanceof Error ? error.stack : String(error) });
     return c.json({ error: "Internal server error" }, 500);
   }
 });
@@ -94,7 +95,7 @@ dashboardUsersApp.get("/:slackUserId", async (c) => {
 
     return c.json({ profile, person, memories: userMemories });
   } catch (error) {
-    logger.error("Failed to get user detail", { error: String(error) });
+    logger.error("Failed to get user detail", { error: error instanceof Error ? error.stack : String(error) });
     return c.json({ error: "Internal server error" }, 500);
   }
 });
@@ -104,9 +105,15 @@ const VALID_ROLES = ["owner", "admin", "power_user", "member"] as const;
 dashboardUsersApp.patch("/:slackUserId/role", async (c) => {
   try {
     const slackUserId = c.req.param("slackUserId");
-    const body = await c.req.json<{ role: string }>();
 
-    if (!VALID_ROLES.includes(body.role as (typeof VALID_ROLES)[number])) {
+    let body: { role: string };
+    try {
+      body = await c.req.json<{ role: string }>();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    if (!body.role || !VALID_ROLES.includes(body.role as (typeof VALID_ROLES)[number])) {
       return c.json(
         { error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}` },
         400,
@@ -125,7 +132,10 @@ dashboardUsersApp.patch("/:slackUserId/role", async (c) => {
 
     return c.json(result[0]);
   } catch (error) {
-    logger.error("Failed to update user role", { error: String(error) });
+    logger.error("Failed to update user role", {
+      error: error instanceof Error ? error.stack : String(error),
+      slackUserId: c.req.param("slackUserId"),
+    });
     return c.json({ error: "Internal server error" }, 500);
   }
 });
@@ -158,7 +168,7 @@ dashboardUsersApp.patch("/person/:personId", async (c) => {
 
     return c.json(result[0]);
   } catch (error) {
-    logger.error("Failed to update person", { error: String(error) });
+    logger.error("Failed to update person", { error: error instanceof Error ? error.stack : String(error) });
     return c.json({ error: "Internal server error" }, 500);
   }
 });

--- a/apps/dashboard/src/app/users/[slackUserId]/user-detail.tsx
+++ b/apps/dashboard/src/app/users/[slackUserId]/user-detail.tsx
@@ -36,6 +36,7 @@ export function UserDetail({ data }: { data: UserData }) {
   const [role, setRole] = useState(profile.role || "member");
   const [saving, setSaving] = useState(false);
   const [savingRole, setSavingRole] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const roleOptions = [
     { value: "owner", label: "Owner" },
@@ -46,16 +47,26 @@ export function UserDetail({ data }: { data: UserData }) {
 
   async function handleSaveRole() {
     setSavingRole(true);
-    await updateUserRole(profile.slackUserId, role);
+    setError(null);
+    const result = await updateUserRole(profile.slackUserId, role);
     setSavingRole(false);
+    if (!result.ok) {
+      setError(result.error ?? "Failed to update role");
+      return;
+    }
     router.refresh();
   }
 
   async function handleSave() {
     if (!person?.id) return;
     setSaving(true);
-    await updatePerson(person.id, { jobTitle, preferredLanguage, gender, notes });
+    setError(null);
+    const result = await updatePerson(person.id, { jobTitle, preferredLanguage, gender, notes });
     setSaving(false);
+    if (!result.ok) {
+      setError(result.error ?? "Failed to update person");
+      return;
+    }
     router.refresh();
   }
 
@@ -101,6 +112,14 @@ export function UserDetail({ data }: { data: UserData }) {
           </CardContent>
         </Card>
       </div>
+
+      {error && (
+        <Card className="border-destructive bg-destructive/10">
+          <CardContent className="py-3">
+            <p className="text-sm text-destructive">{error}</p>
+          </CardContent>
+        </Card>
+      )}
 
       <Tabs defaultValue="profile">
         <TabsList>

--- a/apps/dashboard/src/app/users/actions.ts
+++ b/apps/dashboard/src/app/users/actions.ts
@@ -15,15 +15,32 @@ export async function getUser(slackUserId: string) {
   return apiGetOrNull<any>(`/users/${slackUserId}`);
 }
 
-export async function updateUserRole(slackUserId: string, role: string) {
-  await apiPatch(`/users/${slackUserId}/role`, { role });
-  revalidatePath("/users");
+export async function updateUserRole(
+  slackUserId: string,
+  role: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await apiPatch(`/users/${slackUserId}/role`, { role });
+    revalidatePath("/users");
+    return { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("updateUserRole failed:", message);
+    return { ok: false, error: message };
+  }
 }
 
 export async function updatePerson(
   personId: string,
   data: { jobTitle?: string; preferredLanguage?: string; gender?: string; notes?: string },
-) {
-  await apiPatch(`/users/person/${personId}`, data);
-  revalidatePath("/users");
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await apiPatch(`/users/person/${personId}`, data);
+    revalidatePath("/users");
+    return { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("updatePerson failed:", message);
+    return { ok: false, error: message };
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The dashboard role dropdown at `/users/[slackUserId]` returned a 500 error when changing a user's role. Multiple issues contributed:

1. **Server action threw on error** — `updateUserRole()` called `apiPatch()` which throws on non-200 responses. The uncaught throw in a Next.js server action surfaced as an opaque 500 to the browser.
2. **No error handling in frontend** — `handleSaveRole()` had no try-catch, so errors left the button stuck on "Saving..." with no user feedback.
3. **Missing `role` in list endpoint** — The `GET /users` SELECT query omitted the `role` field, so the list page couldn't display roles.
4. **Poor error logging** — Backend used `String(error)` which lost stack traces, making debugging difficult.

## Changes

### `apps/api/src/routes/dashboard/users.ts`
- Added `role: userProfiles.role` to the GET `/users` list query
- Wrapped PATCH body parsing in try-catch to return 400 on malformed JSON
- Added null check for `body.role` before validation
- Improved all error logging to use `error.stack` instead of `String(error)`
- Added `slackUserId` to PATCH error context for debugging

### `apps/dashboard/src/app/users/actions.ts`
- Changed `updateUserRole()` and `updatePerson()` to return `{ ok, error? }` instead of throwing
- Errors are caught and returned as structured responses, preventing Next.js from converting them to 500s

### `apps/dashboard/src/app/users/[slackUserId]/user-detail.tsx`
- Added error state and UI display (red card with error message)
- `handleSaveRole()` and `handleSave()` now check the result and show errors
- Errors clear when a new save is attempted

## Testing

- `npx tsc --noEmit` passes for both `apps/dashboard` and `apps/api` (pre-existing error in `people.ts` is unrelated)

Closes #811
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab86ae7c-8b22-4cea-9a52-0a2542f70087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab86ae7c-8b22-4cea-9a52-0a2542f70087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

