### PR TITLE
fix: check AURA_ADMIN_USER_IDS before DB role in getUserRole

### DIFF
--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -28,7 +28,6 @@ function resolveCallingUserId(passedUserId: string | undefined): string | undefi
 
 /**
  * Check whether a user has at least the specified role.
- * Falls back to AURA_ADMIN_USER_IDS env var during migration period.
  *
  * The userId is resolved via resolveCallingUserId(): the execution
  * context's callingUserId takes priority over the passed parameter so
@@ -53,32 +52,10 @@ export async function hasRole(
     });
   }
 
-  try {
-    const profile = await db
-      .select({ role: users.role })
-      .from(users)
-      .where(eq(users.slackUserId, effectiveUserId))
-      .limit(1);
-
-    if (profile.length > 0 && profile[0].role) {
-      const userLevel = ROLE_HIERARCHY[profile[0].role as Role] ?? 0;
-      const requiredLevel = ROLE_HIERARCHY[minimumRole];
-      return userLevel >= requiredLevel;
-    }
-  } catch {
-    // DB query failed — fall through to env var fallback
-  }
-
-  const adminIds = (process.env.AURA_ADMIN_USER_IDS || "")
-    .split(",")
-    .map((id) => id.trim())
-    .filter(Boolean);
-  if (adminIds.includes(effectiveUserId)) {
-    const requiredLevel = ROLE_HIERARCHY[minimumRole];
-    return ROLE_HIERARCHY.admin >= requiredLevel;
-  }
-
-  return false;
+  const role = await getUserRole(effectiveUserId);
+  const userLevel = ROLE_HIERARCHY[role] ?? 0;
+  const requiredLevel = ROLE_HIERARCHY[minimumRole];
+  return userLevel >= requiredLevel;
 }
 
 /**
@@ -97,10 +74,24 @@ export function isAdmin(userId: string | undefined): boolean {
 }
 
 /**
- * Look up a user's role from the DB. Returns 'member' if not found.
+ * Look up a user's role. Checks AURA_ADMIN_USER_IDS env var first (hard
+ * override), then falls back to the DB role column, then defaults to 'member'.
+ *
+ * The env var takes priority because migration 0045 set every existing user
+ * to role='member' and the DB was never back-filled. Without the override,
+ * getUserRole returns "member" for everyone and the env var fallback is dead
+ * code (the column is NOT NULL DEFAULT 'member', so it's always truthy).
  */
 async function getUserRole(userId: string): Promise<Role> {
   if (userId === "aura") return "admin";
+
+  const adminIds = (process.env.AURA_ADMIN_USER_IDS || "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (adminIds.includes(userId)) {
+    return "admin";
+  }
 
   try {
     const profile = await db
@@ -113,14 +104,6 @@ async function getUserRole(userId: string): Promise<Role> {
     }
   } catch {
     // fall through
-  }
-
-  const adminIds = (process.env.AURA_ADMIN_USER_IDS || "")
-    .split(",")
-    .map((id) => id.trim())
-    .filter(Boolean);
-  if (adminIds.includes(userId)) {
-    return "admin";
   }
 
   return "member";


### PR DESCRIPTION
## Summary

- **Root cause**: `getUserRole()` checked the DB role first and returned `"member"` immediately (the column is `NOT NULL DEFAULT 'member'`), making the `AURA_ADMIN_USER_IDS` env var fallback dead code. After the `TRUNCATE entities CASCADE` in `reset-entities.ts` wiped the `users` table, all recreated records had `role='member'`, silently disabling every credential-gated tool (sandbox, browser, web search, subagents, cursor agent, voice) for all users.
- **Fix**: Move the `AURA_ADMIN_USER_IDS` check ahead of the DB lookup so it acts as a hard override. Simplify `hasRole()` to delegate to `getUserRole()` instead of duplicating the same (buggy) lookup logic.

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Verify admin users in `AURA_ADMIN_USER_IDS` get `run_command` tool access on Slack after deploy
- [ ] Verify non-admin users still cannot access admin-gated tools

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core role/permission resolution used to gate access to tools and credentials; misconfiguration or logic mistakes could unintentionally broaden or restrict access.
> 
> **Overview**
> Fixes role resolution so `AURA_ADMIN_USER_IDS` is checked *before* the DB `users.role` lookup in `getUserRole()`, ensuring env-configured admins aren’t treated as `member` when the DB defaults everyone to `member`.
> 
> Simplifies `hasRole()` to delegate entirely to `getUserRole()` instead of duplicating DB/env fallback logic, making permission checks consistent across the API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ac4f89eb8605de5a3fa952eafb4ae055e0df44e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->