### PR TITLE
Add entity backfill script, detail page, and standardize env convention

### DIFF
--- a/.cursor/rules/aura-project.mdc
+++ b/.cursor/rules/aura-project.mdc
@@ -66,6 +66,25 @@ Every new table MUST include a `workspace_id` column for multi-workspace tenant 
 
 ## Environment Variables
 
+### Local env convention
+
+All environment variables live in **two files at the repo root** (both gitignored):
+
+- **`.env.local`** — local development (default for everything)
+- **`.env.production`** — production credentials (opt-in via `--prod` flag)
+
+No per-app `.env` files. No plain `.env` file. `.env.example` is the committed template.
+
+**All `pnpm` scripts** use `./scripts/env.sh` which loads `.env.local` by default. Pass `--prod` to any script to use `.env.production` instead:
+```bash
+pnpm db:migrate            # uses .env.local
+pnpm db:migrate --prod     # uses .env.production
+```
+
+Standalone scripts (backfills, sandbox builds) also support `--prod` via their own `dotenv` loading.
+
+### Vercel env vars (production)
+
 - **Add env vars via CLI**: `printf '%s' 'value' | npx --yes vercel@50.13.2 env add VAR_NAME production --scope realadvisor`
 - **Always use `printf '%s'`** to pipe values -- never `echo` (it adds trailing newlines that break Vercel).
 - **After adding env vars**, trigger a redeploy: either push a commit or run `npx --yes vercel@50.13.2 --prod --scope realadvisor`.

--- a/.cursor/skills/aura-deployment/SKILL.md
+++ b/.cursor/skills/aura-deployment/SKILL.md
@@ -94,11 +94,11 @@ After adding new scopes or events, reinstall the app at api.slack.com/apps.
 
 ## Direct API Investigation (POWERFUL)
 
-When debugging Slack/GitHub integration issues, **call APIs directly with curl** using tokens from `.env` to see raw responses. This bypasses Aura's code and reveals undocumented fields, hidden metadata, and the true API response shape.
+When debugging Slack/GitHub integration issues, **call APIs directly with curl** using tokens from `.env.local` to see raw responses. This bypasses Aura's code and reveals undocumented fields, hidden metadata, and the true API response shape.
 
-**Slack API** (source `.env` first for tokens):
+**Slack API** (source `.env.local` first for tokens):
 ```bash
-source .env && curl -s -X POST 'https://slack.com/api/<METHOD>' \
+source .env.local && curl -s -X POST 'https://slack.com/api/<METHOD>' \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"channel":"C...","limit":5}' | python3 -m json.tool
@@ -108,7 +108,7 @@ Use `$SLACK_USER_TOKEN` (xoxp-) for user-scoped methods (e.g. `search.messages`)
 
 **GitHub API**:
 ```bash
-source .env && curl -s -H "Authorization: token $GITHUB_TOKEN" \
+source .env.local && curl -s -H "Authorization: token $GITHUB_TOKEN" \
   'https://api.github.com/repos/realadvisor/aura/pulls' | python3 -m json.tool
 ```
 

--- a/.cursor/skills/aura-self-modification/SKILL.md
+++ b/.cursor/skills/aura-self-modification/SKILL.md
@@ -69,7 +69,7 @@ run_command("cat /home/user/aura/src/tools/slack.ts")
 When tools return unexpected results, call the API directly with curl:
 
 ```bash
-source .env && curl -s -X POST 'https://slack.com/api/conversations.history' \
+source .env.local && curl -s -X POST 'https://slack.com/api/conversations.history' \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"channel":"C088REN54FM","limit":5}' | python3 -m json.tool

--- a/.env.example
+++ b/.env.example
@@ -1,61 +1,81 @@
-# Neon PostgreSQL
+# ── Neon PostgreSQL ──────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+NEON_PROJECT_ID=your-neon-project-id
+PGDATABASE=neondb
+PGPASSWORD=your-pg-password
+PGUSER=neondb_owner
+POSTGRES_DATABASE=neondb
+POSTGRES_PASSWORD=your-pg-password
 
-# Slack
+# ── Vercel ───────────────────────────────────────────────────────────────────
+# Auto-provisioned by `vercel env pull` — short-lived JWT for AI Gateway OIDC
+VERCEL_OIDC_TOKEN=your-oidc-token
+
+# ── Slack ────────────────────────────────────────────────────────────────────
 SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_USER_TOKEN=xoxp-your-user-token
 SLACK_SIGNING_SECRET=your-signing-secret
-# Optional: user token for message search (requires search:read scope)
-# SLACK_USER_TOKEN=xoxp-your-user-token
+SLACK_CLIENT_ID=your-slack-client-id
+SLACK_CLIENT_SECRET=your-slack-client-secret
 
-# Models (provider/model format — routed through Vercel AI Gateway)
+# ── Models (provider/model format — routed through Vercel AI Gateway) ────────
 # See available models: https://ai-sdk.dev/docs/ai-sdk-providers/ai-gateway
 MODEL_MAIN=anthropic/claude-sonnet-4-20250514
 MODEL_FAST=anthropic/claude-haiku-4.5
 MODEL_EMBEDDING=openai/text-embedding-3-small
 
