### PR TITLE
fix: skip all per_user credentials when userId is omitted

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -104,12 +104,12 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
       // row OR rows they've been explicitly granted access to.
       // Without this, two users with the same credential name (e.g.
       // `github_token`) would collide and the last row wins silently.
-      if (
-        row.scope === "per_user" &&
-        userId &&
-        row.ownerId !== userId &&
-        !grantedCredentialIds.has(row.id)
-      ) continue;
+      // When userId is omitted, skip ALL per_user credentials to prevent
+      // leaking every user's secrets into an anonymous sandbox.
+      if (row.scope === "per_user") {
+        if (!userId) continue;
+        if (row.ownerId !== userId && !grantedCredentialIds.has(row.id)) continue;
+      }
 
       // Use the explicit sandboxEnvName if set, otherwise uppercase the name
       const envName = row.sandboxEnvName || row.name.toUpperCase();


### PR DESCRIPTION
## Problem

Bugbot caught this on #829 ([comment](https://github.com/AuraHQ-ai/aura/pull/829#discussion_r2994969951)): when `getSandboxEnvs()` is called without a `userId`, Gate 2's condition `userId && ...` short-circuits to `false`, making the entire owner check a no-op. This silently injects **all** `per_user` credentials from every user into the sandbox -- the exact collision bug #829 was supposed to fix.

Current callers always pass `userId`, but the function signature explicitly allows omission (`userId?: string`), so this is a security footgun for future callers.

## Fix

Split Gate 2 into two steps:
1. If `row.scope === "per_user"` and no `userId` → skip entirely (safe default)
2. If `userId` exists → check ownership or explicit grant (existing behavior)

## Testing

No behavior change for current callers (all pass `userId`). The fix only hardens the edge case where `userId` is omitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox credential-injection logic; while the change is small and defensive, mistakes here could affect secret exposure or missing env vars in sandbox runs.
> 
> **Overview**
> Hardens `getSandboxEnvs()` so `per_user` credentials are **never injected** when `userId` is omitted, preventing accidental leakage of other users’ secrets into anonymous/unspecified sandboxes.
> 
> Keeps existing behavior when `userId` is provided: per-user credentials are still injected only if owned by the caller or explicitly granted via `credentialGrants`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccbca7c04ed428607e0a1156170327cc076df18e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->