### PR TITLE
feat: add Grok 4.20 Multi-Agent Beta to MAIN_MODELS

### DIFF
--- a/apps/api/src/lib/models.ts
+++ b/apps/api/src/lib/models.ts
@@ -15,6 +15,7 @@ export const MAIN_MODELS: ModelOption[] = [
   { value: "google/gemini-3-pro-preview", label: "Gemini 3 Pro" },
   { value: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   { value: "xai/grok-4.20-reasoning-beta", label: "Grok 4.20 Beta" },
+  { value: "xai/grok-4.20-multi-agent-beta", label: "Grok 4.20 Multi-Agent" },
   { value: "xai/grok-4", label: "Grok 4" },
   { value: "xai/grok-4.1-fast-reasoning", label: "Grok 4.1 Fast" },
   { value: "xai/grok-4-fast-reasoning", label: "Grok 4 Fast" },


### PR DESCRIPTION
## What

Adds `xai/grok-4.20-multi-agent-beta` to the MAIN_MODELS dropdown in App Home.

## Why

This model became available on Vercel AI Gateway on 03/11/2026 but was missing from Aura's model selector. It's xAI's multi-agent research model where multiple agents collaborate in parallel for deep research tasks.

**Specs:** 2M context, $2/M input, $6/M output, 3.3s latency, 1232 tps.

## Changes

- `apps/api/src/lib/models.ts`: Added entry to MAIN_MODELS after the existing Grok 4.20 reasoning beta entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new model option to the `MAIN_MODELS` list used by the models endpoint and UI dropdowns, without changing selection logic or defaults.
> 
> **Overview**
> **Adds a new selectable main model option** by inserting `xai/grok-4.20-multi-agent-beta` ("Grok 4.20 Multi-Agent") into `MAIN_MODELS` in `apps/api/src/lib/models.ts`.
> 
> This expands what `GET /dashboard/models` and the Slack/App Home main-model dropdown can present, without altering defaults or any request/response logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e69edb52617fa4519ef962c99cee55d4b88d959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->