### PR TITLE
docs: update memory extraction to reflect thread-scoped reconciliation

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -64,7 +64,7 @@ When a Slack message arrives:
 5. **LLM reasoning** — The selected model (Claude, Grok, etc.) processes the message with full context and available tools. Extended thinking captures the reasoning trace (Claude models).
 6. **Response streaming** — The response streams back to Slack in real-time via the Vercel AI SDK.
 7. **Conversation persistence** — The full conversation trace (messages, tool calls, reasoning, token usage) is stored with cost tracking.
-8. **Memory extraction** — Facts, decisions, and sentiments are extracted from the conversation and stored as new memories.
+8. **Memory extraction** — Thread-scoped reconciliation compares the full conversation against existing memories and produces create, update, and delete operations to keep memory accurate.
 
 ## Conversation Traces
 

--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -102,13 +102,16 @@ In addition to discrete memory facts, Aura retrieves full conversation threads f
 
 ## Memory Extraction
 
-After every conversation turn, Aura extracts new memories:
+After each conversation, Aura runs **thread-scoped reconciliation** to maintain memory accuracy:
 
-1. The recent messages are sent to Claude with a structured extraction prompt
-2. Claude identifies facts, decisions, sentiments, open threads, and entity mentions
-3. Each extraction is checked for duplicates against existing memories
-4. New memories are embedded and stored
-5. Extracted entities are resolved and linked to their memories (see below)
+1. The full conversation thread is loaded alongside all existing memories linked to its participants
+2. The LLM sees both the thread and existing memories, then produces explicit **create**, **update**, and **delete** operations
+3. New memories are checked for importance (low-signal extractions are filtered), embedded, and deduplicated against existing memories
+4. Updated memories have their content and embeddings refreshed in place
+5. Outdated or contradicted memories are archived with a supersession chain
+6. Extracted entities are resolved and linked to their memories (see below)
+
+When thread context is unavailable (e.g. during dashboard replay or backfill), Aura falls back to **single-exchange extraction** -- the same create pipeline but scoped to the latest message pair only.
 
 ## Entity Extraction & Resolution
 


### PR DESCRIPTION
## What changed

PR #872 replaced single-turn memory extraction with thread-scoped reconciliation. The docs still described the old flow.

### Fixes
- **memory-system.mdx**: Rewrote Memory Extraction section -- now describes the reconciliation flow (load thread + existing memories → LLM produces create/update/delete ops → process each). Mentions single-exchange fallback.
- **architecture.mdx**: Updated pipeline step 8 to reference reconciliation instead of simple extraction.

### Why P0
The old docs said "recent messages are sent to Claude" and "checked for duplicates" -- neither is accurate anymore. The LLM now sees the *full thread* and *existing memories*, and produces explicit update/delete ops (not just creates). This is a fundamental behavioral change that would mislead anyone reading the docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update; no runtime behavior changes, with minimal risk beyond potentially misdescribing the new reconciliation flow if inaccurate.
> 
> **Overview**
> Updates documentation to reflect the new **thread-scoped memory reconciliation** flow instead of single-turn extraction.
> 
> `memory-system.mdx` now describes loading the full thread plus existing participant-linked memories, and the LLM emitting explicit `create`/`update`/`delete` ops (including supersession/archival), with a documented single-exchange fallback when thread context is missing. `architecture.mdx` updates pipeline step 8 to match this reconciliation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cba915d5425daab4eab96212423c11196199f5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->