### PR TITLE
fix(chat): restore follow-up turns, tool cards, and gateway-driven thinking

### DIFF
--- a/apps/api/src/cron/persist-conversation.ts
+++ b/apps/api/src/cron/persist-conversation.ts
@@ -133,6 +133,13 @@ function stepToParts(step: Step): PartRow[] {
     parts.push({ type: "reasoning", orderIndex: idx++, textValue: step.reasoning.map((r) => r.text).join('\n\n') });
   }
 
+  // Text must precede tool-invocations. Anthropic's API rejects assistant
+  // messages that have tool_use blocks followed by text, because the next
+  // message MUST start with tool_result for the pending tool_use IDs.
+  if (step.text) {
+    parts.push({ type: "text", orderIndex: idx++, textValue: step.text });
+  }
+
   if (step.toolCalls && step.toolCalls.length > 0) {
     for (const tc of step.toolCalls) {
       const tr = step.toolResults?.find((r) => r.toolCallId === tc.toolCallId);
@@ -146,10 +153,6 @@ function stepToParts(step: Step): PartRow[] {
         toolState: tr ? "result" : "call",
       });
     }
-  }
-
-  if (step.text) {
-    parts.push({ type: "text", orderIndex: idx++, textValue: step.text });
   }
 
   return parts;
@@ -197,16 +200,14 @@ export function buildConversationSteps(
 // Saves system + user messages immediately so they survive crashes.
 // Returns the next orderIndex for assistant messages.
 //
-// Optional `conversationHistory` captures prior user/assistant turns that were
-// sent to the model as `messages` (dashboard path). For Slack, thread context
-// is already inside the system prompt as <conversation>, so this is typically
-// only used by the dashboard.
+// Each trace represents ONE turn (system + user + assistant steps). Prior
+// turns live in their own traces and are reconstructed by walking all traces
+// of a thread in order — so we do NOT re-persist prior history here.
 
 export async function persistConversationInputs(
   conversationId: string,
   systemPrompt: string,
   userPrompt: string,
-  conversationHistory?: Array<{ role: string; content: string }>,
 ): Promise<number> {
   try {
     let orderIndex = 0;
@@ -215,26 +216,18 @@ export async function persistConversationInputs(
       { type: "text", orderIndex: 0, textValue: systemPrompt },
     ], systemPrompt, null, null);
 
-    if (conversationHistory && conversationHistory.length > 0) {
-      for (const msg of conversationHistory) {
-        await insertMessage(conversationId, msg.role, orderIndex++, [
-          { type: "text", orderIndex: 0, textValue: msg.content },
-        ], msg.content, null, null);
-      }
-    }
-
     await insertMessage(conversationId, "user", orderIndex++, [
       { type: "text", orderIndex: 0, textValue: userPrompt },
     ], userPrompt, null, null);
 
-    logger.info("persistConversationInputs: saved", { conversationId, historyMessages: conversationHistory?.length ?? 0 });
+    logger.info("persistConversationInputs: saved", { conversationId });
     return orderIndex;
   } catch (err: any) {
     logger.error("persistConversationInputs: failed (non-fatal)", {
       conversationId,
       error: err.message,
     });
-    return conversationHistory ? conversationHistory.length + 2 : 2;
+    return 2;
   }
 }
 

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -58,31 +58,14 @@ export async function getMainModel() {
 }
 
 /**
- * Map Vercel AI Gateway model IDs to direct Anthropic API model IDs.
- * Gateway uses short names (e.g. "anthropic/claude-haiku-4-5") while
- * the direct API requires dated slugs (e.g. "claude-3-5-haiku-20241022").
+ * Convert a Vercel AI Gateway model ID into a direct Anthropic API model ID.
+ * Gateway uses dotted versions (e.g. "anthropic/claude-opus-4.7") while the
+ * direct API uses dashed versions ("claude-opus-4-7"). Returns null for
+ * non-Anthropic models.
  */
