### PR TITLE
improve: entity summary quality — type-specific prompts, importance-ordered backfill

### DIFF
--- a/apps/api/src/memory/entity-summaries.ts
+++ b/apps/api/src/memory/entity-summaries.ts
@@ -9,20 +9,6 @@ import { logger } from "../lib/logger.js";
 const MAX_MEMORIES_PER_ENTITY = 200;
 const DELAY_BETWEEN_CALLS_MS = 200;
 
-/** Priority order: high-value entity types first, then by memory count */
-const TYPE_PRIORITY: Record<string, number> = {
-  person: 0,
-  company: 1,
-  channel: 2,
-  technology: 3,
-  product: 4,
-  project: 5,
-};
-
-function getTypePriority(type: string): number {
-  return TYPE_PRIORITY[type] ?? 99;
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
**Problem:** Current summaries are too verbose (500-800 chars), don't differentiate by entity type, and the backfill processes alphabetically — so all projects get summarized before any person or company entities.

**Changes:**

### Prompt overhaul
- **Type-specific system prompts** for person, company, channel, technology, product, project — each with focused guidance on what to include/skip
- **Hard 2-3 sentence max** constraint (down from 'max 200 words')
- **Closed projects get ONE sentence** ('done, merged via PR #X') instead of a full writeup
- **No filler** — starts directly with the most important fact
- **Specifics required** — names, numbers, dates when available

### Ordering overhaul
- **Type priority:** person → company → channel → technology → product → project
- **Within type:** most-referenced entities first (by memory_count DESC)
- The highest-retrieval-impact entities (people, companies) now get summarized first instead of last

### No schema changes, no migration needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the LLM prompting and the regeneration ordering for entity summaries, which will materially alter stored `entities.summary` output and the load pattern of the summarization cron/backfill. New SQL grouping/ordering by `memory_count` and `type` could impact performance or prioritization if entity types are unexpected.
> 
> **Overview**
> Entity summary generation now uses **type-specific system prompts** (e.g. `person`, `company`, `project`) with stricter guidance, including a hard *2–3 sentence* constraint and special handling for completed projects.
> 
> The stale-summary regeneration query was rewritten to **prioritize by entity type** (person→company→…→project) and then by **linked `memory_count` descending**, so high-impact entities are summarized first; logging now includes memory counts for better visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a5ef2d038720a8dbd152e9215146f699dc26439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->