-# App config
+# ── App config ───────────────────────────────────────────────────────────────
 AURA_BOT_USER_ID=U_AURA_BOT_ID
 AURA_ADMIN_USER_IDS=U_YOUR_USER_ID
 LOG_LEVEL=info
-
-# Cron secret (to protect cron endpoints)
+PORT=3001
 CRON_SECRET=your-cron-secret
 
-# Web search (optional, free tier: 1000 searches/month)
-# TAVILY_API_KEY=tvly-your-api-key
+# ── Dashboard ────────────────────────────────────────────────────────────────
+DASHBOARD_API_SECRET=dev-secret-for-dashboard-chat
+DASHBOARD_SESSION_SECRET=your-session-secret
 
-# E2B sandbox (optional, for shell/code execution)
+# ── AI providers ─────────────────────────────────────────────────────────────
+ANTHROPIC_API_KEY=your-anthropic-api-key
+COHERE_API_KEY=your-cohere-api-key
+OPENAI_API_KEY=sk-proj-your-openai-api-key
+
+# ── E2B sandbox ──────────────────────────────────────────────────────────────
 # E2B_API_KEY=e2b_your-api-key
 # E2B_TEMPLATE_ID=your-template-id
 
-# GitHub (optional, for self-access and PRs)
-# GITHUB_TOKEN=github_pat_your-token
+# ── Google ───────────────────────────────────────────────────────────────────
+# BigQuery service account (base64 JSON)
+# GOOGLE_BQ_CREDENTIALS=base64-encoded-service-account-json
 
-# Vercel (optional, read-only — for self-diagnosing crashes via `vercel logs`)
-# VERCEL_TOKEN=your-vercel-token
-
-# Upstash Redis (shared rate limiting across serverless instances)
-# If using Vercel KV integration, these are set automatically:
-# KV_REST_API_URL=https://your-db.upstash.io
-# KV_REST_API_TOKEN=your-token
-# Otherwise, set the standalone Upstash env vars:
-# UPSTASH_REDIS_REST_URL=https://your-db.upstash.io
-# UPSTASH_REDIS_REST_TOKEN=your-upstash-token
-
-ANTHROPIC_API_KEY=your-anthropic-api-key
-
-# Cursor Cloud Agent (optional — tools degrade gracefully if unset)
-# CURSOR_API_KEY=key_your-cursor-api-key
-# CURSOR_WEBHOOK_SECRET=your-webhook-secret (if unset, webhook signature verification is skipped)
-
-# OpenAI (voice transcription)
-# OPENAI_API_KEY=sk-proj-your-openai-api-key
-
-# Gmail (OAuth2 for aura@realadvisor.com)
+# Gmail OAuth2
 # GOOGLE_EMAIL_CLIENT_ID=your-client-id
 # GOOGLE_EMAIL_CLIENT_SECRET=your-client-secret
-# GOOGLE_EMAIL_REFRESH_TOKEN=your-refresh-token (obtained via /api/oauth/google/callback)
+# GOOGLE_EMAIL_REFRESH_TOKEN=your-refresh-token
 # AURA_EMAIL_ADDRESS=aura@realadvisor.com
 
-# Claap (meeting recordings API)
+# ── Upstash Redis ────────────────────────────────────────────────────────────
+# KV_REST_API_URL=https://your-db.upstash.io
+# KV_REST_API_TOKEN=your-token
+
+# ── Credential encryption ────────────────────────────────────────────────────
+CREDENTIALS_KEY=your-credentials-encryption-key
+
+# ── ElevenLabs ───────────────────────────────────────────────────────────────
+# ELEVENLABS_API_KEY=your-elevenlabs-api-key
+
+# ── Cursor Cloud Agent ───────────────────────────────────────────────────────
+# CURSOR_API_KEY=key_your-cursor-api-key
+# CURSOR_WEBHOOK_SECRET=your-webhook-secret
+
+# ── GitHub ───────────────────────────────────────────────────────────────────
+# GITHUB_TOKEN=github_pat_your-token
+
+# ── Vercel CLI ───────────────────────────────────────────────────────────────
+# VERCEL_TOKEN=your-vercel-token
+
+# ── Web search ───────────────────────────────────────────────────────────────
+# TAVILY_API_KEY=tvly-your-api-key
+
+# ── Claap ────────────────────────────────────────────────────────────────────
 # CLAAP_API_KEY=your-claap-api-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,18 +32,27 @@ This is a pnpm workspace monorepo. Run `pnpm install` at the root.
 
 ## Database workflow
 ```bash
-pnpm db:generate    # generate migrations from schema changes
-pnpm db:migrate     # apply pending migrations
-pnpm db:push        # push schema directly (dev only)
-pnpm db:studio      # open Drizzle Studio
+pnpm db:generate            # generate migrations from schema changes
+pnpm db:migrate             # apply pending migrations (uses .env.local)
+pnpm db:migrate --prod      # apply pending migrations against production DB
+pnpm db:push                # push schema directly (dev only)
+pnpm db:studio              # open Drizzle Studio
 ```
