### PR TITLE
fix(dashboard): keep settings hook order stable on refresh

### DIFF
--- a/apps/dashboard/src/routes/settings/index.tsx
+++ b/apps/dashboard/src/routes/settings/index.tsx
@@ -111,13 +111,6 @@ function SettingsPage() {
     },
   });
 
-  if (loadingSettings) return <PageSkeleton rows={8} />;
-  if (settingsError) return <div className="text-destructive text-sm">Failed to load settings: {settingsError.message}</div>;
-
-  const nonModelSettings = (settings ?? []).filter(
-    (s) => !s.key.startsWith("model_") && !s.key.startsWith("credential:"),
-  );
-
   const providerByModelId = useMemo(
     () => new Map((models?.catalog ?? []).map((model) => [model.value, model.provider])),
     [models?.catalog],
@@ -130,6 +123,14 @@ function SettingsPage() {
       })),
     [providerByModelId],
   );
+
+  if (loadingSettings) return <PageSkeleton rows={8} />;
+  if (settingsError) return <div className="text-destructive text-sm">Failed to load settings: {settingsError.message}</div>;
+
+  const nonModelSettings = (settings ?? []).filter(
+    (s) => !s.key.startsWith("model_") && !s.key.startsWith("credential:"),
+  );
+
   const MAIN_MODELS = enrichOptions(models?.main ?? []);
   const FAST_MODELS = enrichOptions(models?.fast ?? []);
   const EMBEDDING_MODELS = enrichOptions(models?.embedding ?? []);


### PR DESCRIPTION
## Summary
- move the settings page `useMemo` setup above the loading early return so hard refreshes keep a stable hook order
- preserve the shared model autocomplete UI while preventing the production `/settings` crash introduced in `#901`

## Test plan
- [x] `pnpm --dir apps/dashboard build`
- [x] `pnpm typecheck`

Made with [Cursor](https://cursor.com)