### PR TITLE
docs: update memories table schema to match current codebase

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -30,24 +30,25 @@ Memories are stored in PostgreSQL with a 1536-dimensional vector embedding (Open
 ```sql
 CREATE TABLE memories (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id TEXT NOT NULL DEFAULT 'default' REFERENCES workspaces(id),
   content TEXT NOT NULL,
   type memory_type NOT NULL,
+  category TEXT NOT NULL DEFAULT 'semantic',  -- semantic | episodic | procedural
   source_message_id UUID REFERENCES messages(id),
   source_channel_type channel_type NOT NULL,
   related_user_ids TEXT[] NOT NULL DEFAULT '{}',
   embedding vector(1536),
-  category TEXT NOT NULL DEFAULT 'semantic',
+  importance INTEGER,                         -- 1-100, set by extraction LLM
   relevance_score REAL NOT NULL DEFAULT 1.0,
   shareable INTEGER NOT NULL DEFAULT 0,
-  search_vector tsvector GENERATED ALWAYS AS (
-    to_tsvector('english', coalesce(content, ''))
-  ) STORED,
-  -- Temporal lifecycle (added v0.55)
+  extraction_source_role extraction_source_role, -- user | assistant | tool
+  search_vector tsvector,
+  -- Temporal lifecycle
   status memory_status NOT NULL DEFAULT 'current',
   confidence REAL DEFAULT 0.8,
   valid_from TIMESTAMPTZ,
   valid_until TIMESTAMPTZ,
-  supersedes_memory_id UUID REFERENCES memories(id),
+  supersedes_memory_id UUID,
   superseded_at TIMESTAMPTZ,
   superseded_by_memory_id UUID,
   created_at TIMESTAMPTZ DEFAULT NOW(),


### PR DESCRIPTION
## What

The SQL schema shown in `memory-system.mdx` was missing several columns that have been added over recent PRs. This fixes the documented schema to match the actual Drizzle schema on main.

## Changes

- **Added** `workspace_id`, `importance`, `extraction_source_role` columns
- **Fixed** `search_vector` -- was shown as `GENERATED ALWAYS AS (...) STORED` but hasn't been that since an earlier migration
- **Fixed** `supersedes_memory_id` -- removed stale FK constraint (not in Drizzle schema)
- **Reordered** `category` column to match Drizzle schema position

## Context

Companion to #873 which fixes the memory types table (9→5). This PR handles the SQL schema separately to keep reviews clean and avoid merge conflicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to the `memories` table schema with no runtime or data-path code changes.
> 
> **Overview**
> Updates `content/docs/memory-system.mdx` to reflect the current `memories` PostgreSQL schema by documenting additional columns (e.g. `workspace_id`, `importance`, `extraction_source_role`) and reordering `category`.
> 
> Corrects the documented definition of `search_vector` (no longer a generated stored column) and removes the stale FK constraint on `supersedes_memory_id` so the docs match the actual schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0ba36143106614cb640f796e080f70a437395a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->