### PR TITLE
fix: auto-build @aura/db to prevent stale dist + show entity summary in dashboard

### DIFF
--- a/apps/dashboard/src/routes/memories/entities_.$id.tsx
+++ b/apps/dashboard/src/routes/memories/entities_.$id.tsx
@@ -30,6 +30,8 @@ interface EntityDetail {
   canonicalName: string;
   description: string | null;
   slackUserId: string | null;
+  summary: string | null;
+  summaryUpdatedAt: string | null;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -86,6 +88,24 @@ function EntityDetailPage() {
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm">Summary</CardTitle>
+            {entity.summaryUpdatedAt && (
+              <span className="text-xs text-muted-foreground">
+                Updated {formatDate(entity.summaryUpdatedAt)}
+              </span>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground">
+            {entity.summary || "No summary generated yet"}
+          </p>
+        </CardContent>
+      </Card>
 
       {entity.aliases.length > 0 && (
         <Card>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "prepare": "husky",
-    "dev": "pnpm --filter aura-api --filter aura-dashboard --parallel dev",
+    "dev": "pnpm --filter @aura/db build && pnpm --filter aura-api --filter aura-dashboard --parallel dev",
     "typecheck": "pnpm --filter aura-api typecheck && pnpm --filter aura-dashboard typecheck",
     "db:generate": "./scripts/env.sh pnpm --filter @aura/db db:generate",
     "db:migrate": "./scripts/env.sh pnpm --filter @aura/db db:migrate",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
     }
   },
   "scripts": {
+    "prepare": "tsc",
     "build": "tsc",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/migrate.ts",


### PR DESCRIPTION
## Summary

- **Fix stale `@aura/db` dist**: Added `"prepare": "tsc"` to `packages/db/package.json` so `dist/` auto-rebuilds on `pnpm install`. Also prefixed the root `dev` script with `pnpm --filter @aura/db build` so the schema is always fresh when starting dev.
- **Show entity summary in dashboard**: Added the `summary` and `summaryUpdatedAt` fields to the entity detail page. The summary card always renders — shows the text when available, or "No summary generated yet" when null.

## Context

The `@aura/db` package exports compiled JS from `dist/`, but schema changes weren't triggering a rebuild. This caused silent failures: Drizzle would generate queries with empty `SET` clauses or reference columns missing from the compiled schema. These changes ensure the build is always up to date in common workflows.

## Test plan

- [ ] `pnpm install` at repo root triggers `@aura/db` build automatically
- [ ] `pnpm dev` builds `@aura/db` before starting API and dashboard
- [ ] Entity detail page shows "No summary generated yet" for entities without summaries
- [ ] Entity detail page shows summary text + "Updated ..." date for entities with summaries

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI adds two optional fields to an entity detail view, and the rest is build-script wiring to reduce stale generated `@aura/db` artifacts.
> 
> **Overview**
> The dashboard entity detail page now requests and renders `summary` and `summaryUpdatedAt`, always showing a new **Summary** card with a fallback message when no summary exists.
> 
> Dev workflows now ensure `@aura/db` is compiled before use: the root `dev` script builds the package first, and `packages/db` adds a `prepare` script to run `tsc` on install to avoid stale `dist/` exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c255204fdadc354cfe3d8f1202fb95d219e23be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->