### PR TITLE
docs: add script execution, persistent storage, OpenAPI spec

### DIFF
--- a/content/docs/api-reference/overview.mdx
+++ b/content/docs/api-reference/overview.mdx
@@ -67,3 +67,13 @@ The admin dashboard (`apps/dashboard`) has its own API routes for authentication
 - `GET /api/auth/login` — Initiate OAuth login
 - `GET /api/auth/callback` — OAuth callback handler
 - `POST /api/auth/logout` — End session
+
+All dashboard data routes are served by an OpenAPIHono app with full Zod schema validation. The API spec is available at:
+
+### `GET /api/dashboard/openapi.json`
+
+Returns the full OpenAPI 3.1 specification for all dashboard API routes. Useful for generating client SDKs, testing with tools like Swagger UI, or validating request/response shapes.
+
+**Auth:** Dashboard session cookie.
+
+The spec covers 14 route groups: auth, chat, stats, notes, memories, users, conversations, errors, jobs, credentials, resources, consumption, settings, and models.

--- a/content/docs/tools/jobs.mdx
+++ b/content/docs/tools/jobs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jobs & Scheduling Tools"
-description: "One-shot reminders, recurring cron jobs, headless execution, and background tasks — 6 tools."
+description: "One-shot reminders, recurring cron jobs, script execution, headless dispatch, and background tasks — 6 tools."
 ---
 
 # Jobs & Scheduling Tools
@@ -30,6 +30,21 @@ Create a one-shot task, recurring job, or follow-up.
 | `priority` | enum | no | `high`, `normal` (default), or `low` |
 | `max_per_day` | number | no | Max executions per day (recurring jobs) |
 | `min_interval_hours` | number | no | Minimum hours between executions |
+| `script` | string | no | Shell command to run before/instead of LLM. See [execution modes](#execution-modes) below. |
+
+---
+
+## Execution modes
+
+Jobs support three execution modes depending on which fields are set:
+
+| Mode | Fields | Behavior | LLM cost |
+|------|--------|----------|----------|
+| **Playbook-only** | `playbook` set, no `script` | LLM executes the playbook with full tool access | Normal |
+| **Script-only** | `script` set, no `playbook` | Script runs in E2B sandbox, output posted directly | Zero |
+| **Hybrid** | Both `script` and `playbook` | Script runs first, output injected as context into a smaller LLM prompt | Reduced |
+
+Script-only mode is ideal for jobs that just need to run a command and post the result (e.g. `git log`, database queries, health checks). Hybrid mode lets a script gather data cheaply, then uses the LLM only for summarization or decision-making.
 
 ---
 
@@ -73,6 +88,7 @@ Update an existing job's configuration without recreating it. Preserves job ID a
 | `updates.enabled` | boolean | no | Re-enable a disabled job by setting to `true` |
 | `updates.max_per_day` | number | no | New max executions per day |
 | `updates.min_interval_hours` | number | no | New minimum hours between executions |
+| `updates.script` | string/null | no | New shell command. Set to `null` to remove an existing script. |
 
 When a cron schedule or timezone is updated, the next execution time is automatically recalculated. Setting `enabled: true` on a cancelled recurring job re-enables it with a fresh next execution time.
 

--- a/content/docs/tools/sandbox.mdx
+++ b/content/docs/tools/sandbox.mdx
@@ -57,6 +57,23 @@ Common paths:
 
 ---
 
+## Persistent storage
+
+Each user gets a persistent home directory backed by Google Cloud Storage (GCS) via gcsfuse. Files written to `/mnt/aura-files/<user_id>/` survive across sandbox sessions — unlike `/home/user/`, which resets when the sandbox pauses.
+
+Use persistent storage for:
+- Long-running work that spans multiple conversations (large datasets, intermediate results)
+- SQLite databases for complex analysis
+- Downloaded files you need to reference later
+
+The mount is set up automatically when `run_command` executes. If the mount isn't available (e.g. GCS credentials not configured), Aura falls back to `/home/user/` with a warning.
+
+Common persistent paths:
+- `/mnt/aura-files/<user_id>/` — per-user persistent root
+- `/mnt/aura-files/<user_id>/downloads/` — persistent downloads
+
+---
+
 ## Isolation model
 
 The sandbox is isolated from the Vercel runtime. It **cannot** access:


### PR DESCRIPTION
## What changed

Three doc gaps from recent merges:

1. **tools/jobs.mdx** — Document the new `script` param on `create_job` and `update_job`. Add an "Execution modes" section explaining script-only, hybrid, and playbook-only modes. (From #786)

2. **tools/sandbox.mdx** — Document GCS-backed persistent storage at `/mnt/aura-files/` for per-user files that survive sandbox restarts. (From #801)

3. **api-reference/overview.mdx** — Document the new `GET /api/dashboard/openapi.json` endpoint for the full OpenAPI 3.1 spec. (From #822)

## Files changed
- `content/docs/tools/jobs.mdx` — +18 lines (script param + execution modes table)
- `content/docs/tools/sandbox.mdx` — +17 lines (persistent storage section)
- `content/docs/api-reference/overview.mdx` — +10 lines (OpenAPI endpoint)

Automated by docs-maintenance job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates; no runtime behavior changes, but accuracy matters for users relying on the new `script`/storage/OpenAPI endpoints.
> 
> **Overview**
> Documents three recently-added capabilities: a dashboard OpenAPI endpoint (`GET /api/dashboard/openapi.json`), a `script` parameter for `create_job`/`update_job` plus an *execution modes* explanation (playbook-only/script-only/hybrid), and GCS-backed persistent sandbox storage under `/mnt/aura-files/<user_id>/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1532a5f04ac06e52665720e73cdc24a894bc7e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->