### PR TITLE
fix(thinking): use adaptive thinking type for Opus 4.7

### DIFF
--- a/apps/api/src/pipeline/prepare-step.ts
+++ b/apps/api/src/pipeline/prepare-step.ts
@@ -54,6 +54,32 @@ type PrepareStepFn = (options: {
  * `defaultEffort` is accepted for backwards compatibility but currently
  * ignored — we rely on the model's own adaptive behavior.
  */
+
+/**
+ * Some Anthropic models only support adaptive thinking (self-managed budget),
+ * not the classic `{ type: "enabled", budgetTokens }` API. Opus 4.7 is the
+ * first such model. Sending `enabled` to an adaptive-only model causes the
+ * direct Anthropic API to reject the request, producing
+ * `AI_NoOutputGeneratedError` with an empty stream.
+ *
+ * The gateway catalog only exposes a single `reasoning` tag and doesn't
+ * distinguish the two thinking modes, so we keep a small allowlist of
+ * adaptive-only gateway IDs. When more land, add them here.
+ */
+const ADAPTIVE_ONLY_THINKING_MODELS = new Set<string>([
+  "anthropic/claude-opus-4.7",
+]);
+
+function getAnthropicThinkingOptions(
+  modelId: string,
+  budgetTokens: number,
+): { type: "adaptive" } | { type: "enabled"; budgetTokens: number } {
+  if (ADAPTIVE_ONLY_THINKING_MODELS.has(modelId)) {
+    return { type: "adaptive" };
+  }
+  return { type: "enabled", budgetTokens };
+}
+
 export function createPrepareStep(opts: {
   stepLimit?: number;
   warningThreshold?: number;
@@ -168,10 +194,10 @@ export function createPrepareStep(opts: {
     const thinkingEnabled = await modelSupportsThinking(effectiveModelId);
 
     // --- Build Anthropic provider options ---
-    if (thinkingEnabled && opts.thinkingBudget) {
+    if (thinkingEnabled && opts.thinkingBudget && effectiveModelId) {
       providerOptions = {
         anthropic: {
-          thinking: { type: "enabled", budgetTokens: opts.thinkingBudget },
+          thinking: getAnthropicThinkingOptions(effectiveModelId, opts.thinkingBudget),
         },
       };
     }


### PR DESCRIPTION
## Summary

Fixes Slack + Dashboard chat failures on Opus 4.7 (`AI_NoOutputGeneratedError` → 'Sorry, I got interrupted…' fallback).

**Root cause:** Opus 4.7 dropped support for `thinking: { type: "enabled", budgetTokens }` — it only supports `{ type: "adaptive" }`. Sending `enabled` makes the direct Anthropic API reject the request with an empty stream.

PR #908 made capability lookup gateway-driven via the `reasoning` tag, but the Vercel AI Gateway catalog carries a single `reasoning` tag for both thinking modes — so we can't distinguish Opus 4.7 (adaptive-only) from Opus 4.6 / Sonnet 4.6 (both modes supported) from the catalog alone.

## Evidence

Live Anthropic `/v1/models` returns:

| Model | thinking.enabled | thinking.adaptive |
|---|---|---|
| claude-opus-4-7 | **false** | true |
| claude-opus-4-6 | true | true |
| claude-sonnet-4-6 | true | true |

Error pattern in `error_events` after PR #908 merged (17:52 UTC):

```
18:04:53  AI_NoOutputGeneratedError  pipeline_error    dm
18:04:50  AI_NoOutputGeneratedError  streaming_failure
18:00:16  AI_NoOutputGeneratedError  pipeline_error    dm
18:00:15  AI_NoOutputGeneratedError  streaming_failure
```

## Fix

`prepare-step.ts` builds provider options via a new `getAnthropicThinkingOptions(modelId, budget)` helper that returns `{ type: "adaptive" }` for models in an `ADAPTIVE_ONLY_THINKING_MODELS` allowlist (currently just `anthropic/claude-opus-4.7`), and `{ type: "enabled", budgetTokens }` for everything else.

Non-adaptive-only models keep identical behavior to today.

## Test plan

- [ ] Merge + deploy
- [ ] Ping Aura in Slack with `model_main = anthropic/claude-opus-4.7` → streams cleanly, no fallback message
- [ ] Ping in dashboard chat with Opus 4.7 → same
- [ ] Sanity-check Opus 4.6 / Sonnet 4.6 still work unchanged

## Follow-up (not in this PR)

Longer-term: add a second gateway catalog tag (e.g. `thinking-adaptive-only`) and drop the allowlist. Will file an issue.