### PR TITLE
fix(memory): improve entity summary backfill with incremental mode and CLI flags

### DIFF
--- a/apps/api/src/memory/entity-summaries.ts
+++ b/apps/api/src/memory/entity-summaries.ts
@@ -162,8 +162,12 @@ export async function generateEntitySummary(
  * then by memory count DESC within each type (most-referenced entities first).
  */
 export async function regenerateStaleSummaries(
-  opts?: { forceAll?: boolean; concurrency?: number; onProgress?: (completed: number, total: number) => void },
-): Promise<{ updated: number; skipped: number }> {
+  opts?: {
+    forceAll?: boolean;
+    concurrency?: number;
+    onProgress?: (completed: number, total: number) => void;
+  },
+): Promise<{ updated: number; skipped: number; totalCandidates: number }> {
   const forceAll = opts?.forceAll ?? false;
 
   type StaleRow = {
@@ -247,5 +251,5 @@ export async function regenerateStaleSummaries(
   logger.info(
     `Entity summaries complete: ${updated} updated, ${skipped} skipped`,
   );
-  return { updated, skipped };
+  return { updated, skipped, totalCandidates: total };
 }

--- a/apps/api/src/scripts/backfill-entity-summaries.ts
+++ b/apps/api/src/scripts/backfill-entity-summaries.ts
@@ -10,17 +10,32 @@ const envFile = isProd ? ".env.production" : ".env.local";
 config({ path: resolve(repoRoot, envFile) });
 if (isProd) console.log("Using .env.production (--prod)");
 
+function parseIntFlag(name: string): number | undefined {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  if (!arg) return undefined;
+  const val = parseInt(arg.slice(prefix.length), 10);
+  return Number.isNaN(val) ? undefined : val;
+}
+
+const forceAll = process.argv.includes("--force-all");
+const concurrency = parseIntFlag("concurrency") ?? 5;
+
 const { regenerateStaleSummaries } = await import(
   "../memory/entity-summaries.js"
 );
 
 async function main() {
   console.log("=== Entity Summary Backfill ===\n");
+  console.log(`  mode:        ${forceAll ? "force-all (regenerate everything)" : "incremental (stale/missing only)"}`);
+  console.log(`  concurrency: ${concurrency}`);
+  console.log();
 
   let progress: ProgressTracker | null = null;
 
   const result = await regenerateStaleSummaries({
-    forceAll: true,
+    forceAll,
+    concurrency,
     onProgress: (_completed, total) => {
       if (!progress) progress = createProgress(total, { label: "entities", logEvery: 5 });
       progress.tick();
@@ -29,8 +44,13 @@ async function main() {
 
   console.log(`\n=== Summary ===`);
   (progress as ProgressTracker | null)?.done();
-  console.log(`Updated: ${result.updated}`);
-  console.log(`Skipped: ${result.skipped}`);
+  console.log(`Candidates: ${result.totalCandidates}`);
+  console.log(`Updated:    ${result.updated}`);
+  console.log(`Skipped:    ${result.skipped}`);
+
+  if (!forceAll && result.totalCandidates === 0) {
+    console.log("\nAll entity summaries are up to date. Use --force-all to regenerate everything.");
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Default the backfill script to **incremental mode** (stale/missing only) instead of always regenerating all summaries — add `--force-all` flag to opt into full regeneration
- Add `--concurrency=N` CLI flag (default 5) so concurrency is configurable at runtime
- Return `totalCandidates` from `regenerateStaleSummaries` for clearer reporting in the script output

## Test plan
- [ ] Run `npx tsx apps/api/src/scripts/backfill-entity-summaries.ts` — verify incremental mode with aligned summary output
- [ ] Run with `--force-all` — verify all entities are regenerated
- [ ] Run with `--concurrency=10` — verify custom concurrency is respected

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a maintenance script and a small return-shape extension for `regenerateStaleSummaries`, with the main impact being operational load if higher `--concurrency` is used.
> 
> **Overview**
> Improves the entity summary backfill flow by defaulting to *incremental* regeneration (only stale/missing summaries) and adding CLI flags to control behavior.
> 
> `backfill-entity-summaries.ts` now supports `--force-all` and `--concurrency=N` (default `5`), and reports the total number of candidate entities processed. `regenerateStaleSummaries` now returns `totalCandidates` to support clearer progress/output reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d354c6a9a3e60058ade254c569ba7e30c28d581f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->