### PR TITLE
docs(dashboard): update Consumption, Settings, Chat, and Navigation sections

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -15,7 +15,7 @@ aura/
 │   ├── api/            # Core agent (Hono + Vercel Functions)
 │   │   └── src/
 │   │       ├── pipeline/    # Message processing, prompt assembly
-│   │       ├── tools/       # 23 tool modules (Slack, email, BigQuery, etc.)
+│   │       ├── tools/       # 25 tool modules (Slack, email, BigQuery, etc.)
 │   │       ├── memory/      # Extract, store, retrieve, consolidate
 │   │       ├── cron/        # Heartbeat, memory consolidation, email sync
 │   │       └── routes/      # API routes (Slack events, dashboard, chat)
@@ -48,7 +48,7 @@ Slack Event → Vercel Function → Hono Router → Message Pipeline → LLM (Ve
                                               PostgreSQL + pgvector
                                       (memories, messages, conversations, notes, jobs)
                                                       ↕
-                                              Tools (23 modules)
+                                              Tools (25 modules)
                                                       ↕
                                               Admin Dashboard (Vite + React)
 ```
@@ -80,7 +80,7 @@ The [Dashboard](/dashboard) provides a UI for browsing conversation traces, filt
 
 ## Tool System
 
-Tools are defined using `defineTool()`, a wrapper around the Vercel AI SDK's `tool()` that adds audit logging and approval policies. Aura has **23 tool modules** organized by domain:
+Tools are defined using `defineTool()`, a wrapper around the Vercel AI SDK's `tool()` that adds audit logging and approval policies. Aura has **25 tool modules** organized by domain:
 
 | Category | Tools | Description |
 |----------|-------|-------------|
@@ -125,6 +125,24 @@ Two thinking modes are supported:
 
 - **Classic budget** -- `{ type: "enabled", budgetTokens }`. The caller sets a token budget per step. Used for Sonnet and older Opus models.
 - **Adaptive** -- `{ type: "adaptive" }`. The model self-manages its own reasoning budget. Opus 4.7 is adaptive-only and will reject a classic budget request with `AI_NoOutputGeneratedError`. Adaptive-only gateway IDs are kept in a small allowlist in `prepare-step.ts`.
+
+## Slack Streaming & Task Display
+
+Aura uses the Slack 2026 Agent SDK (`chat.startStream` / `chat.appendStream`) to stream responses in real time. Tool calls render as native task cards rather than inline markdown.
+
+Three display modes are supported via the `slack_task_display_mode` workspace setting (configurable from the App Home admin panel):
+
+- **`timeline`** (default) -- per-step `task_update` chunks render as a live feed of tool cards.
+- **`plan`** -- an upfront plan block is emitted at stream start, seeded from the registered tools' `slackMeta.status`, then updated as steps progress.
+- **`hybrid`** -- both a plan block and per-step timeline cards.
+
+When a tool result includes sources, they are emitted as dedicated `url_source` chunks (separate from the `task_update` payload) so Slack renders citation blocks inline with the response.
+
+Non-fatal chunk shapes (e.g. `plan`, `url_source`, `blocks`) are skipped rather than collapsing the stream to a `postMessage` fallback. Truly invalid payloads log a warning and continue.
+
+### setStatus shimmer
+
+While Aura reasons, an assistant-thread status is shown via `assistant.threads.setStatus` (e.g. "Thinking...", "Thinking deeply..."). Channels where the workspace lacks permission are cached in-process on first failure and skipped on subsequent calls to avoid log spam and repeated retries.
 
 ## Multi-Tenancy
 

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -119,6 +119,13 @@ Aura uses Claude's extended thinking capability, which captures the model's reas
 - Visible in the dashboard for debugging
 - Useful for understanding why Aura made specific decisions or tool calls
 
+Thinking capability is detected from the gateway model catalog rather than a hand-maintained regex. `getModelCapabilities` reads the `tags` column synced from the Vercel AI Gateway and reports `supportsThinking` when the catalog tags include `reasoning`. This means new Claude releases light up automatically without a code change.
+
+Two thinking modes are supported:
+
+- **Classic budget** -- `{ type: "enabled", budgetTokens }`. The caller sets a token budget per step. Used for Sonnet and older Opus models.
+- **Adaptive** -- `{ type: "adaptive" }`. The model self-manages its own reasoning budget. Opus 4.7 is adaptive-only and will reject a classic budget request with `AI_NoOutputGeneratedError`. Adaptive-only gateway IDs are kept in a small allowlist in `prepare-step.ts`.
+
 ## Multi-Tenancy
 
 Aura's database schema is workspace-scoped. A central `workspaces` table (keyed by Slack team ID) owns all data, and every major table includes a `workspace_id` foreign key:

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -27,10 +27,13 @@ The **Invocations** sub-tab (`/conversations/invocations`) shows each individual
 
 Track token usage and costs over time:
 
-- Daily/weekly/monthly cost charts
+- Daily/weekly/monthly cost charts with shareable date range filters
 - Breakdown by model (Claude, Grok, etc.)
-- Per-user consumption
+- Per-user consumption tables with totals and pagination
 - Token type distribution (input vs output vs cache)
+- Share bars for quick relative comparisons
+
+The date range selection is reflected in the URL so specific windows can be bookmarked and shared.
 
 ### Memories
 
@@ -96,8 +99,9 @@ Manage ingested content:
 Configure instance behavior:
 
 - Admin user IDs
-- Model selection
+- Model selection (searchable autocomplete grouped by provider)
 - Feature flags
+- Theme selection (light/dark/system) -- moved here from the header
 
 ## Access & Authentication
 
@@ -115,3 +119,9 @@ The callback issues a session JWT (HS256, 30-day expiry) stored as an HTTP-only 
 ## Chat
 
 The dashboard includes an embedded chat interface for interacting with Aura directly from the admin UI -- useful for testing and debugging without switching to Slack.
+
+The model picker in the chat panel uses the same searchable autocomplete as the Settings page, grouped by provider. Both stay in sync -- changing the model in one place updates the other.
+
+## Navigation
+
+Account controls (settings, account menu) live in the sidebar footer, following the Cursor navigation pattern. The header stays focused on page actions. Theme selection (light/dark/system) is inside Settings rather than the header.

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -122,6 +122,10 @@ The dashboard includes an embedded chat interface for interacting with Aura dire
 
 The model picker in the chat panel uses the same searchable autocomplete as the Settings page, grouped by provider. Both stay in sync -- changing the model in one place updates the other.
 
+A copy-to-clipboard button in the chat header exports the current conversation (including tool calls, tool results, and reasoning) as JSON -- handy for sharing a repro, filing a bug, or seeding an evaluation case.
+
+Each chat message carries its own `modelId` / `resolvedModelId` metadata, so the exported JSON records which model actually produced each turn even when the selection changes mid-conversation.
+
 ## Navigation
 
 Account controls (settings, account menu) live in the sidebar footer, following the Cursor navigation pattern. The header stays focused on page actions. Theme selection (light/dark/system) is inside Settings rather than the header.


### PR DESCRIPTION
## What

Syncs dashboard docs with four recent feature merges:

- **#895/#896** — Consumption page now has shareable URL-based date range filters, per-user tables with totals and pagination, and share bars. Docs reflected.
- **#901** — Model picker is now a unified searchable autocomplete grouped by provider in both Chat and Settings. Documented in both sections + a note that they stay in sync.
- **#904** — Account controls (settings link, account menu) moved to sidebar footer. Theme selection moved into Settings. Added a new Navigation section + updated Settings bullet.

## Why

These were all P2 gaps -- the docs described the old behaviour. No P0/P1 inaccuracies found in today's run.

## Checklist
- [x] No changes to main directly
- [x] One PR per run
- [x] Accuracy-first (fixes wrong/stale info before adding new)