### PR TITLE
feat: inject available credentials into system prompt per-user

### DIFF
--- a/apps/api/src/lib/api-credentials.ts
+++ b/apps/api/src/lib/api-credentials.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, isNull, inArray, sql } from "drizzle-orm";
+import { eq, and, or, isNull, inArray, gt, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import {
   credentials,
@@ -343,6 +343,48 @@ export async function getCredentialById(
     .where(eq(credentials.id, credentialId))
     .limit(1);
   return rows[0] ?? null;
+}
+
+export async function listAccessibleCredentials(
+  userId: string,
+): Promise<
+  Array<{ name: string; type: string; ownerName: string | null; isOwn: boolean }>
+> {
+  const [owned, granted] = await Promise.all([
+    db
+      .select({
+        name: credentials.name,
+        type: credentials.type,
+      })
+      .from(credentials)
+      .where(
+        and(
+          eq(credentials.ownerId, userId),
+          or(isNull(credentials.expiresAt), gt(credentials.expiresAt, new Date())),
+        ),
+      ),
+    db
+      .select({
+        name: credentials.name,
+        type: credentials.type,
+        ownerName: userProfiles.displayName,
+      })
+      .from(credentialGrants)
+      .innerJoin(credentials, eq(credentialGrants.credentialId, credentials.id))
+      .leftJoin(userProfiles, eq(credentials.ownerId, userProfiles.slackUserId))
+      .where(
+        and(
+          eq(credentialGrants.granteeId, userId),
+          isNull(credentialGrants.revokedAt),
+          or(isNull(credentials.expiresAt), gt(credentials.expiresAt, new Date())),
+        ),
+      ),
+  ]);
+
+  return [
+    ...owned.map((r) => ({ name: r.name, type: r.type, ownerName: null, isOwn: true })),
+    ...granted.map((r) => ({ name: r.name, type: r.type, ownerName: r.ownerName, isOwn: false })),
+  ];
 }
 
 export async function listApiCredentials(

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -558,6 +558,23 @@ export async function buildSystemPrompt(
   };
 }
 
+export interface AccessibleCredential {
+  name: string;
+  type: string;
+  ownerName: string | null;
+  isOwn: boolean;
+}
+
+export function formatAvailableCredentials(creds: AccessibleCredential[]): string {
+  if (creds.length === 0) return "";
+
+  const lines = creds.map((c) => {
+    const source = c.isOwn ? "yours" : `via ${c.ownerName ?? "unknown"}`;
+    return `- ${c.name} (${source}, ${c.type})`;
+  });
+  return `## Available credentials\n${lines.join("\n")}`;
+}
+
 /**
  * Build the dynamic context block (current time, model, channel, thread).
  * Separated from the stable system prompt so it can be passed as an uncached
@@ -569,11 +586,15 @@ export function buildDynamicContext(context: {
   channelId?: string;
   threadTs?: string;
   usageStats?: string;
+  availableCredentials?: AccessibleCredential[];
 }): string {
   let s = `## Current context\n\n${getCurrentTimeContext(context.userTimezone)}`;
   if (context.modelId) s += `\nActive model: \`${context.modelId}\``;
   if (context.channelId) s += `\nCurrent channel: ${context.channelId}`;
   if (context.threadTs) s += `\nCurrent thread_ts: ${context.threadTs}`;
   if (context.usageStats) s += `\n\n${context.usageStats}`;
+  if (context.availableCredentials && context.availableCredentials.length > 0) {
+    s += `\n\n${formatAvailableCredentials(context.availableCredentials)}`;
+  }
   return s;
 }

--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -11,6 +11,7 @@ import {
 import { embedText } from "../lib/embeddings.js";
 import { getProfile } from "../users/profiles.js";
 import { getMainModelId } from "../lib/ai.js";
+import { listAccessibleCredentials } from "../lib/api-credentials.js";
 import type { Memory, UserProfile } from "@aura/db/schema";
 import { people } from "@aura/db/schema";
 import { db } from "../db/client.js";
@@ -160,7 +161,7 @@ export async function buildCorePrompt(
     .filter((id) => id !== session.userId)
     .slice(0, 10);
 
-  const [memories, conversations, userProfile, mentionedPeople, interlocutor, usageStats] =
+  const [memories, conversations, userProfile, mentionedPeople, interlocutor, usageStats, accessibleCreds] =
     await Promise.all([
       queryEmbedding
         ? retrieveMemories({
@@ -186,6 +187,10 @@ export async function buildCorePrompt(
       lookupMentionedPeople(participantIds),
       lookupPerson(session.userId),
       getUsageStats(),
+      listAccessibleCredentials(session.userId).catch((error) => {
+        logger.error("Failed to list accessible credentials", { error: String(error) });
+        return [] as Array<{ name: string; type: string; ownerName: string | null; isOwn: boolean }>;
+      }),
     ]);
 
   const channelContext = session.channel === "dashboard"
@@ -216,6 +221,7 @@ export async function buildCorePrompt(
     channelId: session.conversationId,
     threadTs: session.threadId,
     usageStats,
+    availableCredentials: accessibleCreds,
   });
 
   if (session.channel === "dashboard") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #838

Aura frequently says "I don't have access" or "no credential stored" when a user asks for CRM/API data -- even when credentials exist (owned by the user, or org-shared via grants). The LLM had no visibility into what credentials are available at prompt time, so it guessed wrong or gave up.

This PR injects a summary of accessible credentials into the **dynamic context** block of the system prompt so the LLM knows exactly what's available per-invocation.

## Changes

### `apps/api/src/lib/api-credentials.ts`
- Added `listAccessibleCredentials(userId)` -- queries credentials the user owns (non-expired) and credentials granted to them (non-revoked, non-expired), returning only metadata: `{ name, type, ownerName, isOwn }`. No values/tokens are ever exposed.

### `apps/api/src/personality/system-prompt.ts`
- Added `AccessibleCredential` interface and `formatAvailableCredentials()` to format the block:
  ```
  ## Available credentials
  - github_token (yours, token)
  - close_fr (via Jonas, token)
  ```
- Extended `buildDynamicContext()` with optional `availableCredentials` param -- appended to dynamic context (not stable prefix) to preserve Anthropic prompt caching.

### `apps/api/src/pipeline/core-prompt.ts`
- Added `listAccessibleCredentials` to the existing `Promise.all` block in `buildCorePrompt()` with graceful error handling (logs and returns empty array on failure).
- Passed `accessibleCreds` into `buildDynamicContext()`.

## Key constraints respected
- **No credential values** in the prompt -- only names, types, and owner info
- **Dynamic context only** -- doesn't break Anthropic prompt cache hits
- **Graceful degradation** -- if the credentials query fails, the section is simply omitted
- **Zero credentials** -- section is not added when empty
- **Expired credentials** filtered out via `expires_at` check
- **Revoked grants** filtered out via `revoked_at IS NULL`
- Passes `pnpm typecheck` cleanly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4288f545-79b9-43e7-abe4-a4ba997dadcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4288f545-79b9-43e7-abe4-a4ba997dadcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