+
+All `db:*` scripts use `./scripts/env.sh` which loads `.env.local` by default. Pass `--prod` to use `.env.production`.
+
+## Environment variables
+- **`.env.local`** at repo root — all local development env vars (gitignored)
+- **`.env.production`** at repo root — production credentials, opt-in via `--prod` (gitignored)
+- **`.env.example`** — committed template documenting all variables
+- No per-app `.env` files. No plain `.env` file.
+- Production env vars managed via Vercel CLI, some injected into sandbox at runtime
 
 ## Conventions
 - TypeScript strict mode
 - All tool functions return `{ ok: true, ... }` or `{ ok: false, error: "..." }`
 - Slack message formatting uses mrkdwn (not markdown)
 - ISO 8601 timestamps in user's timezone throughout
-- Environment variables configured in Vercel, some injected into sandbox at runtime
 - Import schema types via `import { ... } from "@aura/db/schema"`
 
 ## Tool documentation convention

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --env-file=.env.local --import tsx --watch src/index.ts",
+    "dev": "node --env-file=../../.env.local --import tsx --watch src/index.ts",
     "build": "tsc",
     "vercel-build": "pnpm --filter @aura/db db:migrate",
     "start": "node dist/index.js",
@@ -37,6 +37,7 @@
     "cron-parser": "^5.5.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "dotenv": "^17.3.1",
     "drizzle-orm": "^0.44.0",
     "e2b": "^2.12.1",
     "google-auth-library": "^10.5.0",

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -18,7 +18,7 @@ import { MODEL_DEFAULTS } from "./models.js";
  * change models from the Slack App Home without redeploying.
  *
  * When deployed on Vercel, auth is handled automatically via OIDC.
