### PR TITLE
docs: fix memory types (9→5) and permissions precedence

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -13,15 +13,11 @@ Each memory has a `type` that determines how it's used during retrieval:
 
 | Type | Description | Example |
 |------|-------------|---------|
-| `fact` | Objective information about the world | "The BigQuery dataset is `analytics.prod`" |
-| `decision` | A decision made by someone | "Team decided to delay the launch by 2 weeks" |
-| `personal` | Personal details about a person | "Joan's birthday is March 15" |
-| `preference` | How someone likes things done | "Joan prefers bullet points over prose" |
-| `relationship` | How two people or entities relate | "Tali reports to Marc and works on the search team" |
-| `sentiment` | How someone feels about something | "The team is frustrated with the slow CI pipeline" |
-| `event` | A notable occurrence or milestone | "v2.0 launched on March 1st" |
-| `open_thread` | Something that needs follow-up | "Marc promised to share the Q4 numbers by Friday" |
-| `insight` | A derived observation or pattern | "Sales team closes more deals after Thursday demos" |
+| `fact` | Durable information about people, the org, or the world (subsumes the former `personal`, `relationship`, `sentiment` types) | "The BigQuery dataset is `analytics.prod`" |
+| `decision` | An explicit choice made by someone, with participants | "Team decided to delay the launch by 2 weeks" |
+| `preference` | How someone wants things done | "Joan prefers bullet points over prose" |
+| `event` | Something that happened at a specific time | "v2.0 launched on March 1st" |
+| `open_thread` | Unresolved work or pending questions | "Marc promised to share the Q4 numbers by Friday" |
 
 ## Storage
 
@@ -59,7 +55,7 @@ Memories are also classified by `category`:
 
 | Category | Description |
 |----------|-------------|
-| `semantic` | Facts, relationships, preferences -- the default |
+| `semantic` | Facts, preferences, decisions -- the default |
 | `episodic` | Specific events, conversations, moments in time |
 | `procedural` | How-to knowledge, workflows, processes |
 
@@ -105,7 +101,7 @@ In addition to discrete memory facts, Aura retrieves full conversation threads f
 After every conversation turn, Aura extracts new memories:
 
 1. The recent messages are sent to Claude with a structured extraction prompt
-2. Claude identifies facts, decisions, sentiments, open threads, and entity mentions
+2. Claude identifies facts, decisions, preferences, events, open threads, and entity mentions
 3. Each extraction is checked for duplicates against existing memories
 4. New memories are embedded and stored
 5. Extracted entities are resolved and linked to their memories (see below)

--- a/content/docs/permissions.mdx
+++ b/content/docs/permissions.mdx
@@ -5,7 +5,7 @@ description: "Role-based access control: user roles, tool permissions, note scop
 
 # Permissions
 
-Aura uses a three-tier role system to control access to tools, notes, and resources. Roles are stored in the database (`users.role`) with an env var fallback for backwards compatibility.
+Aura uses a three-tier role system to control access to tools, notes, and resources. Roles are stored in the database (`users.role`) with `AURA_ADMIN_USER_IDS` as a hard override (checked first, before the DB).
 
 ## Roles
 
@@ -25,13 +25,13 @@ The `owner` role was removed in the RBAC simplification (migration 0048). Existi
 
 The `hasRole(userId, minimumRole)` function in `apps/api/src/lib/permissions.ts` is the single source of truth:
 
-1. Look up `users.role` in the database
-2. If a DB role exists, compare it against the minimum required role and return the result
-3. If no DB profile exists (or query fails), fall back to `AURA_ADMIN_USER_IDS` env var — users listed there get `admin`-level access
-4. The system user `aura` always resolves to `admin` and passes all role checks
+1. The system user `aura` always resolves to `admin` and passes all role checks
+2. Check `AURA_ADMIN_USER_IDS` env var first -- users listed there get `admin`-level access as a hard override
+3. If not in the env var, look up `users.role` in the database and compare against the minimum required role
+4. If no DB profile exists (or query fails), default to `member`
 
 <Warning>
-If a user has an explicit role in the database, the env var is **not** consulted. A user demoted to `member` in the DB won't regain admin via the env var. This is intentional — the DB is authoritative once set.
+The env var is checked **before** the database. A user listed in `AURA_ADMIN_USER_IDS` gets `admin` regardless of their DB role. This is intentional -- the env var acts as a hard override to prevent lockouts when DB roles are misconfigured (e.g. after a migration that resets all roles to `member`).
 </Warning>
 
 ## Tool Permissions
@@ -95,7 +95,7 @@ Users who interact with Aura in Slack but never log into the dashboard won't hav
 
 ## Migration from `AURA_ADMIN_USER_IDS`
 
-The env var still works as a fallback for users without a DB profile. For new deployments, set roles via the dashboard instead. The env var will be deprecated in a future release.
+The env var is checked before the DB and acts as a hard override. For new deployments, set roles via the dashboard instead. The env var will be deprecated in a future release once all deployments have properly backfilled DB roles.
 
 ## Database Schema
 


### PR DESCRIPTION
Two P0 factual errors from recent merges:

**memory-system.mdx** — #871 simplified the taxonomy from 9 types to 5 (`fact`, `decision`, `preference`, `event`, `open_thread`). The docs still listed all 9 (`personal`, `relationship`, `sentiment`, `insight` are gone — `fact` now subsumes them). Fixed the type table, category table, and extraction description.

**permissions.mdx** — #870 moved `AURA_ADMIN_USER_IDS` env var check *before* the DB lookup in `getUserRole()`. The docs still described the old order (DB first, env var fallback) and had a warning saying the env var is never consulted if a DB role exists — now the opposite is true. Fixed all four affected sections.

Both are accuracy fixes, no new content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes correcting the described memory taxonomy and RBAC precedence; no runtime behavior is modified.
> 
> **Overview**
> Updates docs to reflect the simplified memory taxonomy (**9 → 5 types**), including revising the `type` table, the `semantic` category description, and the memory extraction step list.
> 
> Corrects permissions documentation to match current RBAC behavior where `AURA_ADMIN_USER_IDS` is checked **before** the DB role as a hard admin override, updating the role-check order, warning text, and migration guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 707b8f42fcb4e7f8aa42a9b59a7154a7cb9907fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->