### PR TITLE
Fix usage stats unique users to count only engaged users

### DIFF
--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -78,8 +78,25 @@ export async function getUsageStats(): Promise<string> {
 
     const result = await db.execute(sql`
       SELECT
-        COUNT(DISTINCT CASE WHEN created_at > now() - INTERVAL '7 days' AND role = 'user' THEN user_id END) AS users_this_week,
-        COUNT(DISTINCT CASE WHEN created_at > now() - INTERVAL '14 days' AND created_at <= now() - INTERVAL '7 days' AND role = 'user' THEN user_id END) AS users_last_week,
+        COUNT(DISTINCT CASE
+          WHEN created_at > now() - INTERVAL '7 days'
+            AND role = 'user'
+            AND (
+              channel_type = 'dm'
+              OR COALESCE(metadata->>'isMentioned', 'false') = 'true'
+            )
+          THEN user_id
+        END) AS users_this_week,
+        COUNT(DISTINCT CASE
+          WHEN created_at > now() - INTERVAL '14 days'
+            AND created_at <= now() - INTERVAL '7 days'
+            AND role = 'user'
+            AND (
+              channel_type = 'dm'
+              OR COALESCE(metadata->>'isMentioned', 'false') = 'true'
+            )
+          THEN user_id
+        END) AS users_last_week,
         COUNT(CASE WHEN created_at > now() - INTERVAL '7 days' AND role = 'user' THEN 1 END) AS received_this_week,
         COUNT(CASE WHEN created_at > now() - INTERVAL '7 days' AND role = 'assistant' THEN 1 END) AS sent_this_week,
         COUNT(CASE WHEN created_at > now() - INTERVAL '14 days' AND created_at <= now() - INTERVAL '7 days' AND role = 'user' THEN 1 END) AS received_last_week,

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -84,10 +84,15 @@ function shouldFastReject(event: SlackEvent, botUserId: string): boolean {
  * Returns undefined when there's nothing worth storing.
  */
 function buildMessageMetadata(
+  context: MessageContext,
   event: SlackEvent,
 ): Record<string, unknown> | undefined {
   const meta: Record<string, unknown> = {};
   const ev = event as unknown as Record<string, unknown>;
+
+  // Persist engagement signal so usage stats can distinguish true interactions
+  // (@mentions and DMs) from ambient channel chatter.
+  meta.isMentioned = context.isMentioned;
 
   if (Array.isArray(ev.attachments) && ev.attachments.length > 0) {
     meta.attachments = ev.attachments;
@@ -739,7 +744,7 @@ async function storeUserMessage(context: MessageContext, event: SlackEvent): Pro
       userId: context.userId,
       role: "user",
       content: context.text,
-      metadata: buildMessageMetadata(event),
+      metadata: buildMessageMetadata(context, event),
     });
   } catch (error: any) {
     recordError("storeUserMessage", error, { userId: context.userId });
@@ -788,7 +793,7 @@ async function runBackgroundTasks(params: {
       userId: context.userId,
       role: "user",
       content: context.text,
-      metadata: buildMessageMetadata(event),
+      metadata: buildMessageMetadata(context, event),
     });
 
     // Store Aura's response with a pseudo-timestamp


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #887 by changing the usage-stats "Unique users" metric to count only users who actually engaged with Aura:

- users who sent a DM to Aura (`channel_type = 'dm'`), or
- users who @mentioned Aura in channel messages.

### What changed

- **`apps/api/src/pipeline/core-prompt.ts`**
  - Updated the SQL for `users_this_week` and `users_last_week` to count distinct `user_id` only when:
    - `channel_type = 'dm'`, or
    - `metadata.isMentioned = true`.
- **`apps/api/src/pipeline/index.ts`**
  - Updated message metadata persistence to always include `isMentioned` from `MessageContext` on stored user messages.
  - This creates a durable engagement signal for channel @mentions.

## Why this fix

Previously, unique users counted all channel participants whose messages were stored (`role='user'`), which inflated the metric with ambient channel chatter. The new logic measures actual Aura engagement.

## Verification

- Ran `npx tsc --noEmit` in `apps/api` successfully.
- Push hook also ran full monorepo typecheck (`apps/api` + `apps/dashboard`) successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1093d3c4-7da1-4b6e-b2dc-8cc0cac59321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1093d3c4-7da1-4b6e-b2dc-8cc0cac59321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

