### PR TITLE
docs: add temporal lifecycle to memory system docs

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -42,6 +42,14 @@ CREATE TABLE memories (
   search_vector tsvector GENERATED ALWAYS AS (
     to_tsvector('english', coalesce(content, ''))
   ) STORED,
+  -- Temporal lifecycle (added v0.55)
+  status memory_status NOT NULL DEFAULT 'current',
+  confidence REAL DEFAULT 0.8,
+  valid_from TIMESTAMPTZ,
+  valid_until TIMESTAMPTZ,
+  supersedes_memory_id UUID REFERENCES memories(id),
+  superseded_at TIMESTAMPTZ,
+  superseded_by_memory_id UUID,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
@@ -135,12 +143,42 @@ Each entity accumulates a **compiled summary** -- a dossier that distills everyt
 
 Entity summaries sit above individual memories in the prompt hierarchy because they represent consolidated knowledge rather than isolated facts.
 
+## Temporal Lifecycle
+
+Every memory has a lifecycle governed by its `status` field:
+
+| Status | Meaning |
+|--------|---------|
+| `current` | Active and used in retrieval |
+| `superseded` | Replaced by a newer memory (excluded from retrieval) |
+| `disputed` | Contradicted but not yet resolved (still surfaces in retrieval) |
+| `archived` | Manually archived, excluded from retrieval |
+| `deleted` | Soft-deleted, excluded from everything |
+
+### Confidence scores
+
+Each memory carries a `confidence` score (0.0 -- 1.0, default 0.8) representing how certain the extraction is. Future retrieval and consolidation logic can use this to rank conflicting memories.
+
+### Temporal validity
+
+Memories can have `valid_from` and `valid_until` timestamps to represent time-bounded facts. For example, "Joan is on vacation until March 15" gets a `valid_until` of March 15. By default, `valid_from` is set to the memory's creation time.
+
+### Supersession chains
+
+When a new memory replaces an old one (e.g., "the project deadline moved from April to May"), the old memory is marked `superseded` with:
+- `superseded_at` -- when it was superseded
+- `superseded_by_memory_id` -- which memory replaced it
+
+The new memory gets `supersedes_memory_id` pointing back to the old one. This creates a traceable chain of how facts evolved over time.
+
+Retrieval filters to `status IN ('current', 'disputed')` -- superseded and archived memories are automatically excluded.
+
 ## Consolidation
 
 A nightly consolidation job (4 AM UTC) maintains memory quality:
 
-- **Decay** — relevance scores decrease by 0.5% per day (~50% after 138 days)
-- **Merge** — memories with >95% cosine similarity are consolidated
+- **Decay** — relevance scores decrease by 0.5% per day (~50% after 138 days). Only applies to `current` memories.
+- **Merge** — memories with >95% cosine similarity are consolidated. The loser is marked `superseded` with a proper supersession chain linking to the winner.
 - **Strengthen** — frequently accessed memories get relevance boosts
 - **Expire** — `open_thread` memories are resolved or aged out
 - **Entity summaries** — regenerate summaries for entities with new linked memories since last run


### PR DESCRIPTION
Documents PR #861 (temporal lifecycle — status, valid_during, confidence, supersession chain).

### Changes
- **Schema**: added 7 new columns (status, confidence, valid_from, valid_until, supersedes_memory_id, superseded_at, superseded_by_memory_id) to the documented CREATE TABLE
- **New section**: 'Temporal Lifecycle' covering status enum, confidence scores, temporal validity, and supersession chains
- **Updated section**: Consolidation now documents status-aware decay (only current memories) and supersession-based merge (loser gets proper status transition)

Automated docs maintenance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates with no runtime or schema changes applied in code. Main risk is minor confusion if the documented fields/behavior diverge from the actual implementation.
> 
> **Overview**
> Adds documentation for a **temporal lifecycle** on memories, including a `status` model (`current`, `superseded`, `disputed`, `archived`, `deleted`), `confidence` scoring, time-bounded validity (`valid_from`/`valid_until`), and supersession chains.
> 
> Updates the documented `memories` table schema to include the new lifecycle columns and clarifies consolidation behavior so **decay only applies to `current` memories** and **merge marks the losing memory as `superseded` with proper linkage**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 933fc42bfb8795db39995af9616af58c6356d42c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->