### PR TITLE
docs: update memory types to match simplified 5-type taxonomy

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -9,19 +9,15 @@ Aura's memory is the core of what makes her different from a stateless chatbot. 
 
 ## Memory Types
 
-Each memory has a `type` that determines how it's used during retrieval:
+Each memory has a `type` that determines how it's classified. Since v0.58, the taxonomy was simplified from 9 types to 5 -- `personal`, `relationship`, `sentiment`, and `insight` were folded into `fact`:
 
 | Type | Description | Example |
 |------|-------------|---------|
-| `fact` | Objective information about the world | "The BigQuery dataset is `analytics.prod`" |
-| `decision` | A decision made by someone | "Team decided to delay the launch by 2 weeks" |
-| `personal` | Personal details about a person | "Joan's birthday is March 15" |
-| `preference` | How someone likes things done | "Joan prefers bullet points over prose" |
-| `relationship` | How two people or entities relate | "Tali reports to Marc and works on the search team" |
-| `sentiment` | How someone feels about something | "The team is frustrated with the slow CI pipeline" |
-| `event` | A notable occurrence or milestone | "v2.0 launched on March 1st" |
-| `open_thread` | Something that needs follow-up | "Marc promised to share the Q4 numbers by Friday" |
-| `insight` | A derived observation or pattern | "Sales team closes more deals after Thursday demos" |
+| `fact` | Durable information about people, the org, or the world. Subsumes what was previously `personal`, `relationship`, `sentiment`, and `insight`. | "Joan manages the Aura codebase", "The BigQuery dataset is `analytics.prod`" |
+| `decision` | An explicit choice made, with who made it | "Team decided to use Postgres instead of MongoDB" |
+| `preference` | How someone wants things done -- communication style, tool choices, formatting | "Joan prefers bullet points over prose" |
+| `event` | Something that happened at a specific time -- incidents, launches, meetings with outcomes | "Production went down on March 10 due to a migration bug" |
+| `open_thread` | Unresolved work, pending questions, things someone said they'd do | "Marc promised to share the Q4 numbers by Friday" |
 
 ## Storage
 
@@ -30,24 +26,25 @@ Memories are stored in PostgreSQL with a 1536-dimensional vector embedding (Open
 ```sql
 CREATE TABLE memories (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id TEXT NOT NULL DEFAULT 'default' REFERENCES workspaces(id),
   content TEXT NOT NULL,
-  type memory_type NOT NULL,
+  type memory_type NOT NULL,        -- fact | decision | preference | event | open_thread
+  category TEXT NOT NULL DEFAULT 'semantic', -- semantic | episodic | procedural
   source_message_id UUID REFERENCES messages(id),
   source_channel_type channel_type NOT NULL,
   related_user_ids TEXT[] NOT NULL DEFAULT '{}',
   embedding vector(1536),
-  category TEXT NOT NULL DEFAULT 'semantic',
+  importance INTEGER,               -- 1-100, set by extraction LLM
   relevance_score REAL NOT NULL DEFAULT 1.0,
   shareable INTEGER NOT NULL DEFAULT 0,
-  search_vector tsvector GENERATED ALWAYS AS (
-    to_tsvector('english', coalesce(content, ''))
-  ) STORED,
-  -- Temporal lifecycle (added v0.55)
+  extraction_source_role extraction_source_role, -- user | assistant | tool
+  search_vector tsvector,
+  -- Temporal lifecycle
   status memory_status NOT NULL DEFAULT 'current',
   confidence REAL DEFAULT 0.8,
   valid_from TIMESTAMPTZ,
   valid_until TIMESTAMPTZ,
-  supersedes_memory_id UUID REFERENCES memories(id),
+  supersedes_memory_id UUID,
   superseded_at TIMESTAMPTZ,
   superseded_by_memory_id UUID,
   created_at TIMESTAMPTZ DEFAULT NOW(),


### PR DESCRIPTION
## What

The memory system docs still showed 9 memory types, but PR #871 simplified the taxonomy to 5 types on March 31.

## Changes

- **Memory Types table**: 9 types → 5. Removed `personal`, `relationship`, `sentiment`, `insight` (all folded into `fact`).
- **`fact` type description**: Updated to reflect it now subsumes personal details, relationships, sentiment, and insights.
- **SQL schema**: Added missing columns that exist in the current Drizzle schema: `workspace_id`, `importance`, `extraction_source_role`. Fixed `search_vector` definition (no longer `GENERATED ALWAYS`).

## Why

P0 accuracy issue -- the docs directly contradicted the codebase. Anyone reading the memory system docs would think there are 9 types when the extraction pipeline only produces 5.

Caught by daily docs maintenance audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that don’t affect runtime behavior. Main risk is minor confusion if any downstream docs reference the old 9-type taxonomy.
> 
> **Overview**
> Updates the Memory System docs to reflect the simplified 5-type memory taxonomy, explicitly folding `personal`, `relationship`, `sentiment`, and `insight` into `fact` and revising type descriptions/examples accordingly.
> 
> Refreshes the `memories` SQL schema snippet to match the current table shape by documenting `workspace_id`, `importance`, and `extraction_source_role`, and by changing `search_vector` to a plain `tsvector` (no longer a generated column) and loosening/clarifying a few lifecycle/reference fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eb9e0baf398327fb7ff5e8fbde6127301651dbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->