### PR TITLE
fix: remove owner role, simplify RBAC — admin is max role

### DIFF
--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -8,7 +8,6 @@ const ROLE_HIERARCHY = {
   member: 0,
   power_user: 1,
   admin: 2,
-  owner: 3,
 } as const;
 
 type Role = keyof typeof ROLE_HIERARCHY;
@@ -101,7 +100,7 @@ export function isAdmin(userId: string | undefined): boolean {
  * Look up a user's role from the DB. Returns 'member' if not found.
  */
 async function getUserRole(userId: string): Promise<Role> {
-  if (userId === "aura") return "owner";
+  if (userId === "aura") return "admin";
 
   try {
     const profile = await db
@@ -132,10 +131,9 @@ async function getUserRole(userId: string): Promise<Role> {
  *
  * Credential scope uses the role hierarchy directly:
  * - 'member' -> everyone can access
- * - 'power_user' -> power_user, admin, owner
- * - 'admin' -> admin, owner
- * - 'owner' -> owner only
- * - 'per_user' -> only the credential owner
+ * - 'power_user' -> power_user, admin
+ * - 'admin' -> admin only
+ * - 'owner' -> only the credential owner (owner_id must match)
  *
  * Plus explicit grants and synthetic env-var-based credentials.
  */
@@ -156,14 +154,12 @@ export async function resolveUserCredentials(
       .from(credentials);
 
     for (const cred of allCreds) {
-      const scope = (cred.scope || "member") as Role | "per_user";
-      if (scope === "per_user") {
-        // Only the credential owner gets it
+      const scope = (cred.scope || "member") as Role | "owner";
+      if (scope === "owner") {
         if (cred.ownerId === effectiveUserId) {
           result.add(cred.name);
         }
       } else {
-        // Role-based scope: user needs at least this role
         const requiredLevel = ROLE_HIERARCHY[scope as Role] ?? 0;
         if (userLevel >= requiredLevel) {
           result.add(cred.name);

--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -43,7 +43,7 @@ async function loadE2B() {
  * returns a flat NAME → value map. Uses `sandboxEnvName` when set on the
  * credential row, otherwise falls back to uppercasing the credential name.
  *
- * Owner-aware: for `per_user` scoped credentials, only the calling user's
+ * Owner-aware: for `owner` scoped credentials, only the calling user's
  * row is injected. This prevents collisions when multiple users store a
  * credential with the same name (e.g. `github_token`).
  *
@@ -68,7 +68,7 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
   }
 
   try {
-    // Resolve explicit credential grants so Gate 2 can allow per_user
+    // Resolve explicit credential grants so Gate 2 can allow owner-scoped
     // credentials the caller doesn't own but was explicitly granted.
     const grantedCredentialIds = new Set<string>();
     if (userId) {
@@ -100,13 +100,13 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
       // Gate 1: user must have access to this credential name
       if (userCredNames && !userCredNames.has(row.name)) continue;
 
-      // Gate 2: for per_user credentials, only inject the calling user's own
-      // row OR rows they've been explicitly granted access to.
+      // Gate 2: for owner-scoped credentials, only inject the calling user's
+      // own row OR rows they've been explicitly granted access to.
       // Without this, two users with the same credential name (e.g.
       // `github_token`) would collide and the last row wins silently.
-      // When userId is omitted, skip ALL per_user credentials to prevent
+      // When userId is omitted, skip ALL owner-scoped credentials to prevent
       // leaking every user's secrets into an anonymous sandbox.
-      if (row.scope === "per_user") {
+      if (row.scope === "owner") {
         if (!userId) continue;
         if (row.ownerId !== userId && !grantedCredentialIds.has(row.id)) continue;
       }

--- a/apps/api/src/routes/dashboard/auth.ts
+++ b/apps/api/src/routes/dashboard/auth.ts
@@ -24,7 +24,7 @@ export async function createSessionJwt(payload: { slackUserId: string; name: str
 
 export const dashboardAuthApp = createDashboardApp();
 
-const ALLOWED_ROLES = ["owner", "admin", "power_user"];
+const ALLOWED_ROLES = ["admin", "power_user"];
 
 /**
  * Check if a Slack user is allowed to access the dashboard.
@@ -51,12 +51,12 @@ export async function checkUserRole(
   const bootstrapResult = await db.transaction(async (tx) => {
     await tx.execute(sql`SELECT pg_advisory_xact_lock(42)`);
 
-    const ownerCount = await tx
+    const adminCount = await tx
       .select({ count: sql<number>`count(*)::int` })
       .from(userProfiles)
-      .where(eq(userProfiles.role, "owner"));
+      .where(eq(userProfiles.role, "admin"));
 
-    if ((ownerCount[0]?.count ?? 0) > 0) {
+    if ((adminCount[0]?.count ?? 0) > 0) {
       return null;
     }
 
@@ -64,20 +64,20 @@ export async function checkUserRole(
       .insert(userProfiles)
       .values({
         slackUserId,
-        displayName: name || "Owner",
-        role: "owner",
+        displayName: name || "Admin",
+        role: "admin",
       })
       .onConflictDoUpdate({
         target: [userProfiles.workspaceId, userProfiles.slackUserId],
-        set: { role: "owner", updatedAt: new Date() },
+        set: { role: "admin", updatedAt: new Date() },
       })
       .returning({ role: userProfiles.role });
 
-    return inserted[0]?.role ?? "owner";
+    return inserted[0]?.role ?? "admin";
   });
 
   if (bootstrapResult) {
-    logger.info("Auto-seeded first user as owner", { slackUserId });
+    logger.info("Auto-seeded first user as admin", { slackUserId });
     return { allowed: true, role: bootstrapResult, bootstrapped: true };
   }
 

--- a/apps/api/src/routes/dashboard/credentials.ts
+++ b/apps/api/src/routes/dashboard/credentials.ts
@@ -268,7 +268,7 @@ dashboardCredentialsApp.openapi(getCredentialRoute, async (c) => {
   }
 });
 
-const VALID_SCOPES = ["member", "power_user", "admin", "owner", "per_user"] as const;
+const VALID_SCOPES = ["member", "power_user", "admin", "owner"] as const;
 
 dashboardCredentialsApp.patch("/:id/scope", async (c) => {
   try {

--- a/apps/api/src/routes/dashboard/users.ts
+++ b/apps/api/src/routes/dashboard/users.ts
@@ -154,7 +154,7 @@ dashboardUsersApp.openapi(getUserRoute, async (c) => {
   }
 });
 
-const VALID_ROLES = ["owner", "admin", "power_user", "member"] as const;
+const VALID_ROLES = ["admin", "power_user", "member"] as const;
 
 const updateUserRoleRoute = createRoute({
   method: "patch",

--- a/packages/db/drizzle/0048_remove_owner_role.sql
+++ b/packages/db/drizzle/0048_remove_owner_role.sql
@@ -1,0 +1,4 @@
+-- Migrate owner role to admin (owner role is being removed; admin is now the highest role)
+UPDATE user_profiles SET role = 'admin', updated_at = NOW() WHERE role = 'owner';--> statement-breakpoint
+-- Migrate any credentials using per_user scope to owner scope (per_user is being removed)
+UPDATE credentials SET scope = 'owner', updated_at = NOW() WHERE scope = 'per_user';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1774521600000,
       "tag": "0047_credential_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1774608000000,
+      "tag": "0048_remove_owner_role",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `owner` role in the user role hierarchy conflicts with `owner` as a credential scope. This causes a credential isolation bug: `getSandboxEnvs` Gate 2 checks `scope === "per_user"` but all tokens have `owner` scope, so the check never fires and `github_token` leaks between users (Callan's token gets injected for everyone).

## Changes

### 1. `apps/api/src/lib/permissions.ts`
- Removed `owner: 3` from `ROLE_HIERARCHY` — max role is now `admin: 2`
- Changed Aura bot fallback role from `"owner"` to `"admin"` in `getUserRole()`
- **Credential isolation fix:** changed `if (scope === "per_user")` to `if (scope === "owner")` in `resolveUserCredentials()` — when scope is `"owner"`, only inject the credential if `userId === row.owner_id`

### 2. `apps/api/src/lib/sandbox.ts`
- Gate 2: changed `if (row.scope === "per_user")` to `if (row.scope === "owner")` — same credential isolation fix as in permissions.ts

### 3. `apps/api/src/routes/dashboard/auth.ts`
- Bootstrap first user as `"admin"` instead of `"owner"`
- Updated `ALLOWED_ROLES` to remove `"owner"`
- Updated all role references: insert values, onConflict set, fallback return, log message, displayName fallback

### 4. `apps/api/src/routes/dashboard/credentials.ts`
- Removed `"per_user"` from `VALID_SCOPES` — kept: `["member", "power_user", "admin", "owner"]`

### 5. `apps/api/src/routes/dashboard/users.ts`
- Removed `"owner"` from `VALID_ROLES` — kept: `["admin", "power_user", "member"]`

### 6. `packages/db/drizzle/0048_remove_owner_role.sql` (new migration)
- Migrates existing `owner` role users → `admin`
- Migrates existing `per_user` scoped credentials → `owner` scope
- Includes `-->statement-breakpoint` between statements per Drizzle convention

## Notes
- `owner_id` / `ownerId` references are untouched — those refer to credential ownership, not the role
- No test changes needed — no tests reference the `owner` role string directly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6612271-7d04-435c-a29f-0376fafcd938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6612271-7d04-435c-a29f-0376fafcd938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

