### PR TITLE
fix: stabilize dashboard table layout with proper scrolling and loading states

### DIFF
--- a/apps/dashboard/src/components/page-skeleton.tsx
+++ b/apps/dashboard/src/components/page-skeleton.tsx
@@ -1,7 +1,7 @@
 import { TableRow, TableCell } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
-export function TableRowsSkeleton({ columns, rows = 5 }: { columns: number; rows?: number }) {
+export function TableRowsSkeleton({ columns, rows = 25 }: { columns: number; rows?: number }) {
   return (
     <>
       {Array.from({ length: rows }).map((_, i) => (

--- a/apps/dashboard/src/components/pagination.tsx
+++ b/apps/dashboard/src/components/pagination.tsx
@@ -10,14 +10,13 @@ interface PaginationProps {
 
 export function Pagination({ total, pageSize, page, onPageChange }: PaginationProps) {
   const totalPages = Math.ceil(total / pageSize);
-
-  if (totalPages <= 1) return null;
+  const hasPages = totalPages > 1;
 
   const start = (page - 1) * pageSize + 1;
   const end = Math.min(page * pageSize, total);
 
   return (
-    <div className="flex items-center justify-between pt-2">
+    <div className="flex items-center justify-between pt-2" style={{ visibility: hasPages ? "visible" : "hidden" }}>
       <span className="text-[13px] text-muted-foreground">
         {start}–{end} of {total.toLocaleString()}
       </span>

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -8,13 +8,13 @@ export function cn(...inputs: ClassValue[]) {
 export function formatDate(date: Date | string | null | undefined): string {
   if (!date) return "—";
   const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const hh = d.getHours().toString().padStart(2, "0");
+  const mm = d.getMinutes().toString().padStart(2, "0");
+  const ss = d.getSeconds().toString().padStart(2, "0");
+  const month = d.toLocaleDateString("en-US", { month: "short" });
+  const day = d.getDate();
+  const year = d.getFullYear();
+  return `${hh}:${mm}:${ss}, ${month} ${day}, ${year}`;
 }
 
 export function truncate(str: string | null | undefined, max: number): string {

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -105,8 +105,8 @@ function RootLayout() {
         <Panel id="content" minSize="50%">
           <div className="flex h-full flex-col overflow-hidden">
             <Header session={session} chatOpen={chatOpen} toggleChat={toggleChat} />
-            <main className="flex-1 overflow-y-auto">
-              <div className="px-4 py-3 md:px-5 md:py-4">
+            <main className="flex-1 flex flex-col min-h-0 overflow-hidden">
+              <div className="flex-1 flex flex-col min-h-0 overflow-y-auto px-4 py-3 md:px-5 md:py-4">
                 <Outlet />
               </div>
             </main>

--- a/apps/dashboard/src/routes/conversations/index.tsx
+++ b/apps/dashboard/src/routes/conversations/index.tsx
@@ -80,11 +80,11 @@ function InvocationsTable({
   isLoading?: boolean;
 }) {
   return (
-    <div className="rounded-xl border overflow-x-auto">
-      <Table className="min-w-[800px]">
+    <div className="flex-1 min-h-0 rounded-xl border overflow-auto">
+      <Table className="min-w-[850px]">
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[140px]">Timestamp</TableHead>
+            <TableHead className="w-[160px]">Timestamp</TableHead>
             <TableHead className="w-[80px]">Source</TableHead>
             <TableHead>Preview</TableHead>
             <TableHead className="w-[160px]">Model</TableHead>
@@ -157,12 +157,12 @@ function InvocationsTable({
 
 function ThreadsTable({ threads, isLoading }: { threads: ThreadRow[]; isLoading?: boolean }) {
   return (
-    <div className="rounded-xl border overflow-x-auto">
-      <Table className="min-w-[800px]">
+    <div className="flex-1 min-h-0 rounded-xl border overflow-auto">
+      <Table className="min-w-[860px]">
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[140px]">Started</TableHead>
-            <TableHead className="w-[140px]">Last Active</TableHead>
+            <TableHead className="w-[160px]">Started</TableHead>
+            <TableHead className="w-[160px]">Last Active</TableHead>
             <TableHead className="w-[80px]">Source</TableHead>
             <TableHead>Preview</TableHead>
             <TableHead className="w-[80px]">Messages</TableHead>
@@ -267,7 +267,7 @@ function ConversationsPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Conversations</h1>
         <span className="text-sm text-muted-foreground">
@@ -312,7 +312,7 @@ function ConversationsPage() {
         </div>
       </Tabs>
 
-      <div className={cn("transition-opacity", isFetching && !isLoading && "opacity-50")}>
+      <div className={cn("flex-1 min-h-0 flex flex-col transition-opacity", isFetching && !isLoading && "opacity-50")}>
         {view === "threads" ? (
           <ThreadsTable threads={items as ThreadRow[]} isLoading={isLoading} />
         ) : (

--- a/apps/dashboard/src/routes/credentials/index.tsx
+++ b/apps/dashboard/src/routes/credentials/index.tsx
@@ -140,7 +140,7 @@ function CredentialsPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Credentials</h1>
         <span className="text-sm text-muted-foreground">
@@ -166,15 +166,15 @@ function CredentialsPage() {
         </Button>
       </div>
 
-      <div className={cn("rounded-xl border overflow-x-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table className="min-w-[550px]">
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[650px]">
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead className="w-[80px]">Type</TableHead>
               <TableHead className="w-[120px]">Scope</TableHead>
               <TableHead className="w-[160px]">Owner</TableHead>
-              <TableHead className="w-[140px]">Expires</TableHead>
+              <TableHead className="w-[160px]">Expires</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/dashboard/src/routes/errors/index.tsx
+++ b/apps/dashboard/src/routes/errors/index.tsx
@@ -84,7 +84,7 @@ function ErrorsPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Errors</h1>
         <span className="text-sm text-muted-foreground">
@@ -132,8 +132,8 @@ function ErrorsPage() {
         )}
       </div>
 
-      <div className={cn("rounded-xl border overflow-hidden transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table>
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[700px]">
           <TableHeader>
             <TableRow>
               <TableHead className="w-10" />
@@ -141,7 +141,7 @@ function ErrorsPage() {
               <TableHead className="w-[80px]">Code</TableHead>
               <TableHead>Message</TableHead>
               <TableHead className="w-[80px]">Status</TableHead>
-              <TableHead className="w-[140px]">Time</TableHead>
+              <TableHead className="w-[160px]">Time</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/dashboard/src/routes/jobs/index.tsx
+++ b/apps/dashboard/src/routes/jobs/index.tsx
@@ -66,7 +66,7 @@ function JobsPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Jobs</h1>
         <span className="text-sm text-muted-foreground">
@@ -87,8 +87,8 @@ function JobsPage() {
         />
       </div>
 
-      <div className={cn("rounded-xl border overflow-x-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table className="min-w-[960px]">
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[1020px]">
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
@@ -97,8 +97,8 @@ function JobsPage() {
               <TableHead className="w-[120px]">Schedule</TableHead>
               <TableHead className="w-[70px]">Enabled</TableHead>
               <TableHead className="w-[90px]">Executions</TableHead>
-              <TableHead className="w-[140px]">Last Run</TableHead>
-              <TableHead className="w-[140px]">Created</TableHead>
+              <TableHead className="w-[160px]">Last Run</TableHead>
+              <TableHead className="w-[160px]">Created</TableHead>
               <TableHead className="w-[80px]">Priority</TableHead>
             </TableRow>
           </TableHeader>

--- a/apps/dashboard/src/routes/memories/index.tsx
+++ b/apps/dashboard/src/routes/memories/index.tsx
@@ -58,7 +58,7 @@ function MemoriesPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Memories</h1>
         <span className="text-sm text-muted-foreground">
@@ -88,15 +88,15 @@ function MemoriesPage() {
         </select>
       </div>
 
-      <div className={cn("rounded-xl border overflow-hidden transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table>
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[600px]">
           <TableHeader>
             <TableRow>
               <TableHead>Content</TableHead>
               <TableHead className="w-[90px]">Type</TableHead>
               <TableHead className="w-[80px]">Relevance</TableHead>
               <TableHead className="w-[80px]">Shareable</TableHead>
-              <TableHead className="w-[140px]">Created</TableHead>
+              <TableHead className="w-[160px]">Created</TableHead>
               <TableHead className="w-10" />
             </TableRow>
           </TableHeader>

--- a/apps/dashboard/src/routes/notes/index.tsx
+++ b/apps/dashboard/src/routes/notes/index.tsx
@@ -72,7 +72,7 @@ function NotesPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Notes</h1>
         <span className="text-sm text-muted-foreground">
@@ -95,14 +95,14 @@ function NotesPage() {
         </Button>
       </div>
 
-      <div className={cn("rounded-xl border overflow-hidden transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table>
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[600px]">
           <TableHeader>
             <TableRow>
               <TableHead>Topic</TableHead>
               <TableHead className="w-[100px]">Category</TableHead>
-              <TableHead className="w-[140px]">Updated</TableHead>
-              <TableHead className="w-[140px]">Expires</TableHead>
+              <TableHead className="w-[160px]">Updated</TableHead>
+              <TableHead className="w-[160px]">Expires</TableHead>
               <TableHead className="w-10" />
             </TableRow>
           </TableHeader>

--- a/apps/dashboard/src/routes/resources/index.tsx
+++ b/apps/dashboard/src/routes/resources/index.tsx
@@ -86,7 +86,7 @@ function ResourcesPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Resources</h1>
         <span className="text-sm text-muted-foreground">
@@ -144,15 +144,15 @@ function ResourcesPage() {
         </Select>
       </div>
 
-      <div className={cn("rounded-xl border overflow-hidden transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table>
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[680px]">
           <TableHeader>
             <TableRow>
               <TableHead>Title</TableHead>
               <TableHead className="w-[80px]">Source</TableHead>
               <TableHead className="w-[80px]">Status</TableHead>
-              <TableHead className="w-[140px]">Crawled</TableHead>
-              <TableHead className="w-[140px]">Updated</TableHead>
+              <TableHead className="w-[160px]">Crawled</TableHead>
+              <TableHead className="w-[160px]">Updated</TableHead>
               <TableHead className="w-10" />
             </TableRow>
           </TableHeader>

--- a/apps/dashboard/src/routes/settings/index.tsx
+++ b/apps/dashboard/src/routes/settings/index.tsx
@@ -169,7 +169,7 @@ function SettingsPage() {
             <TableRow>
               <TableHead className="w-[200px]">Key</TableHead>
               <TableHead>Value</TableHead>
-              <TableHead className="w-[140px]">Updated</TableHead>
+              <TableHead className="w-[160px]">Updated</TableHead>
               <TableHead className="w-[120px]">By</TableHead>
               <TableHead className="w-10" />
             </TableRow>

--- a/apps/dashboard/src/routes/users/index.tsx
+++ b/apps/dashboard/src/routes/users/index.tsx
@@ -56,7 +56,7 @@ function UsersPage() {
   const total = data?.total ?? 0;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 flex-1 min-h-0">
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold tracking-tight">Users</h1>
         <span className="text-sm text-muted-foreground">
@@ -77,16 +77,16 @@ function UsersPage() {
         />
       </div>
 
-      <div className={cn("rounded-xl border overflow-x-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table className="min-w-[700px]">
+      <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
+        <Table className="min-w-[850px]">
           <TableHeader>
             <TableRow>
               <TableHead className="w-[160px]">Name</TableHead>
               <TableHead className="w-[120px]">Slack ID</TableHead>
               <TableHead>Job Title</TableHead>
               <TableHead className="w-[100px]">Interactions</TableHead>
-              <TableHead className="w-[140px]">Last Active</TableHead>
-              <TableHead className="w-[140px]">Joined</TableHead>
+              <TableHead className="w-[160px]">Last Active</TableHead>
+              <TableHead className="w-[160px]">Joined</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>


### PR DESCRIPTION
## Summary

- Tables now use `flex-1` height with internal scrolling and sticky headers — no more scrolling the entire page to reach pagination
- Horizontal scroll kicks in when column min-widths exceed the available table width
- Date columns formatted as `HH:mm:ss, Mon D, YYYY` so time is visible even if the column truncates
- Pagination bar always reserves its vertical space during loading (`visibility: hidden` instead of returning `null`), preventing layout shift when data arrives
- Skeleton rows increased from 5 to 25 to fill the viewport while loading

## Test plan

- [ ] Navigate to each table page (Notes, Memories, Conversations, Jobs, Errors, Users, Credentials, Resources) and verify:
  - Table fills available height
  - Headers stay fixed while scrolling rows
  - Pagination is visible without scrolling the page
- [ ] On narrow viewports, verify horizontal scroll appears when columns overflow
- [ ] Observe loading states — skeleton rows should fill the table, and pagination area should not shift when data lands


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared UI primitives (`formatDate`, `Pagination`) and refactors layout/scroll behavior across many list pages, so regressions may show up broadly in table rendering and date display. Changes are frontend-only with no auth or data-mutation logic impact.
> 
> **Overview**
> Stabilizes dashboard list pages by converting table sections to flex layouts that fill available height and scroll internally (`flex-1`, `min-h-0`, `overflow-auto`), keeping pagination reachable without scrolling the whole page and enabling horizontal scroll via explicit `min-w-*` table widths.
> 
> Updates shared UI behavior: `Pagination` now always reserves space (uses `visibility: hidden` when only one page) to prevent layout shift, `TableRowsSkeleton` defaults to 25 rows to better fill the viewport while loading, and `formatDate` switches to a fixed `HH:mm:ss, Mon D, YYYY` string to keep time visible in narrow columns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bfa92530a125ce36655749374142744bc26ce0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->