### PR TITLE
docs: update entity types, roles, and resolution cascade

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -112,16 +112,21 @@ After every conversation turn, Aura extracts new memories:
 
 ## Entity Extraction & Resolution
 
-Alongside memory extraction, Aura identifies **entities** -- people, companies, projects, products, channels, and technologies -- mentioned in conversations. Each entity is resolved to a canonical record using a four-step cascade:
+Alongside memory extraction, Aura identifies **entities** -- people, companies, projects, products, channels, technologies, concepts, and locations -- mentioned in conversations. Each entity is extracted with:
 
-1. **Exact canonical match** -- direct match against known entity names
+- A **type**: `person`, `company`, `project`, `product`, `channel`, `technology`, `concept`, `location`
+- A **role**: `subject` (primary), `object` (secondary), or `mentioned` (just referenced)
+- Optional **aliases**: first names, abbreviations, usernames (e.g. "Joan" for "Joan Rodriguez")
+
+Entities are resolved to a canonical record using a cascade:
+
+1. **Exact canonical match** -- direct match against known entity names (same type)
 2. **Alias match** -- match against registered aliases (e.g. "Joan" → "Joan Rodriguez")
-3. **Fuzzy match** -- trigram similarity (>0.4 threshold) catches misspellings and variations
-4. **Create new** -- if no match is found, a new entity record is created
+3. **Cross-type match** -- prevents duplicates across types (e.g. "SMG" as technology when "SMG" as company exists)
+4. **Fuzzy match** -- trigram similarity (>0.4 threshold) with LLM disambiguation to confirm
+5. **Create new** -- if no match is found, a new entity record is created with any extracted aliases
 
-Entities are linked to the memories that mention them via the `memory_entities` join table. This enables **entity-first retrieval**: when a query mentions a known entity, Aura finds all memories linked to that entity and merges them into the hybrid search results with an RRF boost, ensuring relevant context surfaces even when the exact wording differs.
-
-Entity types: `person`, `company`, `project`, `product`, `channel`, `technology`.
+Entities are linked to the memories that mention them via the `memory_entities` join table (with the role preserved). This enables **entity-first retrieval**: when a query mentions a known entity, Aura finds all memories linked to that entity and merges them into the hybrid search results with an RRF boost, ensuring relevant context surfaces even when the exact wording differs.
 
 ### LLM-Based Entity Extraction
 


### PR DESCRIPTION
## What

Entity extraction schema changes (#862, #869) added `concept` and `location` types, `subject/object/mentioned` roles, and LLM-assisted alias extraction -- but the docs still listed only 6 types and a 4-step cascade.

### Fixes
- **Entity types**: `person, company, project, product, channel, technology` → add `concept, location` (8 total)
- **Entity roles**: Document `subject`, `object`, `mentioned` roles (new in #862)
- **Alias extraction**: Note that entities are extracted with optional aliases
- **Resolution cascade**: Update from 4-step to 5-step (add cross-type match, note LLM disambiguation on fuzzy)

### Why P2
Stale section that misrepresents current behavior. Anyone reading the entity docs would miss two types and wouldn't know about roles or the cross-type dedup step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the described entity schema and matching behavior; no runtime logic is modified.
> 
> **Overview**
> Updates the *Entity Extraction & Resolution* documentation to reflect the current entity schema: expands entity types to include `concept` and `location`, documents per-entity `subject`/`object`/`mentioned` roles, and notes optional alias extraction.
> 
> Revises the described entity resolution cascade from 4 to 5 steps by adding a cross-type de-duplication match and clarifying fuzzy matching now uses LLM disambiguation, and notes that `memory_entities` preserves the entity role when linking to memories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083fdcfb177b640abd667c3993db117b266ec484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->