- * For local development, set VERCEL_AI_GATEWAY_API_KEY in .env.
+ * For local development, set VERCEL_AI_GATEWAY_API_KEY in .env.local.
  *
  * All model functions automatically include Anthropic fallback middleware:
  * if the gateway returns a GatewayAuthenticationError (credits depleted,

--- a/apps/api/src/routes/dashboard/entities.ts
+++ b/apps/api/src/routes/dashboard/entities.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { eq, desc, count, sql, ilike, and, type SQL } from "drizzle-orm";
-import { entities, entityAliases, memoryEntities } from "@aura/db/schema";
+import { entities, entityAliases, memoryEntities, memories } from "@aura/db/schema";
 import { db } from "../../db/client.js";
 import { logger } from "../../lib/logger.js";
 import { errorSchema, paginationQuerySchema, createDashboardApp } from "./schemas.js";
@@ -134,9 +134,15 @@ dashboardEntitiesApp.openapi(getEntityRoute, async (c) => {
       .select({
         memoryId: memoryEntities.memoryId,
         role: memoryEntities.role,
+        content: memories.content,
+        type: memories.type,
+        relevanceScore: memories.relevanceScore,
+        createdAt: memories.createdAt,
       })
       .from(memoryEntities)
-      .where(eq(memoryEntities.entityId, id));
+      .innerJoin(memories, eq(memories.id, memoryEntities.memoryId))
+      .where(eq(memoryEntities.entityId, id))
+      .orderBy(desc(memories.createdAt));
 
     return c.json({ ...entity, aliases, linkedMemories } as any, 200);
   } catch (error) {

--- a/apps/api/src/routes/dashboard/memories.ts
+++ b/apps/api/src/routes/dashboard/memories.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { eq, desc, count, inArray, sql } from "drizzle-orm";
-import { memories, users } from "@aura/db/schema";
+import { memories, users, memoryEntities, entities } from "@aura/db/schema";
 import { db } from "../../db/client.js";
 import { logger } from "../../lib/logger.js";
 import { errorSchema, idParamSchema, createDashboardApp } from "./schemas.js";
@@ -158,7 +158,19 @@ dashboardMemoriesApp.openapi(getMemoryRoute, async (c) => {
         .where(inArray(users.slackUserId, memory.relatedUserIds));
     }
 
-    return c.json({ ...memory, relatedUsers } as any, 200);
+    const linkedEntities = await db
+      .select({
+        entityId: memoryEntities.entityId,
+        role: memoryEntities.role,
+        canonicalName: entities.canonicalName,
+        type: entities.type,
+        description: entities.description,
+      })
+      .from(memoryEntities)
+      .innerJoin(entities, eq(entities.id, memoryEntities.entityId))
+      .where(eq(memoryEntities.memoryId, id));
+
+    return c.json({ ...memory, relatedUsers, linkedEntities } as any, 200);
   } catch (error) {
     logger.error("Failed to get memory", { error });
     return c.json({ error: "Failed to get memory" }, 500);

--- a/apps/api/src/scripts/backfill-entities.ts
+++ b/apps/api/src/scripts/backfill-entities.ts
@@ -1,0 +1,344 @@
+import { config } from "dotenv";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+import { sql } from "drizzle-orm";
+import { generateText, Output } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+import { entities, entityAliases, memoryEntities } from "@aura/db/schema";
+
+// Load env before importing db client (which reads DATABASE_URL at import time).
+// Pass --prod to use .env.production instead of .env.local.
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const isProd = process.argv.includes("--prod");
+const envFile = isProd ? ".env.production" : ".env.local";
+config({ path: resolve(repoRoot, envFile) });
+if (isProd) console.log("Using .env.production (--prod)");
+
+const { db } = await import("../db/client.js");
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const BATCH_SIZE = 50;
+const CONCURRENCY = 10;
+const WORKSPACE_ID = process.env.DEFAULT_WORKSPACE_ID || "default";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ANTHROPIC_API_KEY is required");
+  process.exit(1);
+}
+
+// ── LLM Setup ───────────────────────────────────────────────────────────────
+
+const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+const model = anthropic("claude-haiku-4-5-20251001");
+
+const extractionSchema = z.object({
+  results: z.array(
+    z.object({
+      memory_id: z.string(),
+      entities: z.array(
+        z.object({
+          name: z.string(),
+          type: z.enum([
+            "person",
+            "company",
+            "project",
+            "product",
+            "channel",
+            "technology",
+          ]),
+          role: z.enum(["subject", "object", "mentioned"]),
+        }),
+      ),
+    }),
+  ),
+});
+
+const SYSTEM_PROMPT = `Extract entity mentions from these memories. For each memory, return the entities mentioned with their type and role.
+
+Entity types: person, company, project, product, channel, technology
+Roles: subject (who/what the memory is primarily about), object (secondary entity), mentioned (just referenced)`;
+
+// ── Entity Resolution with In-Memory Cache ──────────────────────────────────
+
+const entityCache = new Map<string, string>();
+
+function cacheKey(type: string, name: string): string {
+  return `${type}:${name.toLowerCase().trim()}`;
+}
+
+type ResultRow = Record<string, any>;
+
+function extractRows(result: unknown): ResultRow[] {
+  return ((result as any).rows ?? result) as ResultRow[];
+}
+
+async function resolveEntityCached(
+  name: string,
+  type: string,
+): Promise<{ entityId: string; isNew: boolean }> {
+  const key = cacheKey(type, name);
+  const cached = entityCache.get(key);
+  if (cached) return { entityId: cached, isNew: false };
+
+  const lowerName = name.toLowerCase().trim();
+  if (!lowerName) throw new Error("Entity name cannot be empty");
+
+  // 1. Exact canonical match
+  const exactRows = extractRows(
+    await db.execute(sql`
+      SELECT id FROM entities
+      WHERE workspace_id = ${WORKSPACE_ID}
+        AND type = ${type}
+        AND lower(canonical_name) = ${lowerName}
+      LIMIT 1
+    `),
+  );
+  if (exactRows.length > 0) {
+    entityCache.set(key, exactRows[0].id);
+    return { entityId: exactRows[0].id, isNew: false };
+  }
+
+  // 2. Alias match
+  const aliasRows = extractRows(
+    await db.execute(sql`
+      SELECT e.id FROM entities e
+      JOIN entity_aliases ea ON e.id = ea.entity_id
+      WHERE ea.alias_lower = ${lowerName}
+        AND e.type = ${type}
+        AND e.workspace_id = ${WORKSPACE_ID}
+      LIMIT 1
+    `),
+  );
+  if (aliasRows.length > 0) {
+    entityCache.set(key, aliasRows[0].id);
+    return { entityId: aliasRows[0].id, isNew: false };
+  }
+
+  // 3. Trigram fuzzy match (>0.4 similarity)
+  const fuzzyRows = extractRows(
+    await db.execute(sql`
+      SELECT e.id FROM entities e
+      JOIN entity_aliases ea ON e.id = ea.entity_id
+      WHERE ea.alias_lower % ${lowerName}
+        AND e.type = ${type}
+        AND e.workspace_id = ${WORKSPACE_ID}
+        AND similarity(ea.alias_lower, ${lowerName}) > 0.4
+      ORDER BY similarity(ea.alias_lower, ${lowerName}) DESC
+      LIMIT 1
+    `),
+  );
+  if (fuzzyRows.length > 0) {
+    entityCache.set(key, fuzzyRows[0].id);
+    return { entityId: fuzzyRows[0].id, isNew: false };
+  }
+
+  // 4. Create new entity + alias
+  const [newEntity] = await db
+    .insert(entities)
+    .values({
+      workspaceId: WORKSPACE_ID,
+      type,
+      canonicalName: name,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  if (newEntity) {
+    // alias_lower is GENERATED ALWAYS — only provide alias
+    await db
+      .insert(entityAliases)
+      .values({
+        entityId: newEntity.id,
+        alias: name,
+        source: "backfill",
+      })
+      .onConflictDoNothing();
+
+    entityCache.set(key, newEntity.id);
+    return { entityId: newEntity.id, isNew: true };
+  }
+
+  // Conflict on insert — another row exists, retry exact match
+  const retryRows = extractRows(
+    await db.execute(sql`
+      SELECT id FROM entities
+      WHERE workspace_id = ${WORKSPACE_ID}
+        AND type = ${type}
+        AND lower(canonical_name) = ${lowerName}
+      LIMIT 1
+    `),
+  );
+  if (retryRows.length > 0) {
+    entityCache.set(key, retryRows[0].id);
+    return { entityId: retryRows[0].id, isNew: false };
+  }
+
+  throw new Error(`Failed to create or find entity: ${name} (${type})`);
+}
+
+// ── Concurrency Pool ─────────────────────────────────────────────────────────
+
+async function pool<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let idx = 0;
+  async function worker() {
+    while (idx < items.length) {
+      const i = idx++;
+      await fn(items[i]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+}
+
+// ── Process a single batch ───────────────────────────────────────────────────
+
+async function processBatch(
+  batch: Array<{ id: string; content: string }>,
+  batchIdx: number,
+  totalBatches: number,
+): Promise<{ newEntities: number; linked: number; errors: number }> {
+  try {
+    const memoriesPayload = batch.map((m) => ({
+      id: m.id,
+      content: m.content,
+    }));
+
+    const { output: result } = await generateText({
+      model,
+      output: Output.object({ schema: extractionSchema }),
+      system: SYSTEM_PROMPT,
+      prompt: `Memories:\n${JSON.stringify(memoriesPayload)}`,
+    });
+
+    if (!result) {
+      console.warn(
+        `[batch ${batchIdx + 1}/${totalBatches}] LLM returned no output, skipping`,
+      );
+      return { newEntities: 0, linked: 0, errors: 1 };
+    }
+
+    let batchNewEntities = 0;
+    let batchLinked = 0;
+
+    const memResults = result.results.filter(
+      (r) => r.entities && r.entities.length > 0,
+    );
+
+    const allLinks: Array<{
+      memoryId: string;
+      entityId: string;
+      role: string;
+    }> = [];
+
+    await Promise.all(
+      memResults.map(async (memResult) => {
+        const resolved = await Promise.all(
+          memResult.entities.map(async (entity) => {
+            try {
+              const { entityId, isNew } = await resolveEntityCached(
+                entity.name,
+                entity.type,
+              );
+              if (isNew) batchNewEntities++;
+              return { memoryId: memResult.memory_id, entityId, role: entity.role };
+            } catch {
+              return null;
+            }
+          }),
+        );
+
+        for (const link of resolved) {
+          if (link) allLinks.push(link);
+        }
+      }),
+    );
+
+    if (allLinks.length > 0) {
+      // Insert in chunks of 500 to stay within Postgres parameter limits
+      for (let i = 0; i < allLinks.length; i += 500) {
+        await db
+          .insert(memoryEntities)
+          .values(allLinks.slice(i, i + 500))
+          .onConflictDoNothing();
+      }
+      batchLinked = allLinks.length;
+    }
+
+    console.log(
+      `[batch ${batchIdx + 1}/${totalBatches}] processed ${batch.length} memories, ` +
+        `created ${batchNewEntities} new entities, linked ${batchLinked} memory_entities`,
+    );
+
+    return { newEntities: batchNewEntities, linked: batchLinked, errors: 0 };
+  } catch (err) {
+    console.error(
+      `[batch ${batchIdx + 1}/${totalBatches}] ERROR: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { newEntities: 0, linked: 0, errors: 1 };
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== Entity Backfill Script ===\n");
+  console.log(`Concurrency: ${CONCURRENCY} parallel batches of ${BATCH_SIZE}\n`);
+
+  const unlinked = extractRows(
+    await db.execute(sql`
+      SELECT m.id, m.content
+      FROM memories m
+      WHERE NOT EXISTS (
+        SELECT 1 FROM memory_entities me WHERE me.memory_id = m.id
+      )
+      ORDER BY m.created_at
+    `),
+  ) as Array<{ id: string; content: string }>;
+
+  console.log(`Found ${unlinked.length} unlinked memories`);
+  if (unlinked.length === 0) {
+    console.log("Nothing to do — all memories already have entity links.");
+    return;
+  }
+
+  const batches: Array<{ items: Array<{ id: string; content: string }>; idx: number }> = [];
+  const totalBatches = Math.ceil(unlinked.length / BATCH_SIZE);
+  for (let i = 0; i < totalBatches; i++) {
+    batches.push({
+      items: unlinked.slice(i * BATCH_SIZE, (i + 1) * BATCH_SIZE),
+      idx: i,
+    });
+  }
+
+  let totalNewEntities = 0;
+  let totalLinked = 0;
+  let totalErrors = 0;
+  const startTime = Date.now();
+
+  await pool(batches, CONCURRENCY, async (batch) => {
+    const result = await processBatch(batch.items, batch.idx, totalBatches);
+    totalNewEntities += result.newEntities;
+    totalLinked += result.linked;
+    totalErrors += result.errors;
+  });
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`\n=== Summary ===`);
+  console.log(`Elapsed: ${elapsed}s`);
+  console.log(`Memories processed: ${unlinked.length}`);
+  console.log(`New entities created: ${totalNewEntities}`);
+  console.log(`Memory-entity links created: ${totalLinked}`);
+  console.log(`Entity cache size: ${entityCache.size}`);
+  console.log(`Batches with errors: ${totalErrors}`);
+}
+
+main().catch((err) => {
+  console.error("Script failed:", err);
+  process.exit(1);
+});

--- a/apps/dashboard/src/components/sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar.tsx
@@ -65,7 +65,7 @@ function NavContent({ onClose, showLabels }: { onClose?: () => void; showLabels?
                   : "text-muted-foreground",
               )}
             >
-              <item.icon className="h-[24px] w-[24px] shrink-0" strokeWidth="1.75" />
+              <item.icon className="h-[22px] w-[22px] shrink-0" strokeWidth="1.75" />
               {showLabels && item.label}
             </Link>
           );

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ErrorsIdRouteImport } from "./routes/errors/$id"
 import { Route as CredentialsIdRouteImport } from "./routes/credentials/$id"
 import { Route as ConversationsInvocationsRouteImport } from "./routes/conversations/invocations"
 import { Route as ConversationsIdRouteImport } from "./routes/conversations/$id"
+import { Route as MemoriesEntitiesIdRouteImport } from "./routes/memories/entities_.$id"
 import { Route as ConversationsThreadsChannelIdThreadTsRouteImport } from "./routes/conversations/threads.$channelId.$threadTs"
 
 const UnauthorizedRoute = UnauthorizedRouteImport.update({
@@ -150,6 +151,11 @@ const ConversationsIdRoute = ConversationsIdRouteImport.update({
   path: "/conversations/$id",
   getParentRoute: () => rootRouteImport,
 } as any)
+const MemoriesEntitiesIdRoute = MemoriesEntitiesIdRouteImport.update({
+  id: "/memories/entities_/$id",
+  path: "/memories/entities/$id",
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ConversationsThreadsChannelIdThreadTsRoute =
   ConversationsThreadsChannelIdThreadTsRouteImport.update({
     id: "/conversations/threads/$channelId/$threadTs",
@@ -181,6 +187,7 @@ export interface FileRoutesByFullPath {
   "/resources/": typeof ResourcesIndexRoute
   "/settings/": typeof SettingsIndexRoute
   "/users/": typeof UsersIndexRoute
+  "/memories/entities/$id": typeof MemoriesEntitiesIdRoute
   "/conversations/threads/$channelId/$threadTs": typeof ConversationsThreadsChannelIdThreadTsRoute
 }
 export interface FileRoutesByTo {
@@ -207,6 +214,7 @@ export interface FileRoutesByTo {
   "/resources": typeof ResourcesIndexRoute
   "/settings": typeof SettingsIndexRoute
   "/users": typeof UsersIndexRoute
+  "/memories/entities/$id": typeof MemoriesEntitiesIdRoute
   "/conversations/threads/$channelId/$threadTs": typeof ConversationsThreadsChannelIdThreadTsRoute
 }
 export interface FileRoutesById {
@@ -234,6 +242,7 @@ export interface FileRoutesById {
   "/resources/": typeof ResourcesIndexRoute
   "/settings/": typeof SettingsIndexRoute
   "/users/": typeof UsersIndexRoute
+  "/memories/entities_/$id": typeof MemoriesEntitiesIdRoute
   "/conversations/threads/$channelId/$threadTs": typeof ConversationsThreadsChannelIdThreadTsRoute
 }
 export interface FileRouteTypes {
@@ -262,6 +271,7 @@ export interface FileRouteTypes {
     | "/resources/"
     | "/settings/"
     | "/users/"
+    | "/memories/entities/$id"
     | "/conversations/threads/$channelId/$threadTs"
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -288,6 +298,7 @@ export interface FileRouteTypes {
     | "/resources"
     | "/settings"
     | "/users"
+    | "/memories/entities/$id"
     | "/conversations/threads/$channelId/$threadTs"
   id:
     | "__root__"
@@ -314,6 +325,7 @@ export interface FileRouteTypes {
     | "/resources/"
     | "/settings/"
     | "/users/"
+    | "/memories/entities_/$id"
     | "/conversations/threads/$channelId/$threadTs"
   fileRoutesById: FileRoutesById
 }
@@ -341,6 +353,7 @@ export interface RootRouteChildren {
   ResourcesIndexRoute: typeof ResourcesIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
   UsersIndexRoute: typeof UsersIndexRoute
+  MemoriesEntitiesIdRoute: typeof MemoriesEntitiesIdRoute
   ConversationsThreadsChannelIdThreadTsRoute: typeof ConversationsThreadsChannelIdThreadTsRoute
 }
 
@@ -507,6 +520,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof ConversationsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/memories/entities_/$id": {
+      id: "/memories/entities_/$id"
+      path: "/memories/entities/$id"
+      fullPath: "/memories/entities/$id"
+      preLoaderRoute: typeof MemoriesEntitiesIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/conversations/threads/$channelId/$threadTs": {
       id: "/conversations/threads/$channelId/$threadTs"
       path: "/conversations/threads/$channelId/$threadTs"
@@ -541,6 +561,7 @@ const rootRouteChildren: RootRouteChildren = {
   ResourcesIndexRoute: ResourcesIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,
   UsersIndexRoute: UsersIndexRoute,
+  MemoriesEntitiesIdRoute: MemoriesEntitiesIdRoute,
   ConversationsThreadsChannelIdThreadTsRoute:
     ConversationsThreadsChannelIdThreadTsRoute,
 }

--- a/apps/dashboard/src/routes/memories/$id.tsx
+++ b/apps/dashboard/src/routes/memories/$id.tsx
@@ -4,11 +4,20 @@ import { apiGet, apiPatch } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { DetailSkeleton } from "@/components/page-skeleton";
-import { formatDate } from "@/lib/utils";
+import { formatDate, truncate } from "@/lib/utils";
 import { useState } from "react";
 import { MarkdownContent } from "@/components/ui/markdown";
 import { ArrowLeft, Save, Pencil, X } from "lucide-react";
+
+interface LinkedEntity {
+  entityId: string;
+  role: string | null;
+  canonicalName: string;
+  type: string;
+  description: string | null;
+}
 
 interface MemoryDetail {
   id: string;
@@ -20,6 +29,7 @@ interface MemoryDetail {
   sourceId: string | null;
   createdAt: string;
   relatedUsers: { slackUserId: string; displayName: string }[];
+  linkedEntities: LinkedEntity[];
 }
 
 function MemoryDetailPage() {
@@ -181,6 +191,42 @@ function MemoryDetailPage() {
             </CardContent>
           </Card>
         </div>
+      )}
+
+      {(memory.linkedEntities ?? []).length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Linked Entities ({memory.linkedEntities.length})</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="w-[90px]">Type</TableHead>
+                  <TableHead className="w-[80px]">Role</TableHead>
+                  <TableHead>Description</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {memory.linkedEntities.map((e) => (
+                  <TableRow key={e.entityId}>
+                    <TableCell className="font-medium">
+                      <Link to="/memories/entities/$id" params={{ id: e.entityId }} className="hover:underline">
+                        {e.canonicalName}
+                      </Link>
+                    </TableCell>
+                    <TableCell><Badge variant="secondary">{e.type}</Badge></TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{e.role ?? "—"}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {e.description ? truncate(e.description, 60) : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/apps/dashboard/src/routes/memories/entities.tsx
+++ b/apps/dashboard/src/routes/memories/entities.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { apiGet } from "@/lib/api";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -119,7 +119,9 @@ function EntitiesPage() {
               entities.map((entity) => (
                 <TableRow key={entity.id}>
                   <TableCell className="font-medium">
-                    {entity.canonicalName}
+                    <Link to="/memories/entities/$id" params={{ id: entity.id }} className="hover:underline">
+                      {entity.canonicalName}
+                    </Link>
                     {entity.slackUserId && (
                       <span className="ml-1.5 text-xs text-muted-foreground font-mono">{entity.slackUserId}</span>
                     )}

--- a/apps/dashboard/src/routes/memories/entities_.$id.tsx
+++ b/apps/dashboard/src/routes/memories/entities_.$id.tsx
@@ -1,0 +1,148 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { DetailSkeleton } from "@/components/page-skeleton";
+import { formatDate, truncate } from "@/lib/utils";
+import { ArrowLeft } from "lucide-react";
+
+interface LinkedMemory {
+  memoryId: string;
+  role: string | null;
+  content: string;
+  type: string;
+  relevanceScore: number;
+  createdAt: string;
+}
+
+interface EntityAlias {
+  id: string;
+  alias: string;
+  source: string | null;
+}
+
+interface EntityDetail {
+  id: string;
+  type: string;
+  canonicalName: string;
+  description: string | null;
+  slackUserId: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  aliases: EntityAlias[];
+  linkedMemories: LinkedMemory[];
+}
+
+function EntityDetailPage() {
+  const { id } = Route.useParams();
+  const { data: entity, isLoading, error } = useQuery({
+    queryKey: ["entities", id],
+    queryFn: () => apiGet<EntityDetail>(`/entities/${id}`),
+  });
+
+  if (isLoading) return <DetailSkeleton />;
+  if (error) return <div className="text-destructive text-sm">Failed to load entity: {error.message}</div>;
+  if (!entity) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon-sm" asChild>
+          <Link to="/memories/entities" search={{ search: undefined, type: undefined, page: undefined }}>
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <h1 className="text-lg font-semibold tracking-tight flex-1">{entity.canonicalName}</h1>
+        <Badge variant="secondary">{entity.type}</Badge>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Description</CardTitle></CardHeader>
+          <CardContent>
+            <span className="text-sm">{entity.description || "—"}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Slack User</CardTitle></CardHeader>
+          <CardContent>
+            <span className="text-sm font-mono">{entity.slackUserId || "—"}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Created</CardTitle></CardHeader>
+          <CardContent>
+            <span className="text-sm">{formatDate(entity.createdAt)}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Updated</CardTitle></CardHeader>
+          <CardContent>
+            <span className="text-sm">{formatDate(entity.updatedAt)}</span>
+          </CardContent>
+        </Card>
+      </div>
+
+      {entity.aliases.length > 0 && (
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Aliases ({entity.aliases.length})</CardTitle></CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-1.5">
+              {entity.aliases.map((a) => (
+                <Badge key={a.id} variant="outline">{a.alias}</Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Linked Memories ({entity.linkedMemories.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Content</TableHead>
+                <TableHead className="w-[90px]">Type</TableHead>
+                <TableHead className="w-[80px]">Role</TableHead>
+                <TableHead className="w-[80px]">Relevance</TableHead>
+                <TableHead className="w-[160px]">Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entity.linkedMemories.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-muted-foreground py-8">No linked memories</TableCell>
+                </TableRow>
+              ) : (
+                entity.linkedMemories.map((m) => (
+                  <TableRow key={m.memoryId}>
+                    <TableCell>
+                      <Link to="/memories/$id" params={{ id: m.memoryId }} className="hover:underline">
+                        {truncate(m.content, 80)}
+                      </Link>
+                    </TableCell>
+                    <TableCell><Badge variant="secondary">{m.type}</Badge></TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{m.role ?? "—"}</TableCell>
+                    <TableCell className="text-sm">{m.relevanceScore?.toFixed(2) ?? "—"}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{formatDate(m.createdAt)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/memories/entities_/$id")({
+  component: EntityDetailPage,
+});

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "prepare": "husky",
     "dev": "pnpm --filter aura-api --filter aura-dashboard --parallel dev",
     "typecheck": "pnpm --filter aura-api typecheck && pnpm --filter aura-dashboard typecheck",
-    "db:generate": "pnpm --filter @aura/db db:generate",
-    "db:migrate": "set -a && . ./.env.local && set +a && pnpm --filter @aura/db db:migrate",
-    "db:push": "pnpm --filter @aura/db db:push",
-    "db:studio": "pnpm --filter @aura/db db:studio"
+    "db:generate": "./scripts/env.sh pnpm --filter @aura/db db:generate",
+    "db:migrate": "./scripts/env.sh pnpm --filter @aura/db db:migrate",
+    "db:push": "./scripts/env.sh pnpm --filter @aura/db db:push",
+    "db:studio": "./scripts/env.sh pnpm --filter @aura/db db:studio"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       date-fns-tz:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@4.1.0)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
       drizzle-orm:
         specifier: ^0.44.0
         version: 0.44.7(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -33,7 +33,7 @@ pnpm --filter aura-sandbox build
 pnpm --filter aura-sandbox build:prod
 ```
 
-Requires `E2B_API_KEY` in the root `.env` file or as an environment variable.
+Requires `E2B_API_KEY` in the root `.env.local` file or as an environment variable.
 
 After the build, copy the `Template ID` from the output and set:
 ```

--- a/sandbox/build.ts
+++ b/sandbox/build.ts
@@ -6,13 +6,13 @@
  *   pnpm --filter aura-sandbox build:prod     # production
  *
  * Reads e2b.Dockerfile as the single source of truth via fromDockerfile().
- * Requires E2B_API_KEY in .env or environment.
+ * Requires E2B_API_KEY in .env.local or environment.
  */
 import { config } from "dotenv";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-config({ path: resolve(__dirname, "..", ".env") });
+config({ path: resolve(__dirname, "..", ".env.local") });
 
 import { Template, defaultBuildLogger } from "e2b";
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Load env and run a command. Pass --prod anywhere for .env.production.
+#
+# Usage:
+#   ./scripts/env.sh <command>          # loads .env.local
+#   ./scripts/env.sh --prod <command>   # loads .env.production
+#   pnpm db:migrate                     # loads .env.local (via package.json)
+#   pnpm db:migrate --prod              # loads .env.production
+
+ENV_FILE=".env.local"
+CMD=""
+for arg in "$@"; do
+  case "$arg" in
+    --prod) ENV_FILE=".env.production" ;;
+    *) CMD="${CMD:+$CMD }\"$arg\"" ;;
+  esac
+done
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "error: $ENV_FILE not found (run from repo root)" >&2
+  exit 1
+fi
+
+set -a; . "./$ENV_FILE"; set +a
+eval $CMD


### PR DESCRIPTION
## Summary

- **Parallelized entity backfill script** — extracts entities from unlinked memories using 10 concurrent LLM batches (Claude Haiku) with parallel entity resolution and bulk inserts, dramatically faster than sequential processing
- **Entity detail dashboard page** — new `/memories/entities/:id` route showing entity metadata, aliases, and a linked memories table with content previews; entity names are now clickable throughout the dashboard
- **Enriched API routes** — entity detail endpoint returns joined memory data (content, type, relevance, date); memory detail endpoint returns linked entities with canonical names and types
- **Standardized env convention** — new `scripts/env.sh` helper loads `.env.local` by default or `.env.production` with `--prod`; all root `pnpm db:*` scripts, docs (CLAUDE.md, cursor rules, skills), sandbox build, and `.env.example` updated to match

## Test plan

- [ ] Run `npx tsx apps/api/src/scripts/backfill-entities.ts` and verify parallel batch processing completes
- [ ] Open entity list in dashboard, click an entity name → detail page loads with aliases and linked memories
- [ ] Open a memory detail page → linked entities table renders with clickable names
- [ ] Run `pnpm db:migrate` and `pnpm db:migrate --prod` to verify `scripts/env.sh` loads the correct env file
- [ ] Run `pnpm typecheck` — passes cleanly


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a parallelized backfill that writes `entities`/`memory_entities` and expands dashboard API responses, so mistakes could create noisy/incorrect links or increase query payload sizes. Env loading changes also affect local/prod script behavior, but are mostly additive and documented.
> 
> **Overview**
> Adds an LLM-driven `backfill-entities.ts` script to populate `entities`, `entity_aliases`, and `memory_entities` for memories missing links, with batching/concurrency, fuzzy resolution, and `--prod` support for running against production.
> 
> Expands dashboard APIs so entity detail now returns joined memory fields (content/type/relevance/createdAt) and memory detail returns linked entity metadata, enabling a new dashboard entity detail route (`/memories/entities/$id`) and making entity names clickable from the entity list and memory detail page.
> 
> Standardizes environment handling around repo-root `.env.local`/`.env.production` by adding `scripts/env.sh`, updating root `db:*` scripts to use it, adjusting API dev env-file path, updating sandbox build to read `.env.local`, and refreshing docs/`.env.example` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ae25aa1543b5c954ab354467a5c2ac12affceef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->