### PR TITLE
docs: update RBAC, credentials, and sandbox docs after access control refactor

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -58,8 +58,10 @@ Monitor scheduled and recurring jobs:
 
 Manage the encrypted credential store:
 
-- View stored credentials per user (names only -- values are never displayed)
+- View stored credentials per user (names only — values are never displayed)
+- Set scope (owner, admin, power_user, member) to control minimum access level
 - See credential types (token, OAuth client)
+- Manage grants — add or remove user access via a user picker dropdown
 - Monitor usage and last-accessed timestamps
 
 ### Errors
@@ -95,7 +97,7 @@ Configure instance behavior:
 
 ## Access & Authentication
 
-The dashboard uses Slack OAuth for login. Access requires an `admin` or `owner` role (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var serves as a fallback for users without a database role.
+The dashboard uses Slack OAuth for login. Access requires the `admin` role (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var serves as a fallback for users without a database role.
 
 ### Auth Proxy
 

--- a/content/docs/permissions.mdx
+++ b/content/docs/permissions.mdx
@@ -5,7 +5,7 @@ description: "Role-based access control: user roles, tool permissions, note scop
 
 # Permissions
 
-Aura uses a four-tier role system to control access to tools, notes, and resources. Roles are stored in the database (`user_profiles.role`) with an env var fallback for backwards compatibility.
+Aura uses a three-tier role system to control access to tools, notes, and resources. Roles are stored in the database (`user_profiles.role`) with an env var fallback for backwards compatibility.
 
 ## Roles
 
@@ -13,10 +13,13 @@ Aura uses a four-tier role system to control access to tools, notes, and resourc
 |------|-------|-------------|
 | `member` | 0 | Default role. Can chat with Aura, use basic tools, see shared notes. |
 | `power_user` | 1 | Extended access: sandbox, browser, voice, Cursor agents, subagents. |
-| `admin` | 2 | Full access: cross-user email/Slack, system note editing, job management. |
-| `owner` | 3 | Everything. Reserved for workspace owners. |
+| `admin` | 2 | Full access: cross-user email/Slack, system note editing, job management. Maximum role. |
 
 Roles are hierarchical — a user with `admin` automatically has all `power_user` and `member` permissions.
+
+<Note>
+The `owner` role was removed in the RBAC simplification (migration 0048). Existing `owner` users were migrated to `admin`. The word "owner" now only refers to credential ownership — see [Credentials](/tools/credentials).
+</Note>
 
 ## How Roles Are Checked
 
@@ -25,7 +28,7 @@ The `hasRole(userId, minimumRole)` function in `apps/api/src/lib/permissions.ts`
 1. Look up `user_profiles.role` in the database
 2. If a DB role exists, compare it against the minimum required role and return the result
 3. If no DB profile exists (or query fails), fall back to `AURA_ADMIN_USER_IDS` env var — users listed there get `admin`-level access
-4. The system user `aura` always passes all role checks
+4. The system user `aura` always resolves to `admin` and passes all role checks
 
 <Warning>
 If a user has an explicit role in the database, the env var is **not** consulted. A user demoted to `member` in the DB won't regain admin via the env var. This is intentional — the DB is authoritative once set.
@@ -48,7 +51,7 @@ Each tool category requires a minimum role:
 | Job limit bypass | `admin` |
 | System note editing | `admin` |
 
-Members can still use Slack messaging, notes (their own + shared), web search, and basic tools.
+Members have access to Slack messaging, web search, and basic tools.
 
 ## Note Scoping
 
@@ -72,18 +75,23 @@ Default rate limits are seeded per role:
 | Cursor agents/day | 0 | 3 | 10 |
 | Subagent calls/day | 0 | 10 | 50 |
 
-Rate limits are stored in the `rate_limits` table and are workspace-scoped, so different workspaces can have different limits.
-
-<Note>
-Owners have no seeded rate limits — they're unlimited by default.
-</Note>
+Rate limits are stored in the `rate_limits` table and are workspace-scoped, so different workspaces can have different limits. Admins have no hard ceiling by default.
 
 ## Managing Roles
 
 Roles can be set in two ways:
 
-1. **Dashboard** — Navigate to Users → select a user → Profile tab → Role dropdown. Requires admin access.
+1. **Dashboard** — Navigate to Users → select a user → Profile tab → Role dropdown. Valid options: `admin`, `power_user`, `member`. Requires admin access.
 2. **Database** — Update `user_profiles.role` directly.
+
+## User Bootstrapping
+
+Users are created in `user_profiles` when they first log into the dashboard via Slack OAuth:
+
+- **First user** is automatically assigned the `admin` role (the bootstrapping user is assumed to be the workspace admin)
+- **Subsequent users** get the `member` role by default
+
+Users who interact with Aura in Slack but never log into the dashboard won't have a `user_profiles` row. This is fine — the message pipeline identifies users by raw Slack user ID and doesn't require a profile. The pipeline and dashboard are independent systems.
 
 ## Migration from `AURA_ADMIN_USER_IDS`
 
@@ -91,7 +99,7 @@ The env var still works as a fallback for users without a DB profile. For new de
 
 ## Database Schema
 
-The permission system adds these tables:
+The permission system uses these tables:
 
 - **`user_profiles.role`** — `text NOT NULL DEFAULT 'member'` on the existing user profiles table
 - **`tool_definitions`** — Per-tool minimum role configuration (workspace-scoped)

--- a/content/docs/tools/credentials.mdx
+++ b/content/docs/tools/credentials.mdx
@@ -1,18 +1,18 @@
 ---
 title: "Credentials & HTTP"
-description: "Encrypted credential storage and authenticated API requests."
+description: "Encrypted credential storage with owner-scoped access, grants, and authenticated API requests."
 ---
 
 # Credentials & HTTP Requests
 
-Aura has a secure credential system that lets users store API keys and OAuth credentials, which she can use to make authenticated requests to external services.
+Aura has a secure credential system that lets users store API keys and OAuth credentials, which she can use to make authenticated requests to external services. Credentials support fine-grained access control through a combination of ownership, grants, and role-based minimum access levels.
 
 ## How It Works
 
-1. **Users store credentials** via Aura's Slack App Home -- a simple form with name, type, and value
+1. **Users store credentials** via the Aura Dashboard (Credentials page) or Slack App Home
 2. **Credentials are encrypted** at rest using AES-256-GCM
-3. **Aura requests credentials by name** -- the server decrypts and injects the auth header
-4. **The LLM never sees raw keys** -- credentials are resolved server-side
+3. **Aura requests credentials by name** — the server decrypts and injects the auth header
+4. **The LLM never sees raw keys** — credentials are resolved server-side
 
 ## Credential Types
 
@@ -38,6 +38,53 @@ Client Secret: GOCSPX-...
 Token URL: https://oauth2.googleapis.com/token
 ```
 
+## Access Control
+
+Each credential has three access dimensions that compose together:
+
+### 1. Owner
+
+The user who created the credential. Identified by `owner_id` (their Slack user ID). The owner always has access to their own credential.
+
+### 2. Scope (minRole)
+
+Defines the minimum role required to use this credential. This is a floor, not a ceiling — users still need to meet grant requirements if any are set.
+
+| Scope | Who can access |
+|-------|---------------|
+| `owner` | Only the credential owner (and explicit grantees) |
+| `admin` | Any user with the `admin` role |
+| `power_user` | Any user with `power_user` or above |
+| `member` | Any authenticated user |
+
+### 3. Grants
+
+Explicit per-user access grants. Each grant specifies a `grantee_id` (Slack user ID) and an optional `access_level`. Grants override the scope — a `member`-role user can access an `owner`-scoped credential if they have an explicit grant.
+
+### Resolution Logic
+
+When Aura needs a credential for a specific user, the `getSandboxEnvs` and `resolveUserCredentials` functions apply this logic:
+
+1. If `scope === "owner"` — only inject if the calling user is the credential's `owner_id`
+2. If the user has an explicit grant — inject regardless of scope
+3. If the user's role meets the `minRole` (scope) threshold — inject
+4. Otherwise — skip
+
+When multiple credentials share the same name (e.g. three different `github_token` entries from different owners), only the one belonging to the calling user is injected. No more "last row wins" collisions.
+
+## Sandbox Credential Injection
+
+When Aura executes `run_command`, credentials are injected into the sandbox environment dynamically based on the calling user's identity:
+
+- Each credential has a `sandbox_env_name` (e.g. `GITHUB_TOKEN`, `DATABASE_URL`)
+- At sandbox creation and per-command execution, `getSandboxEnvs(userId)` resolves which credentials the current user can access
+- The resolved values are injected as environment variables
+- This means different users get different environment variables in the same sandbox
+
+<Warning>
+The sandbox is currently a single shared instance, not per-user. While credential injection is user-specific per command, the filesystem and process state is shared. Per-user sandboxes are planned.
+</Warning>
+
 ## Making Authenticated Requests
 
 The `http_request` tool makes credentialed HTTP calls:
@@ -52,10 +99,18 @@ Credential Owner: U0678NQJ2
 
 The credential is injected server-side. Aura specifies the credential name and owner, never the actual key value.
 
+## Managing Credentials
+
+Credentials are managed through the Dashboard:
+
+- **Create**: Add a new credential with name, type, value, scope, and optional sandbox env name
+- **Grants**: Add or remove user grants — the Dashboard shows a user picker (not raw Slack IDs)
+- **Scope**: Set the minimum role for access
+
 ## Security Rules
 
-- Credentials are scoped per user -- Aura can only use credentials the owner has stored
 - Raw credential values are never returned to the LLM or displayed in chat
-- If a credential is accidentally pasted in chat, Aura warns immediately
+- If a credential is accidentally pasted in chat, Aura warns immediately and asks the user to rotate it
 - All credential access is audit-logged
 - OAuth tokens are refreshed automatically before expiry
+- Credentials are encrypted with AES-256-GCM — a compromised database dump doesn't expose secrets

--- a/content/docs/tools/sandbox.mdx
+++ b/content/docs/tools/sandbox.mdx
@@ -34,7 +34,7 @@ The sandbox template includes:
 | `node`, `npm` | JavaScript/TypeScript execution |
 | `python3`, `pip` | Python scripting |
 | `git` | Version control |
-| `gh` | GitHub CLI (authenticated via `GH_TOKEN`) |
+| `gh` | GitHub CLI (authenticated via user-specific `GH_TOKEN`) |
 | `gcloud` | Google Cloud SDK |
 | `vercel` | Vercel CLI (install first: `sudo npm install -g vercel`) |
 | `rg` (ripgrep) | Fast code search |
@@ -46,13 +46,26 @@ Install additional packages with `apt-get install` or `pip install`.
 
 ---
 
+## Credential injection
+
+When `run_command` executes, Aura injects environment variables based on the calling user's identity. The function `getSandboxEnvs(userId)` resolves which credentials each user can access:
+
+- **Owner-scoped credentials** (scope = `owner`) are only injected for the credential's owner
+- **Role-scoped credentials** (scope = `admin`, `power_user`, or `member`) are injected for any user meeting the minimum role
+- **Granted credentials** — users with explicit grants receive credentials regardless of scope
+
+This means when Joan runs a `gh` command, she gets her GitHub token. When Callan runs the same command, she gets hers. No cross-contamination.
+
+See [Credentials](/tools/credentials) for full access control details.
+
+---
+
 ## File system
 
 The sandbox persists between messages **within a session** — files and state are preserved across tool calls in the same conversation. The sandbox may auto-pause between sessions; check `/home/user/` to verify state is intact before assuming files exist.
 
 Common paths:
 - `/home/user/` — working directory
-- `/home/user/aura/` — Aura's own codebase (cloned at startup)
 - `/home/user/downloads/` — files saved to disk via `download_slack_file` or `download_email_attachment`
 
 ---
@@ -76,12 +89,16 @@ Common persistent paths:
 
 ## Isolation model
 
-The sandbox is isolated from the Vercel runtime. It **cannot** access:
-- The production PostgreSQL database (use `psql "$DATABASE_URL"` after extracting the URL via `skill-vercel-env-extraction`)
-- Slack tokens (unless extracted and passed explicitly)
-- Other production env vars (must be fetched from Vercel API using the `skill-vercel-env-extraction` playbook)
+The sandbox is isolated from the Vercel runtime. It **cannot** directly access:
+- The production PostgreSQL database (credentials are injected per-user via `DATABASE_URL` if the user has access)
+- Slack tokens (unless injected via the credential system)
+- Other production env vars (must be fetched from Vercel API)
 
 This isolation is intentional — Aura can run untrusted code without risk to the production system.
+
+<Warning>
+The sandbox is currently a single shared instance across all users and threads. While credential injection is user-specific per command, the filesystem and running processes are shared. Per-user sandbox isolation is planned.
+</Warning>
 
 ---
 


### PR DESCRIPTION
## What changed

After the RBAC simplification (#834), the docs were outdated. This PR brings them in line with the actual system.

### permissions.mdx
- **3-tier role system**: member → power_user → admin. The owner role no longer exists (removed in migration 0048, existing owners migrated to admin).
- Aura system user resolves to admin (not owner)
- Added user bootstrapping section
- Rate limit note updated

### tools/credentials.mdx
- **New scope/grants model documented**: owner, admin, power_user, member scopes
- Explicit grants override scope
- Resolution logic explained (owner check → grant check → role check)
- Sandbox credential injection: different users get different env vars per-command
- Dashboard management section

### tools/sandbox.mdx
- Per-user credential injection explained
- Shared sandbox warning added
- Isolation model updated for dynamic credential injection

### dashboard.mdx
- Removed owner role references
- Added credential grant management

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates reflecting the post-refactor RBAC and credential access rules; no runtime behavior changes.
> 
> **Overview**
> Updates docs to match the simplified **3-tier RBAC** model by removing `owner` role references, clarifying that dashboard access requires `admin`, and documenting bootstrapping rules (first dashboard user becomes `admin`).
> 
> Expands credential documentation to describe **owner + scope (minRole) + per-user grants** access control, how collisions are avoided when names overlap, and how credentials are managed via the dashboard (including grant user picker).
> 
> Clarifies sandbox behavior around **per-user credential injection** (e.g., `GH_TOKEN`/`DATABASE_URL`), updates the isolation model wording, and adds/duplicates warnings that the sandbox instance is still shared despite user-specific env injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c6b32f65a8df753c7b6d5e54398449d69347f0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->