### PR TITLE
fix: stop baking credentials into sandbox base environment

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -315,7 +315,7 @@ export async function getOrCreateSandbox(): Promise<any> {
   const templateId = envs.E2B_TEMPLATE_ID || process.env.E2B_TEMPLATE_ID || undefined;
   logger.info("Creating new E2B sandbox", { templateId: templateId || "default" });
 
-  const createOptions: any = { apiKey, timeoutMs: DEFAULT_TIMEOUT_MS, envs };
+  const createOptions: any = { apiKey, timeoutMs: DEFAULT_TIMEOUT_MS };
   const sandbox = templateId
     ? await Sandbox.create(templateId, createOptions)
     : await Sandbox.create(createOptions);


### PR DESCRIPTION
## Problem

`getOrCreateSandbox()` passes `envs` to `Sandbox.create()`, baking credentials into the sandbox base environment at creation time. If E2B merges base envs with per-command envs (rather than replacing), stale or wrong-user credentials from the creation-time env can leak through -- even after #829/#830 fixed the owner filtering in `getSandboxEnvs`.

## Fix

Remove `envs` from `Sandbox.create()` options. One line.

Credentials are already injected per-command via `commands.run({ envs })` in every caller:
- `run_command` tool (sandbox.ts L60)
- `setupSandboxFilesystem` (GCS mount)
- `ensureUserHome`
- `mkdir`, Claude Code install

No setup command loses its envs -- they all pass `envs` explicitly to each `commands.run()` call.

## Related

- #829 -- owner filtering in `getSandboxEnvs`
- #830 -- defensive guard when `userId` is undefined
- #818 -- per-user sandbox architecture (longer-term)