### PR TITLE
docs: add entity system, fix stale people tools, update dashboard pages

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -21,6 +21,8 @@ Browse every conversation Aura has had. Each conversation shows:
 
 Filter by user, channel, date range, or search by content.
 
+The **Invocations** sub-tab (`/conversations/invocations`) shows each individual LLM invocation with its tool calls, token counts, and timing -- useful for debugging multi-step agent work.
+
 ### Consumption
 
 Track token usage and costs over time:
@@ -37,6 +39,8 @@ Browse and search Aura's extracted memories:
 - Filter by type (fact, decision, personal, relationship, sentiment, open_thread)
 - View related users and source conversations
 - Check relevance scores and decay status
+
+The **Entities** sub-tab (`/memories/entities`) lists resolved entities (people, companies, projects, technologies) that Aura has extracted from conversations. Each entity has a canonical name, type, alias list, and count of linked memories.
 
 ### Notes
 

--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -76,9 +76,23 @@ In addition to discrete memory facts, Aura retrieves full conversation threads f
 After every conversation turn, Aura extracts new memories:
 
 1. The recent messages are sent to Claude with a structured extraction prompt
-2. Claude identifies facts, decisions, sentiments, and open threads
+2. Claude identifies facts, decisions, sentiments, open threads, and entity mentions
 3. Each extraction is checked for duplicates against existing memories
 4. New memories are embedded and stored
+5. Extracted entities are resolved and linked to their memories (see below)
+
+## Entity Extraction & Resolution
+
+Alongside memory extraction, Aura identifies **entities** -- people, companies, projects, products, channels, and technologies -- mentioned in conversations. Each entity is resolved to a canonical record using a four-step cascade:
+
+1. **Exact canonical match** -- direct match against known entity names
+2. **Alias match** -- match against registered aliases (e.g. "Joan" → "Joan Rodriguez")
+3. **Fuzzy match** -- trigram similarity (>0.4 threshold) catches misspellings and variations
+4. **Create new** -- if no match is found, a new entity record is created
+
+Entities are linked to the memories that mention them via the `memory_entities` join table. This enables **entity-first retrieval**: when a query mentions a known entity, Aura finds all memories linked to that entity and merges them into the hybrid search results with an RRF boost, ensuring relevant context surfaces even when the exact wording differs.
+
+Entity types: `person`, `company`, `project`, `product`, `channel`, `technology`.
 
 ## Consolidation
 

--- a/content/docs/tools/people.mdx
+++ b/content/docs/tools/people.mdx
@@ -27,7 +27,6 @@ The people database feeds into every conversation:
 ## Tools
 
 - `get_person` — Look up a person's full profile by name or Slack ID
-- `search_people` — Find people by partial name, role, or team
 - `update_person` — Update profile fields (admin only)
 
 ## Privacy


### PR DESCRIPTION
## Changes

**P0 fix: Factually wrong tool reference**
- `tools/people.mdx`: Removed `search_people` from the tool list -- this tool doesn't exist in the codebase. Only `get_person` and `update_person` are real.

**P1: New features with zero docs**
- `memory-system.mdx`: Added new **Entity Extraction & Resolution** section documenting the entity resolve cascade (exact → alias → fuzzy → create new), entity-first retrieval with RRF boost, and supported entity types. Updated extraction steps to include entity mentions.
- `dashboard.mdx`: Documented the new **Invocations** sub-tab under Conversations and the new **Entities** sub-tab under Memories (added in 88ef270).

**Context**: The entity system landed in ba8a924 + ~10 follow-up commits. The `userProfiles → users` rename (957ef4a) already updated `permissions.mdx` in-tree -- no drift there.

Automated via `docs-maintenance` job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; main risk is minor confusion if URLs/tool names drift from the product.
> 
> **Overview**
> Adds documentation for the new **entity extraction/resolution** flow in `memory-system.mdx`, including the matching cascade, supported entity types, and how entity-linked memories are boosted during retrieval.
> 
> Updates `dashboard.mdx` to describe the new `Invocations` view under Conversations and the `Entities` view under Memories, and fixes `tools/people.mdx` by removing the non-existent `search_people` tool reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d12a19aeb3678c7e988e8c5c630582c28d5b4c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->