### PR TITLE
fix: sandbox env injection owner filtering and sandboxEnvName support

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -2,7 +2,7 @@ import * as nodePath from "node:path";
 import { getSetting, setSetting } from "./settings.js";
 import { decryptCredential } from "./credentials.js";
 import { db } from "../db/client.js";
-import { credentials } from "@aura/db/schema";
+import { credentials, credentialGrants } from "@aura/db/schema";
 import { logger } from "./logger.js";
 
 const SANDBOX_NOTE_KEY = "e2b_sandbox_id";
@@ -68,8 +68,26 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
   }
 
   try {
+    // Resolve explicit credential grants so Gate 2 can allow per_user
+    // credentials the caller doesn't own but was explicitly granted.
+    const grantedCredentialIds = new Set<string>();
+    if (userId) {
+      const { eq, and, isNull } = await import("drizzle-orm");
+      const grants = await db
+        .select({ credentialId: credentialGrants.credentialId })
+        .from(credentialGrants)
+        .where(
+          and(
+            eq(credentialGrants.granteeId, userId),
+            isNull(credentialGrants.revokedAt),
+          ),
+        );
+      for (const g of grants) grantedCredentialIds.add(g.credentialId);
+    }
+
     const rows = await db
       .select({
+        id: credentials.id,
         name: credentials.name,
         value: credentials.value,
         ownerId: credentials.ownerId,
@@ -82,10 +100,16 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
       // Gate 1: user must have access to this credential name
       if (userCredNames && !userCredNames.has(row.name)) continue;
 
-      // Gate 2: for per_user credentials, only inject the calling user's row.
+      // Gate 2: for per_user credentials, only inject the calling user's own
+      // row OR rows they've been explicitly granted access to.
       // Without this, two users with the same credential name (e.g.
       // `github_token`) would collide and the last row wins silently.
-      if (row.scope === "per_user" && userId && row.ownerId !== userId) continue;
+      if (
+        row.scope === "per_user" &&
+        userId &&
+        row.ownerId !== userId &&
+        !grantedCredentialIds.has(row.id)
+      ) continue;
 
       // Use the explicit sandboxEnvName if set, otherwise uppercase the name
       const envName = row.sandboxEnvName || row.name.toUpperCase();


### PR DESCRIPTION
## Problem

Two bugs in `getSandboxEnvs()` that become critical now that multiple users can store credentials with the same name (e.g. `github_token`):

### 1. No owner filtering on per_user credentials

The query selects **all** credential rows and filters only by name. When Joan and Callan both store `github_token`, both rows pass the name filter, and whichever row comes last silently wins. In practice, the wrong user's token gets injected.

### 2. `sandboxEnvName` is dead code

The `sandbox_env_name` column exists in the schema but `getSandboxEnvs()` never reads it -- it always uppercases the credential `name`. This means setting a custom env var name on a credential has no effect.

## Fix

- **Owner filtering**: for `per_user` scoped credentials, only inject rows where `ownerId` matches the calling user. Shared/role-scoped credentials continue to work as before.
- **sandboxEnvName**: use `row.sandboxEnvName` when set, fall back to `row.name.toUpperCase()`.

The query now selects `ownerId`, `scope`, and `sandboxEnvName` alongside `name` and `value`.

## Diff summary

- 1 file changed: `apps/api/src/lib/sandbox.ts`
- +17 lines, -2 lines
- Zero new dependencies, zero schema changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches secret injection and access-control gating for sandbox environments; a bug could leak or withhold credentials at runtime. Logic is small but security-sensitive and depends on correct grant filtering.
> 
> **Overview**
> Fixes `getSandboxEnvs()` to **prevent wrong-user secrets being injected into E2B sandboxes** when multiple users have credentials with the same name by filtering `per_user` credentials to the caller’s own rows (or explicitly granted credential IDs via `credentialGrants`).
> 
> Also updates env var naming to honor `credentials.sandboxEnvName` when set, falling back to `name.toUpperCase()`, and expands the credential query to include `id`, `ownerId`, `scope`, and `sandboxEnvName` for these gates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10f09c85ed7489ac02d3d570a4fde3258661b839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->