### PR TITLE
docs: fix stale memory types, entity types, and tool count

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -15,7 +15,7 @@ aura/
 │   ├── api/            # Core agent (Hono + Vercel Functions)
 │   │   └── src/
 │   │       ├── pipeline/    # Message processing, prompt assembly
-│   │       ├── tools/       # 23 tool modules (Slack, email, BigQuery, etc.)
+│   │       ├── tools/       # 24 tool modules (Slack, email, BigQuery, etc.)
 │   │       ├── memory/      # Extract, store, retrieve, consolidate
 │   │       ├── cron/        # Heartbeat, memory consolidation, email sync
 │   │       └── routes/      # API routes (Slack events, dashboard, chat)
@@ -60,11 +60,11 @@ When a Slack message arrives:
 1. **Event deduplication** — Slack sometimes sends duplicate events. The `event_locks` table prevents double-processing.
 2. **Context loading** — Recent conversation history, relevant memories, user profile, notes index, and channel context are loaded in parallel.
 3. **Memory retrieval** — Hybrid search (vector + full-text) finds relevant memories from past conversations.
-4. **Prompt assembly** — System prompt is built in two layers: a stable prefix (personality, self-directive, notes index, memories, user profile) and a dynamic context (current time, active model, channel, and usage stats with 7-day activity metrics and week-over-week trends).
+4. **Prompt assembly** — System prompt is built in two layers: a stable prefix (personality, self-directive, notes index, memories, user profile) and a dynamic context wrapped in a `<runtime>` XML block (current time, active model, channel, and usage stats with 7-day activity metrics and week-over-week trends).
 5. **LLM reasoning** — The selected model (Claude, Grok, etc.) processes the message with full context and available tools. Extended thinking captures the reasoning trace (Claude models).
 6. **Response streaming** — The response streams back to Slack in real-time via the Vercel AI SDK.
 7. **Conversation persistence** — The full conversation trace (messages, tool calls, reasoning, token usage) is stored with cost tracking.
-8. **Memory extraction** — Facts, decisions, and sentiments are extracted from the conversation and stored as new memories.
+8. **Memory extraction** — Facts, decisions, preferences, events, and open threads are extracted from the conversation and stored as new memories.
 
 ## Conversation Traces
 
@@ -80,7 +80,7 @@ The [Dashboard](/dashboard) provides a UI for browsing conversation traces, filt
 
 ## Tool System
 
-Tools are defined using `defineTool()`, a wrapper around the Vercel AI SDK's `tool()` that adds audit logging and approval policies. Aura has **23 tool modules** organized by domain:
+Tools are defined using `defineTool()`, a wrapper around the Vercel AI SDK's `tool()` that adds audit logging and approval policies. Aura has **24 tool modules** organized by domain:
 
 | Category | Tools | Description |
 |----------|-------|-------------|
@@ -89,7 +89,7 @@ Tools are defined using `defineTool()`, a wrapper around the Vercel AI SDK's `to
 | **Data** | BigQuery, Google Sheets, Google Drive | Data warehouse and document access |
 | **Web** | Search, read URLs, browser automation | External information gathering |
 | **Code** | Sandbox (shell), GitHub CLI, subagents | Code execution and development |
-| **Memory** | Notes, conversations, people | Knowledge management |
+| **Memory** | Notes, conversations, people, memories, scratchpad | Knowledge management |
 | **Scheduling** | Jobs, datetime | Autonomous task scheduling |
 | **Integration** | HTTP requests, credentials, Cursor agents | External API access |
 | **Communication** | Voice, resources | Phone calls, content ingestion |

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -36,11 +36,11 @@ Track token usage and costs over time:
 
 Browse and search Aura's extracted memories:
 
-- Filter by type (fact, decision, personal, relationship, sentiment, open_thread)
+- Filter by type (fact, decision, preference, event, open_thread)
 - View related users and source conversations
 - Check relevance scores and decay status
 
-The **Entities** sub-tab (`/memories/entities`) lists resolved entities (people, companies, projects, technologies) that Aura has extracted from conversations. Each entity has a canonical name, type, alias list, and count of linked memories.
+The **Entities** sub-tab (`/memories/entities`) lists resolved entities (people, companies, projects, products, channels, technologies, concepts, locations) that Aura has extracted from conversations. Each entity has a canonical name, type, alias list, and count of linked memories.
 
 ### Notes
 


### PR DESCRIPTION
## What

Fix multiple stale references in `dashboard.mdx` and `architecture.mdx` that drifted from the codebase after the memory taxonomy simplification (9→5 types), entity type expansion, and recent tool additions.

## Changes

**dashboard.mdx (P0 -- factually wrong):**
- Memory type filter listed old types (`personal, relationship, sentiment`) -- updated to current 5 types (`fact, decision, preference, event, open_thread`)
- Entity types listed 4 of 8 -- added `product, channel, concept, location`

**architecture.mdx (P1 -- stale counts/categories):**
- Tool module count: 23 → 24 (memories.ts added in #883)
- Memory category in tool table: added `memories` and `scratchpad` modules
- Memory extraction step: referenced old 'sentiments' type
- Prompt assembly: documented `<runtime>` XML block wrapping from #889

## Verification
- Memory types checked against `memoryTypeEnum` in `packages/db/src/schema.ts`
- Entity types checked against `entityTypeEnum` in `packages/db/src/schema.ts`  
- Tool count verified by `ls apps/api/src/tools/*.ts | grep -v core.ts | wc -l` = 24
- Runtime block verified from commit 8ce24ac (#889)