### PR TITLE
docs: add source provenance columns to memory schema

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -32,6 +32,8 @@ CREATE TABLE memories (
   category TEXT NOT NULL DEFAULT 'semantic',  -- semantic | episodic | procedural
   source_message_id UUID REFERENCES messages(id),
   source_channel_type channel_type NOT NULL,
+  source_thread_ts TEXT,                   -- thread the memory was extracted from
+  source_channel_id TEXT,                  -- channel the memory was extracted from
   related_user_ids TEXT[] NOT NULL DEFAULT '{}',
   embedding vector(1536),
   importance INTEGER,                         -- 1-100, set by extraction LLM
@@ -203,6 +205,7 @@ Memory respects channel boundaries:
 - Memories from DMs are marked `shareable: 0` and only surface in conversations with the same user
 - Memories from public channels are `shareable: 1` and can surface anywhere
 - The `source_channel_type` field enables this filtering at query time
+- The `source_channel_id` and `source_thread_ts` fields provide full provenance -- every memory traces back to the exact conversation that generated it
 
 ## Notes: The Knowledge Graph
 

--- a/content/docs/tools/memories.mdx
+++ b/content/docs/tools/memories.mdx
@@ -71,7 +71,7 @@ Retrieve full details of a single memory by UUID. Returns all fields including c
 
 ### Returns
 
-Full memory object with: `id`, `content`, `type`, `status`, `confidence`, `relevance_score`, `importance`, `related_user_ids`, `source_channel_type`, `supersedes_memory_id`, `superseded_by_memory_id`, `superseded_at`, `valid_from`, `valid_until`, `created_at`, `updated_at`.
+Full memory object with: `id`, `content`, `type`, `status`, `confidence`, `relevance_score`, `importance`, `related_user_ids`, `source_channel_type`, `source_channel_id`, `source_thread_ts`, `supersedes_memory_id`, `superseded_by_memory_id`, `superseded_at`, `valid_from`, `valid_until`, `created_at`, `updated_at`.
 
 ## update_memory
 


### PR DESCRIPTION
PR #886 added `source_thread_ts` and `source_channel_id` to the memories table for full conversation traceability. This was missing from the docs.

**Changes:**
- `memory-system.mdx`: add both columns to the CREATE TABLE schema block, add provenance mention in Privacy section
- `tools/memories.mdx`: add fields to `get_memory` return value list

Small P0 fix -- schema in docs was out of date vs actual codebase.