-const GATEWAY_TO_ANTHROPIC: Record<string, string> = {
-  "anthropic/claude-haiku-4.5": "claude-haiku-4-5-20251001",
-  "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
-  "anthropic/claude-opus-4.6": "claude-opus-4-6",
-  "anthropic/claude-sonnet-4.5": "claude-sonnet-4-5-20250929",
-  "anthropic/claude-sonnet-4.6": "claude-sonnet-4-6",
-  "anthropic/claude-sonnet-4-20250514": "claude-sonnet-4-20250514",
-  "anthropic/claude-opus-4-6": "claude-opus-4-6",
-  "anthropic/claude-sonnet-4-5-20250514": "claude-sonnet-4-5-20250929",
-  "anthropic/claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
-  "anthropic/claude-sonnet-4-6": "claude-sonnet-4-6",
-};
-
 function toDirectAnthropicId(gatewayId: string): string | null {
-  if (GATEWAY_TO_ANTHROPIC[gatewayId]) {
-    return GATEWAY_TO_ANTHROPIC[gatewayId];
-  }
-  // Fallback: strip "anthropic/" prefix (works when gateway ID matches API ID)
-  return gatewayId.startsWith("anthropic/")
-    ? gatewayId.slice("anthropic/".length)
-    : null;
+  if (!gatewayId.startsWith("anthropic/")) return null;
+  return gatewayId.slice("anthropic/".length).replace(/\./g, "-");
 }
 
 async function getDirectAnthropicModel(modelId: string) {
@@ -165,36 +148,10 @@ export async function getEmbeddingModel() {
 }
 
 /**
- * Check if a model supports the Anthropic `effort` parameter.
- * Currently supported: Claude Opus 4.5, Opus 4.6, and Sonnet 4.6.
- */
-export function supportsEffort(modelId: string): boolean {
-  return /claude-(?:opus-4-[56]|sonnet-4-6)/.test(modelId);
-}
-
-/**
- * Check if a model supports adaptive thinking (`thinking.type: "adaptive"`).
- * All models that support the `effort` parameter also require adaptive thinking;
- * sending manual `type: "enabled"` with `budgetTokens` alongside `effort` is invalid.
- */
-export function supportsAdaptiveThinking(modelId: string): boolean {
-  return /claude-(?:opus-4-[56]|sonnet-4-6)/.test(modelId);
-}
-
-/**
- * Check if a model supports extended thinking (manual `type: "enabled"` with `budgetTokens`).
- * Matches Sonnet 4, Sonnet 4.5, Opus 4.5, etc. — but NOT Haiku or non-Claude models.
- * For models that also support adaptive thinking, `supportsAdaptiveThinking` takes priority.
- */
-export function supportsThinking(modelId: string): boolean {
-  return /claude-(?:sonnet|opus)-4/.test(modelId);
-}
-
-/**
- * Check if a model is Anthropic (general check, not thinking-specific).
+ * Check if a model is Anthropic (used to decide where provider options apply).
  */
 export function isAnthropicModel(modelId: string): boolean {
-  return modelId.includes("anthropic") || modelId.includes("claude");
+  return modelId.startsWith("anthropic/") || modelId.startsWith("claude");
 }
 
 /**

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -367,3 +367,62 @@ export async function getDefaultModelId(
   return catalog.defaults[category] ?? null;
 }
 
+// ── Model capabilities (from gateway tags) ───────────────────────────────────
+// The Vercel AI Gateway returns a `tags` array per model. We treat the
+// presence of `"reasoning"` as the signal that a model supports thinking —
+// this is the same source of truth used across repos (mako/mono). No model
+// ID parsing.
+
+export interface ModelCapabilities {
+  supportsThinking: boolean;
+  tags: string[];
+}
+
+const CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
+const capabilityCache = new Map<string, { value: ModelCapabilities; expiresAt: number }>();
+const MISSING_CAPABILITIES: ModelCapabilities = { supportsThinking: false, tags: [] };
+
+export async function getModelCapabilities(
+  modelId: string,
+  workspaceId = DEFAULT_WORKSPACE_ID,
+): Promise<ModelCapabilities> {
+  const cacheKey = `${workspaceId}::${modelId}`;
+  const cached = capabilityCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const [row] = await db
+    .select({ tags: modelCatalog.tags })
+    .from(modelCatalog)
+    .where(
+      and(
+        eq(modelCatalog.workspaceId, workspaceId),
+        eq(modelCatalog.modelId, modelId),
+      ),
+    )
+    .limit(1);
+
+  const tags = Array.isArray(row?.tags) ? row!.tags : [];
+  const value: ModelCapabilities = {
+    supportsThinking: tags.includes("reasoning"),
+    tags,
+  };
+
+  if (!row) {
+    logger.warn("getModelCapabilities: model not in catalog", {
+      modelId,
+      workspaceId,
+    });
+    capabilityCache.set(cacheKey, {
+      value: MISSING_CAPABILITIES,
+      expiresAt: Date.now() + CAPABILITY_CACHE_TTL_MS,
+    });
+    return MISSING_CAPABILITIES;
+  }
+
+  capabilityCache.set(cacheKey, {
+    value,
+    expiresAt: Date.now() + CAPABILITY_CACHE_TTL_MS,
+  });
+  return value;
+}
+

--- a/apps/api/src/pipeline/prepare-step.ts
+++ b/apps/api/src/pipeline/prepare-step.ts
@@ -1,7 +1,8 @@
 import { pruneMessages } from "ai";
 import type { LanguageModel, ModelMessage } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
-import { supportsEffort, supportsAdaptiveThinking, supportsThinking } from "../lib/ai.js";
+import { isAnthropicModel } from "../lib/ai.js";
+import { getModelCapabilities } from "../lib/model-catalog.js";
 import { isInvocationCurrent } from "../lib/invocation-lock.js";
 import { logger } from "../lib/logger.js";
 
@@ -42,10 +43,16 @@ type PrepareStepFn = (options: {
  * Build a `prepareStep` callback for AI SDK's streamText/generateText.
  *
  * Handles:
- * 1. Effort escalation (Anthropic only): starts at defaultEffort (usually "medium"),
- *    bumps to "high" when the agent is deep into a task or hitting tool failures,
- *    and optionally escalates the model from Sonnet to Opus for persistent failures.
- * 2. Step limit warning: injects a system-level wrap-up nudge near the step limit.
+ * 1. Thinking: enables extended thinking with `budgetTokens` on any model
+ *    whose gateway catalog entry carries the `reasoning` tag. No model ID
+ *    parsing — the AI Gateway tells us which models support thinking.
+ * 2. Model escalation: after repeated tool failures, swaps to the escalation
+ *    model (typically Sonnet → Opus).
+ * 3. Step limit warning: injects a system-level wrap-up nudge near the step
+ *    limit.
+ *
+ * `defaultEffort` is accepted for backwards compatibility but currently
+ * ignored — we rely on the model's own adaptive behavior.
  */
 export function createPrepareStep(opts: {
   stepLimit?: number;
@@ -64,11 +71,32 @@ export function createPrepareStep(opts: {
 }): PrepareStepFn {
   const limit = opts.stepLimit ?? STEP_LIMIT;
   const threshold = opts.warningThreshold ?? WARNING_THRESHOLD;
-  const hasEffortSupport = opts.modelId ? supportsEffort(opts.modelId) : false;
-  let currentEffort: EffortLevel = opts.defaultEffort ?? "medium";
   let hasEscalatedModel = false;
   let escalatedModel: { modelId: string; model: LanguageModel } | null = null;
   let failureCount = 0;
+
+  // Cache thinking support per model ID for this prepareStep instance.
+  // Catalog lookups are already in-memory-cached (5 min TTL), but we also
+  // memoize here so we don't hit the cache on every step.
+  const thinkingCache = new Map<string, boolean>();
+  async function modelSupportsThinking(modelId: string | undefined): Promise<boolean> {
+    if (!modelId) return false;
+    if (!isAnthropicModel(modelId)) return false;
+    const hit = thinkingCache.get(modelId);
+    if (hit !== undefined) return hit;
+    try {
+      const caps = await getModelCapabilities(modelId);
+      thinkingCache.set(modelId, caps.supportsThinking);
+      return caps.supportsThinking;
+    } catch (err: any) {
+      logger.warn("prepareStep: capability lookup failed", {
+        modelId,
+        error: err?.message,
+      });
+      thinkingCache.set(modelId, false);
+      return false;
+    }
+  }
 
   return async ({ stepNumber, steps, messages }) => {
     // --- Invocation staleness check (abort if superseded) ---
@@ -109,32 +137,10 @@ export function createPrepareStep(opts: {
 
     if (hadToolFailure) failureCount++;
 
-    // --- Effort escalation (runs first so currentEffort is up to date for model escalation) ---
-    if (hasEffortSupport) {
-      let newEffort = currentEffort;
-
-      if (stepNumber > 8 || hadToolFailure) {
-        if (currentEffort === "low") newEffort = "medium";
-        else if (currentEffort === "medium") newEffort = "high";
-      }
-
-      if (newEffort !== currentEffort) {
-        currentEffort = newEffort;
-        logger.info("prepareStep: escalating effort", {
-          stepNumber,
-          effort: currentEffort,
-        });
-      }
-    }
-
     // --- Model escalation: persistent failures → escalation model ---
-    const readyToEscalateModel = hasEffortSupport
-      ? (currentEffort === "high" && hadToolFailure)
-      : (failureCount >= 3);
-
     if (
       stepNumber > 15 &&
-      readyToEscalateModel &&
+      failureCount >= 3 &&
       !hasEscalatedModel &&
       opts.getEscalationModel
     ) {
@@ -155,25 +161,19 @@ export function createPrepareStep(opts: {
       modelOverride = escalatedModel.model;
     }
 
-    // Recompute capability flags for the effective model (may differ after escalation)
+    // Effective model may have changed via escalation; look up its thinking
+    // support via the gateway-sourced catalog (tags.includes("reasoning")).
     const effectiveModelId = (hasEscalatedModel && escalatedModel) ? escalatedModel.modelId : opts.modelId;
     opts.recordStepModelId?.(stepNumber, effectiveModelId);
-    const activeHasEffortSupport = effectiveModelId ? supportsEffort(effectiveModelId) : false;
-    const activeHasAdaptiveThinking = effectiveModelId ? supportsAdaptiveThinking(effectiveModelId) : false;
-    const activeHasThinkingSupport = effectiveModelId ? supportsThinking(effectiveModelId) : false;
+    const thinkingEnabled = await modelSupportsThinking(effectiveModelId);
 
-    // --- Build Anthropic provider options (thinking + effort) ---
-    const anthropicOpts: Record<string, any> = {};
-    if (activeHasAdaptiveThinking) {
-      anthropicOpts.thinking = { type: "adaptive" };
-    } else if (activeHasThinkingSupport && opts.thinkingBudget) {
-      anthropicOpts.thinking = { type: "enabled", budgetTokens: opts.thinkingBudget };
-    }
-    if (activeHasEffortSupport) {
-      anthropicOpts.effort = currentEffort;
-    }
-    if (Object.keys(anthropicOpts).length > 0) {
-      providerOptions = { anthropic: anthropicOpts };
+    // --- Build Anthropic provider options ---
+    if (thinkingEnabled && opts.thinkingBudget) {
+      providerOptions = {
+        anthropic: {
+          thinking: { type: "enabled", budgetTokens: opts.thinkingBudget },
+        },
+      };
     }
 
     // --- Step limit warning ---

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -2,7 +2,6 @@ import { createRoute, z } from "@hono/zod-openapi";
 import {
   convertToModelMessages,
   type UIMessage,
-  type ModelMessage,
   type StepResult,
   type LanguageModelUsage,
 } from "ai";
@@ -211,11 +210,20 @@ dashboardChatApp.openapi(getThreadMessagesRoute, async (c) => {
 
         if (uiParts.length === 0) continue;
 
+        const metadata =
+          msg.role === "assistant" && (msg.modelId || msg.resolvedModelId)
+            ? {
+                modelId: msg.modelId ?? undefined,
+                resolvedModelId: msg.resolvedModelId ?? undefined,
+              }
+            : undefined;
+
         uiMessages.push({
           id: `restored-${msgIndex++}`,
           role: msg.role as "user" | "assistant",
           parts: uiParts,
-        });
+          ...(metadata ? { metadata } : {}),
+        } as UIMessage);
       }
     }
 
@@ -226,6 +234,35 @@ dashboardChatApp.openapi(getThreadMessagesRoute, async (c) => {
   }
 });
 
+/**
+ * Anthropic rejects assistant messages where tool_use blocks are followed by
+ * text in the same message, because the next message must immediately start
+ * with tool_result. Reorder parts so text comes before tool-invocations.
+ * Also strip reasoning parts from non-final messages (they require signed
+ * provider metadata that we don't persist).
+ */
+function sanitizeAssistantPartOrder(messages: UIMessage[]): UIMessage[] {
+  return messages.map((msg) => {
+    if (msg.role !== "assistant" || !msg.parts) return msg;
+
+    const textParts: any[] = [];
+    const toolParts: any[] = [];
+    const otherParts: any[] = [];
+
+    for (const part of msg.parts as any[]) {
+      if (part.type === "text") textParts.push(part);
+      else if (part.type === "dynamic-tool" || (typeof part.type === "string" && part.type.startsWith("tool-")))
+        toolParts.push(part);
+      else if (part.type === "reasoning" || part.type === "step-start") {
+        // drop: reasoning needs signed metadata, step-start is UI-only
+      } else otherParts.push(part);
+    }
+
+    if (toolParts.length === 0) return msg;
+    return { ...msg, parts: [...otherParts, ...textParts, ...toolParts] } as UIMessage;
+  });
+}
+
 function partsToUIParts(
   parts: (typeof conversationParts.$inferSelect)[],
   fallbackContent: string | null,
@@ -234,23 +271,19 @@ function partsToUIParts(
     return [{ type: "text", text: fallbackContent }];
   }
 
-  const uiParts: UIMessage["parts"] = [];
+  const textParts: UIMessage["parts"] = [];
+  const toolParts: UIMessage["parts"] = [];
 
   for (const part of parts) {
     switch (part.type) {
       case "text":
         if (part.textValue) {
-          uiParts.push({ type: "text", text: part.textValue });
-        }
-        break;
-      case "reasoning":
-        if (part.textValue) {
-          uiParts.push({ type: "reasoning", text: part.textValue, providerMetadata: {} });
+          textParts.push({ type: "text", text: part.textValue });
         }
         break;
       case "tool-invocation":
         if (part.toolCallId && part.toolName) {
-          uiParts.push({
+          toolParts.push({
             type: "dynamic-tool",
             toolName: part.toolName,
             toolCallId: part.toolCallId,
@@ -260,10 +293,17 @@ function partsToUIParts(
           });
         }
         break;
+      // "reasoning" and "step-start" parts are intentionally dropped on restore:
+      // reasoning requires signed provider metadata to re-send to Anthropic, and
+      // step-start is a UI-only marker. Dropping them is safe for follow-up turns.
     }
   }
 
-  return uiParts;
+  // Anthropic requires assistant messages with tool_use blocks to end with
+  // tool_use (tool_result must come immediately after). Put text BEFORE
+  // tool-invocations so the trailing text doesn't break the tool_use →
+  // tool_result pairing that convertToModelMessages emits.
+  return [...textParts, ...toolParts];
 }
 
 // ── Dashboard chat (streaming) ──────────────────────────────────────────────
@@ -363,15 +403,8 @@ dashboardChatApp.openapi(postChatRoute, async (c) => {
 
     const tools = await createCoreTools({ userId, channelId: "dashboard" });
 
-    for (const msg of messages) {
-      const partTypes = msg.parts?.map((p: any) => p.type) ?? [];
-      if (partTypes.some((t: string) => t.startsWith("tool") || t === "dynamic-tool" || t === "step-start")) {
-        logger.info("Dashboard chat message with tools", { id: msg.id, role: msg.role, partTypes });
-      }
-    }
-
-    const modelMessages = await convertToModelMessages(messages);
-    const priorMessages = serializeConversationHistory(modelMessages);
+    const sanitizedMessages = sanitizeAssistantPartOrder(messages);
+    const modelMessages = await convertToModelMessages(sanitizedMessages);
 
     const result = executionContext.run(
       { triggeredBy: userId, triggerType: "user_message", callingUserId: userId, channelId: "dashboard" },
@@ -399,7 +432,6 @@ dashboardChatApp.openapi(postChatRoute, async (c) => {
               userMessage: messageText,
               assistantText: text,
               systemPrompt: fullSystemPrompt,
-              conversationHistory: priorMessages,
               steps,
               stepModelIds,
               totalUsage,
@@ -414,9 +446,17 @@ dashboardChatApp.openapi(postChatRoute, async (c) => {
     return result.toUIMessageStreamResponse({
       originalMessages: messages,
       sendReasoning: true,
+      messageMetadata: ({ part }) => {
+        if (part.type === "start") {
+          return { modelId };
+        }
+      },
     });
   } catch (error) {
-    logger.error("Dashboard chat error", { error });
+    logger.error("Dashboard chat error", {
+      error: error instanceof Error ? error.stack ?? error.message : String(error),
+      name: error instanceof Error ? error.name : undefined,
+    });
     return c.json({ error: "Internal server error" }, 500);
   }
 });
@@ -429,12 +469,11 @@ async function persistDashboardConversation(params: {
   userMessage: string;
   assistantText: string;
   systemPrompt: string;
-  conversationHistory?: Array<{ role: string; content: string }>;
   steps: StepResult<any>[];
   stepModelIds: string[];
   totalUsage: LanguageModelUsage;
 }): Promise<void> {
-  const { userId, messageId, modelId, threadId, userMessage, assistantText, systemPrompt, conversationHistory, steps, stepModelIds, totalUsage } = params;
+  const { userId, messageId, modelId, threadId, userMessage, assistantText, systemPrompt, steps, stepModelIds, totalUsage } = params;
 
   try {
     logger.info("persistDashboardConversation started", { threadId, messageId });
@@ -512,7 +551,7 @@ async function persistDashboardConversation(params: {
     });
 
     if (traceId) {
-      const orderIndex = await persistConversationInputs(traceId, systemPrompt, userMessage, conversationHistory);
+      const orderIndex = await persistConversationInputs(traceId, systemPrompt, userMessage);
 
       const conversationSteps = buildConversationSteps(steps, stepModelIds, modelId);
       await persistConversationSteps(traceId, conversationSteps, orderIndex);
@@ -545,45 +584,4 @@ async function resolveDashboardDisplayName(userId: string): Promise<string> {
   } catch {
     return userId;
   }
-}
-
-/**
- * Extract a flat {role, content} array from ModelMessage[] for trace persistence.
- * Strips the last user message (persisted separately by persistConversationInputs)
- * and skips system messages (already in the system prompt).
- */
-function serializeConversationHistory(
-  modelMessages: ModelMessage[],
-): Array<{ role: string; content: string }> {
-  const result: Array<{ role: string; content: string }> = [];
-
-  for (const msg of modelMessages) {
-    if (msg.role === "system" || msg.role === "tool") continue;
-
-    let content: string;
-    if (typeof msg.content === "string") {
-      content = msg.content;
-    } else if (Array.isArray(msg.content)) {
-      content = msg.content
-        .map((part: any) => {
-          if (part.type === "text") return part.text;
-          if (part.type === "tool-call") return `[tool_call: ${part.toolName}(${JSON.stringify(part.args).slice(0, 200)})]`;
-          if (part.type === "tool-result") return `[tool_result: ${part.toolName} → ${JSON.stringify(part.result).slice(0, 500)}]`;
-          return "";
-        })
-        .filter(Boolean)
-        .join("\n");
-    } else {
-      content = String(msg.content ?? "");
-    }
-
-    if (content) result.push({ role: msg.role, content });
-  }
-
-  // Drop the last user message — it's saved separately as the "current" user prompt
-  if (result.length > 0 && result[result.length - 1].role === "user") {
-    result.pop();
-  }
-
-  return result;
 }

--- a/apps/dashboard/src/components/chat/chat-panel.tsx
+++ b/apps/dashboard/src/components/chat/chat-panel.tsx
@@ -9,6 +9,8 @@ import {
   ArrowUpIcon,
   SquareIcon,
   PaperclipIcon,
+  Copy,
+  Check,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -100,6 +102,7 @@ export function ChatPanel({ onClose, userId }: ChatPanelProps) {
   const [threads, setThreads] = useState<ChatThread[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [loadingThread, setLoadingThread] = useState(false);
+  const [copied, setCopied] = useState(false);
   const [selectedModel, setSelectedModel] = useState("");
   const [modelOptions, setModelOptions] = useState<ModelAutocompleteOption[]>([]);
   const threadIdRef = useRef(currentThreadId);
@@ -180,6 +183,28 @@ export function ChatPanel({ onClose, userId }: ChatPanelProps) {
     setShowHistory(false);
   }, [setMessages]);
 
+  const handleCopyChat = useCallback(async () => {
+    if (messages.length === 0) return;
+    try {
+      const payload = {
+        threadId: currentThreadId,
+        exportedAt: new Date().toISOString(),
+        messages: messages.map((m) => ({
+          id: m.id,
+          role: m.role,
+          parts: m.parts,
+          metadata: (m as { metadata?: unknown }).metadata,
+        })),
+      };
+      const json = JSON.stringify(payload, null, 2);
+      await navigator.clipboard.writeText(json);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard API may fail in insecure contexts; silently ignore
+    }
+  }, [messages, currentThreadId]);
+
   const handleSelectThread = useCallback(
     async (threadId: string) => {
       if (threadId === currentThreadId) {
@@ -233,6 +258,18 @@ export function ChatPanel({ onClose, userId }: ChatPanelProps) {
             title="Chat history"
           >
             <Clock className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={handleCopyChat}
+            disabled={messages.length === 0}
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+            title={copied ? "Copied!" : "Copy chat as JSON"}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-emerald-500" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
           </button>
           <button
             onClick={onClose}


### PR DESCRIPTION
## Summary

- Fixes follow-up turns in the dashboard chat (they were dying with Anthropic `tool_use`/`tool_result` ordering errors and duplicated history from the persistence layer).
- Restores tool cards in the chat feed — each conversation trace now stores only its own turn instead of re-inserting the whole client history as flat text.
- Replaces the hand-maintained Claude-version regex (`parseClaudeVersion`, `supportsEffort`, `supportsAdaptiveThinking`, `supportsThinking`) with a gateway-driven lookup: `getModelCapabilities` reads the catalog `tags` column and treats `tags.includes("reasoning")` as the truth source for thinking support. Same approach as mako-ai/mono. Fixes Opus 4.7 failing in Slack with `AI_NoOutputGeneratedError`.
- Generalizes `toDirectAnthropicId` (strip `anthropic/`, swap `.` → `-`) so new Claude versions work without a hardcoded map.
- Drops adaptive-thinking and effort-escalation branches from `prepare-step.ts`. Model escalation on repeated tool failures is retained.
- Adds a copy-chat button to the dashboard chat header (JSON export, including tool calls).

## Notes

- `defaultEffort` is kept on the prepareStep factory signatures for backwards compatibility but is now a no-op; callers don't need to change.
- Capability lookups are memoized in-memory (5 min TTL at the catalog layer, per-instance cache in prepareStep) to avoid per-step DB hits.

## Test plan

- [ ] Send a multi-turn chat in the dashboard with Sonnet — follow-ups succeed, tool cards render.
- [ ] Switch the dashboard dropdown to Opus 4.7, send a message, verify no errors and tool cards render.
- [ ] Ping Aura in Slack with Opus 4.7 selected and confirm the `AI_NoOutputGeneratedError` is gone.
- [ ] Copy chat JSON from the header; confirm per-message `metadata.modelId` / `resolvedModelId` reflect the actual model used.

Made with [Cursor](https://cursor.com)