### PR TITLE
docs: fix dashboard tech stack (Next.js → Vite), auth flow, and access role

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -19,8 +19,8 @@ aura/
 │   │       ├── memory/      # Extract, store, retrieve, consolidate
 │   │       ├── cron/        # Heartbeat, memory consolidation, email sync
 │   │       └── routes/      # API routes (Slack events, dashboard, chat)
-│   ├── dashboard/      # Admin UI (Next.js)
-│   │   └── src/app/
+│   ├── dashboard/      # Admin UI (Vite + React + TanStack Router)
+│   │   └── src/routes/
 │   │       ├── conversations/   # Conversation traces & threads
 │   │       ├── consumption/     # Token usage & cost tracking
 │   │       ├── memories/        # Memory browser
@@ -50,7 +50,7 @@ Slack Event → Vercel Function → Hono Router → Message Pipeline → LLM (Ve
                                                       ↕
                                               Tools (23 modules)
                                                       ↕
-                                              Admin Dashboard (Next.js)
+                                              Admin Dashboard (Vite + React)
 ```
 
 ## Message Pipeline

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -5,7 +5,7 @@ description: "Monitor and manage your Aura instance through the admin dashboard.
 
 # Dashboard
 
-The admin dashboard is a Next.js application that provides full visibility into Aura's operation. It's deployed alongside the API and accessible to workspace admins.
+The admin dashboard is a Vite + React application (with TanStack Router and TanStack Query) that provides full visibility into Aura's operation. It's deployed alongside the API as a single Vercel project and accessible to workspace admins.
 
 ## Pages
 
@@ -97,13 +97,13 @@ Configure instance behavior:
 
 ## Access & Authentication
 
-The dashboard uses Slack OAuth for login. Access requires the `admin` role (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var serves as a fallback for users without a database role.
+The dashboard uses Slack OAuth for login. Access requires at least the `power_user` role (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var serves as a fallback for users without a database role.
 
-### Auth Proxy
+### Slack OIDC
 
-Preview and branch deployments authenticate via an auth proxy flow. The production instance acts as the OAuth provider, and preview deployments redirect through it to obtain session tokens. This avoids needing to register separate OAuth redirect URLs for every preview deploy.
+Authentication is handled directly by the Hono API via Slack's OpenID Connect flow. The API exposes `/login` and `/callback` routes that handle the full OAuth cycle -- no proxy or intermediate redirects needed.
 
-The flow uses HMAC-SHA256 origin verification (via `DASHBOARD_SESSION_SECRET`) to ensure only legitimate deployments can request authentication. Short-lived transfer tokens (60s expiry) are used to pass credentials between origins, with strict validation to prevent token reuse as session tokens.
+The callback issues a session JWT (HS256, 30-day expiry) stored as an HTTP-only cookie. For preview and branch deployments, an origin allowlist (restricted to trusted domain suffixes like `.aurahq.ai` and `localhost`) prevents token theft via crafted redirect URLs.
 
 **Required env vars:** `DASHBOARD_SESSION_SECRET`, `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`.
 


### PR DESCRIPTION
Three P0 fixes for stale documentation after this week's merges:

**1. Dashboard tech stack: Next.js → Vite + TanStack Router**
PR #832 migrated the dashboard from Next.js to Vite + React + TanStack Router/Query. Both `dashboard.mdx` and `architecture.mdx` still said Next.js.

**2. Auth flow: proxy pattern → direct Slack OIDC**
PR #827 replaced the cross-deployment auth proxy (production → preview redirect with transfer tokens) with direct Slack OIDC handling in the Hono API. The Auth Proxy section in `dashboard.mdx` described the old removed flow.

**3. Access role: admin-only → power_user+**
The code in `auth.ts` has `ALLOWED_ROLES = ["admin", "power_user"]`, but docs said access "requires the admin role". Power users can access the dashboard.

Also fixes `src/app/` → `src/routes/` in the monorepo tree (architecture.mdx).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime code paths are modified.
> 
> **Overview**
> Updates docs to reflect the dashboard migration from **Next.js to Vite + React** (TanStack Router/Query) and the `src/app` → `src/routes` layout.
> 
> Rewrites the dashboard authentication section to describe **direct Slack OpenID Connect handled by the Hono API** (`/login` + `/callback`) issuing a session JWT cookie with an origin allowlist for preview deployments, and clarifies that dashboard access requires **`power_user` or `admin`** (with `AURA_ADMIN_USER_IDS` as fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638347986d0e11788eed489f075009ebde566039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->