### PR TITLE
feat(dashboard): align sidebar controls with Cursor

### DIFF
--- a/apps/dashboard/src/components/sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar.tsx
@@ -13,8 +13,19 @@ import {
   BarChart3,
   Menu,
   X,
+  LogOut,
 } from "lucide-react";
 import { useState } from "react";
+import { useAuth } from "@/lib/auth";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
@@ -39,61 +50,176 @@ const navItems = [
   { href: "/resources", label: "Resources", icon: FileText },
   { href: "/consumption", label: "Consumption", icon: BarChart3 },
   { href: "/credentials", label: "Credentials", icon: KeyRound },
-  { href: "/settings", label: "Settings", icon: Settings },
 ] as const;
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
 
 function NavContent({ onClose, showLabels }: { onClose?: () => void; showLabels?: boolean }) {
   const routerState = useRouterState();
   const pathname = routerState.location.pathname;
 
   return (
-    <TooltipProvider delayDuration={150}>
-      <nav className={cn("flex h-full flex-col py-2 gap-0.5", showLabels ? "px-2" : "items-center")}>
-        {navItems.map((item) => {
-          const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
-          const link = (
-            <Link
-              to={item.href}
-              onClick={onClose}
-              className={cn(
-                "flex items-center rounded-xl transition-colors",
-                showLabels
-                  ? "gap-2 px-1.5 py-1.5 text-[13px]"
-                  : "justify-center w-11 h-11",
-                isActive
-                  ? "bg-foreground/15 text-foreground"
-                  : "text-muted-foreground",
-              )}
-            >
-              <item.icon className="h-[22px] w-[22px] shrink-0" strokeWidth="1.75" />
-              {showLabels && item.label}
-            </Link>
-          );
+    <nav className={cn("flex flex-col gap-0.5", showLabels ? "px-2" : "items-center")}>
+      {navItems.map((item) => {
+        const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+        const link = (
+          <Link
+            to={item.href}
+            onClick={onClose}
+            className={cn(
+              "flex items-center rounded-xl transition-colors",
+              showLabels
+                ? "gap-2 px-1.5 py-1.5 text-[13px]"
+                : "justify-center w-11 h-11",
+              isActive
+                ? "bg-foreground/15 text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            <item.icon className="h-[22px] w-[22px] shrink-0" strokeWidth="1.75" />
+            {showLabels && item.label}
+          </Link>
+        );
 
-          if (showLabels) {
-            return <div key={item.href}>{link}</div>;
-          }
+        if (showLabels) {
+          return <div key={item.href}>{link}</div>;
+        }
 
-          return (
-            <Tooltip key={item.href}>
-              <TooltipTrigger asChild>
-                {link}
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={6}>
-                {item.label}
-              </TooltipContent>
-            </Tooltip>
-          );
-        })}
-      </nav>
-    </TooltipProvider>
+        return (
+          <Tooltip key={item.href}>
+            <TooltipTrigger asChild>
+              {link}
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={6}>
+              {item.label}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </nav>
+  );
+}
+
+function SettingsLink({ onClose, showLabels }: { onClose?: () => void; showLabels?: boolean }) {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const isActive = pathname.startsWith("/settings");
+  const link = (
+    <Link
+      to="/settings"
+      onClick={onClose}
+      className={cn(
+        "flex items-center rounded-xl transition-colors",
+        showLabels
+          ? "gap-2 px-1.5 py-1.5 text-[13px]"
+          : "justify-center h-11 w-11",
+        isActive
+          ? "bg-foreground/15 text-foreground"
+          : "text-muted-foreground",
+      )}
+    >
+      <Settings className="h-[22px] w-[22px] shrink-0" strokeWidth="1.75" />
+      {showLabels && "Settings"}
+    </Link>
+  );
+
+  if (showLabels) {
+    return link;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {link}
+      </TooltipTrigger>
+      <TooltipContent side="right" sideOffset={6}>
+        Settings
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function UserMenu({ onClose, showLabels }: { onClose?: () => void; showLabels?: boolean }) {
+  const { session, logout } = useAuth();
+
+  if (!session) {
+    return null;
+  }
+
+  const trigger = (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center rounded-xl text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+        showLabels
+          ? "w-full gap-2 px-1.5 py-1.5 text-[13px]"
+          : "h-11 w-11 justify-center",
+      )}
+      title={showLabels ? undefined : session.name}
+    >
+      <Avatar size={showLabels ? "sm" : "default"}>
+        <AvatarImage src={session.picture} alt={session.name} referrerPolicy="no-referrer" />
+        <AvatarFallback>{getInitials(session.name)}</AvatarFallback>
+      </Avatar>
+      {showLabels && <span className="truncate">{session.name}</span>}
+      <span className="sr-only">Open account menu</span>
+    </button>
+  );
+
+  const menu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {trigger}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={showLabels ? "start" : "end"} side={showLabels ? "top" : "right"}>
+        <DropdownMenuLabel className="max-w-48 truncate">{session.name}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          onSelect={(event) => {
+            event.preventDefault();
+            logout();
+            onClose?.();
+          }}
+        >
+          <LogOut className="h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  if (showLabels) {
+    return menu;
+  }
+
+  return menu;
+}
+
+function SidebarFooter({ onClose, showLabels }: { onClose?: () => void; showLabels?: boolean }) {
+  return (
+    <div className={cn("mt-auto flex w-full flex-col gap-1 pt-3", showLabels ? "px-2" : "items-center")}>
+      <UserMenu onClose={onClose} showLabels={showLabels} />
+      <SettingsLink onClose={onClose} showLabels={showLabels} />
+    </div>
   );
 }
 
 export function Sidebar() {
   return (
-    <aside className="hidden md:flex md:flex-col w-[52px] shrink-0 border-r items-center" style={{ background: "var(--sidebar-bg)" }}>
-      <NavContent />
+    <aside className="hidden md:flex md:flex-col w-[52px] shrink-0 border-r" style={{ background: "var(--sidebar-bg)" }}>
+      <TooltipProvider delayDuration={150}>
+        <div className="flex h-full w-full flex-col items-center py-2">
+          <NavContent />
+          <SidebarFooter />
+        </div>
+      </TooltipProvider>
     </aside>
   );
 }
@@ -118,9 +244,12 @@ export function MobileNav() {
                 <X className="h-4 w-4" />
               </button>
             </div>
-            <div className="pt-8">
-              <NavContent onClose={() => setOpen(false)} showLabels />
-            </div>
+            <TooltipProvider delayDuration={150}>
+              <div className="flex h-full flex-col pb-2 pt-8">
+                <NavContent onClose={() => setOpen(false)} showLabels />
+                <SidebarFooter onClose={() => setOpen(false)} showLabels />
+              </div>
+            </TooltipProvider>
           </div>
         </div>
       )}

--- a/apps/dashboard/src/components/theme-toggle.tsx
+++ b/apps/dashboard/src/components/theme-toggle.tsx
@@ -1,19 +1,46 @@
 import { useTheme } from "next-themes";
-import { Sun, Moon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-export function ThemeToggle() {
+const themeOptions = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System default" },
+] as const;
+
+export function ThemeSelect({ className }: { className?: string }) {
   const { theme, setTheme } = useTheme();
+  const value = theme ?? "system";
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-    >
-      <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-      <span className="sr-only">Toggle theme</span>
-    </Button>
+    <Select value={value} onValueChange={(nextTheme) => setTheme(nextTheme)}>
+      <SelectTrigger
+        className={cn("w-full", className)}
+        aria-label="Theme preference"
+      >
+        <SelectValue placeholder="Select theme" />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {themeOptions.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function ThemeToggle() {
+  return (
+    <ThemeSelect
+      className="w-[180px]"
+    />
   );
 }

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -1,26 +1,21 @@
 import { createRootRoute, Outlet, useRouterState } from "@tanstack/react-router";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { Sidebar, MobileNav } from "@/components/sidebar";
-import { ThemeToggle } from "@/components/theme-toggle";
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { useAuth } from "@/lib/auth";
-import { LogOut, MessageCircle } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useCallback } from "react";
 
 const PUBLIC_ROUTES = ["/login", "/unauthorized"];
 
 function Header({
-  session,
   chatOpen,
   toggleChat,
 }: {
-  session: { name: string; picture: string; slackUserId: string } | null;
   chatOpen: boolean;
   toggleChat: () => void;
 }) {
-  const { logout } = useAuth();
-
   return (
     <header className="flex h-12 items-center justify-between border-b px-4">
       <div className="flex items-center gap-2">
@@ -43,29 +38,6 @@ function Header({
           <MessageCircle className="h-3.5 w-3.5" />
           <span className="hidden sm:inline">Chat</span>
         </button>
-        <ThemeToggle />
-        {session && (
-          <div className="flex items-center gap-2">
-            {session.picture && (
-              <img
-                src={session.picture}
-                alt={session.name}
-                className="h-6 w-6 rounded-full"
-                referrerPolicy="no-referrer"
-              />
-            )}
-            <span className="text-[13px] hidden sm:inline">
-              {session.name}
-            </span>
-            <button
-              onClick={logout}
-              className="p-1 hover:bg-muted rounded-md text-muted-foreground hover:text-foreground transition-colors"
-              title="Sign out"
-            >
-              <LogOut className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
       </div>
     </header>
   );
@@ -104,7 +76,7 @@ function RootLayout() {
       <Group orientation="horizontal" className="flex-1 overflow-hidden">
         <Panel id="content" minSize="50%">
           <div className="flex h-full flex-col overflow-hidden">
-            <Header session={session} chatOpen={chatOpen} toggleChat={toggleChat} />
+            <Header chatOpen={chatOpen} toggleChat={toggleChat} />
             <main className="flex-1 flex flex-col min-h-0 overflow-hidden">
               <div className="flex-1 flex flex-col min-h-0 overflow-y-auto px-4 py-3 md:px-5 md:py-4">
                 <Outlet />

--- a/apps/dashboard/src/routes/settings/index.tsx
+++ b/apps/dashboard/src/routes/settings/index.tsx
@@ -8,6 +8,7 @@ import { ModelAutocomplete, type ModelAutocompleteOption } from "@/components/mo
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { PageSkeleton } from "@/components/page-skeleton";
+import { ThemeSelect } from "@/components/theme-toggle";
 import { formatDate } from "@/lib/utils";
 import { useMemo, useState } from "react";
 import { RefreshCw, Save, Plus, Pencil } from "lucide-react";
@@ -140,6 +141,19 @@ function SettingsPage() {
   return (
     <div className="space-y-4">
       <h1 className="text-lg font-semibold tracking-tight">Settings</h1>
+
+      <Card>
+        <CardHeader><CardTitle className="text-base">Appearance</CardTitle></CardHeader>
+        <CardContent className="space-y-3">
+          <div className="max-w-xs space-y-1.5">
+            <label className="text-sm font-medium">Theme</label>
+            <ThemeSelect />
+            <p className="text-sm text-muted-foreground">
+              Choose light, dark, or follow your system setting.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader><CardTitle className="text-base">Model Selection</CardTitle></CardHeader>


### PR DESCRIPTION
## Summary
- move the dashboard account controls into the sidebar footer so the avatar sits above settings and sign out is tucked behind the avatar menu
- remove the header theme toggle and add a theme dropdown in settings with `Light`, `Dark`, and `System default`
- keep the dashboard default theme on `system` while making the navigation layout closer to Cursor

## Test plan
- [x] `pnpm typecheck`


Made with [Cursor](https://cursor.com)