### PR TITLE
fix: fuzzy name resolution fallback via fast model (#398)

### DIFF
--- a/apps/api/src/tools/slack.ts
+++ b/apps/api/src/tools/slack.ts
@@ -391,6 +391,46 @@ export async function resolveUserByName(
     };
   }
 
+  // Fuzzy match fallback via fast model (for voice/STT contexts)
+  try {
+    const { generateText } = await import("ai");
+    const { getFastModel } = await import("../lib/ai.js");
+
+    const model = await getFastModel();
+    const userListStr = users
+      .map((u) => `${u.id}: ${u.displayName || u.realName} (@${u.username})`)
+      .join("\n");
+
+    const { text } = await generateText({
+      model,
+      system:
+        "Given a list of team members and a possibly misspelled or speech-transcribed name, return ONLY the user ID (e.g. U066V1AN6) of the best match. If no reasonable match exists, return 'NONE'. Do not explain.",
+      prompt: `Team members:\n${userListStr}\n\nFind: "${cleaned}"`,
+      maxOutputTokens: 50,
+    });
+
+    const matchedId = text.trim();
+    if (matchedId !== "NONE" && /^U[A-Z0-9]+$/.test(matchedId)) {
+      const matchedUser = users.find((u) => u.id === matchedId);
+      if (matchedUser) {
+        logger.info("resolveUserByName: fuzzy match via fast model", {
+          input: cleaned,
+          matchedId: matchedUser.id,
+          matchedName: matchedUser.displayName || matchedUser.realName,
+        });
+        return {
+          id: matchedUser.id,
+          name:
+            matchedUser.displayName ||
+            matchedUser.realName ||
+            matchedUser.username,
+        };
+      }
+    }
+  } catch {
+    // Fuzzy match failed, fall through to return null
+  }
+
   return null;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a fuzzy name resolution fallback to `resolveUserByName` in `apps/api/src/tools/slack.ts` using the fast LLM model (Haiku). This handles voice/STT contexts where names get mangled by speech-to-text (e.g. "Joan" → "Johann", "Kerryan" → "Kerrian", "Cecilia" → "Cecelia").

## What changed

When `resolveUserByName` fails to find an exact case-insensitive match against `displayName`, `realName`, or `username`, it now falls back to a fast LLM call that fuzzy-matches the input name against the full user list.

### Implementation details

- **Dynamic imports** for `generateText` (from `ai`) and `getFastModel` (from `../lib/ai.js`) to keep the module lightweight when fuzzy matching isn't needed
- **Validates** the returned user ID actually exists in the cached user list before returning
- **Graceful degradation**: entire fallback is wrapped in try/catch — if the model call fails for any reason, falls through to `return null` (same behavior as before)
- **Logging**: logs via `logger.info` when fuzzy match succeeds, so we can track how often it fires and audit matches
- **Cost**: ~$0.0001 per call (tiny user list + short response)

### Flow

1. Exact match (existing behavior, unchanged) → return if found
2. **New**: Fuzzy match via fast model → return if confident match found
3. Return `null` (unchanged)

## Testing notes

- The fuzzy fallback only fires when exact match returns `null`
- The returned ID is validated against the user list (no hallucinated IDs)
- Model failures are caught and silently fall through
- Type-checked with `tsc --noEmit` — no new type errors introduced

Closes #398
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf88c4e2-986f-4338-9333-850deb3166c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf88c4e2-986f-4338-9333-850deb3166c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

