### PR TITLE
fix: code-level channel gate for gated channels (#918)

### DIFF
--- a/apps/api/src/pipeline/context.test.ts
+++ b/apps/api/src/pipeline/context.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isChannelGatedOut } from "./context.js";
+
+describe("isChannelGatedOut", () => {
+  it("gates channel messages without explicit mention when channel is configured", () => {
+    const result = isChannelGatedOut(
+      { isDm: false, isMentioned: false, channelId: "Cbugs" },
+      new Set(["Cbugs"]),
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("allows messages with explicit mention in a gated channel", () => {
+    const result = isChannelGatedOut(
+      { isDm: false, isMentioned: true, channelId: "Cbugs" },
+      new Set(["Cbugs"]),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("does not gate when gated_channels is empty", () => {
+    const result = isChannelGatedOut(
+      { isDm: false, isMentioned: false, channelId: "Cbugs" },
+      new Set(),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("bypasses gate for DMs regardless of gated channel config", () => {
+    const result = isChannelGatedOut(
+      { isDm: true, isMentioned: false, channelId: "Cbugs" },
+      new Set(["Cbugs"]),
+    );
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/api/src/pipeline/context.test.ts
+++ b/apps/api/src/pipeline/context.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from "vitest";
-import { isChannelGatedOut } from "./context.js";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+let isChannelGatedOut: (
+  context: { isDm: boolean; isMentioned: boolean; channelId: string },
+  gatedChannels: Set<string>,
+) => boolean;
+
+beforeAll(async () => {
+  vi.mock("../lib/ai.js", () => ({
+    getFastModel: vi.fn(),
+    withCacheControl: vi.fn(),
+  }));
+  vi.mock("../tools/slack.js", () => ({
+    resolveChannelById: vi.fn(),
+  }));
+  ({ isChannelGatedOut } = await import("./context.js"));
+});
 
 describe("isChannelGatedOut", () => {
   it("gates channel messages without explicit mention when channel is configured", () => {

--- a/apps/api/src/pipeline/context.ts
+++ b/apps/api/src/pipeline/context.ts
@@ -163,10 +163,27 @@ export interface ShouldRespondResult {
   reason: string;
 }
 
+export function isChannelGatedOut(
+  context: Pick<MessageContext, "isDm" | "isMentioned" | "channelId">,
+  gatedChannels: Set<string>,
+): boolean {
+  if (context.isDm || context.isMentioned) {
+    return false;
+  }
+
+  return gatedChannels.has(context.channelId);
+}
+
 // ── Channel-level override ───────────────────────────────────────────────────
 // Channels in this list always process new messages without LLM gating (Tier 4
 // is bypassed). Managed via DB setting "always_process_channels" (comma-separated
 // channel IDs). Change at runtime — no redeploy needed.
+//
+// ── Channel gating (hard, code-level) ────────────────────────────────────────
+// Channels in the "gated_channels" setting (JSON array of channel IDs) require
+// an explicit @Aura mention to trigger any pipeline processing. Unlike
+// "always_process_channels" (which OPENS the gate), "gated_channels" CLOSES it.
+// Enforced in runPipeline — see issue #918.
 
 
 /**

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -148,19 +148,21 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
   // Gated-channel gate: for channels listed in the "gated_channels" setting,
   // only proceed if Aura is explicitly @mentioned. This is a HARD, code-level
   // rule that cannot be bypassed by an LLM gate or prompt (see issue #918).
-  const gatedChannels = new Set(
-    (await getSettingJSON<string[]>("gated_channels", [])) ?? [],
-  );
-  if (isChannelGatedOut(context, gatedChannels)) {
-    logger.info("gated_channel_skip", {
-      channelId: context.channelId,
-      userId: context.userId,
-      reason: "gated_channel_no_mention",
-    });
-    // Still store the message for long-term memory / search. Do NOT run
-    // conversation fetch, shouldRespond, invocation lock, or LLM.
-    await scheduleStoreUserMessage(context, event, waitUntil);
-    return;
+  if (!context.isDm && !context.isMentioned) {
+    const gatedChannels = new Set(
+      (await getSettingJSON<string[]>("gated_channels", [])) ?? [],
+    );
+    if (isChannelGatedOut(context, gatedChannels)) {
+      logger.info("gated_channel_skip", {
+        channelId: context.channelId,
+        userId: context.userId,
+        reason: "gated_channel_no_mention",
+      });
+      // Still store the message for long-term memory / search. Do NOT run
+      // conversation fetch, shouldRespond, invocation lock, or LLM.
+      await scheduleStoreUserMessage(context, event, waitUntil);
+      return;
+    }
   }
 
   // 1a. Dedup: atomically claim this event; skip if another handler got there first

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -2,6 +2,7 @@ import type { WebClient } from "@slack/web-api";
 import {
   buildMessageContext,
   shouldRespond,
+  isChannelGatedOut,
   resolveSlackEntities,
   isSlackbotListNotification,
   type MessageContext,
@@ -141,6 +142,24 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
   const context = buildMessageContext(event, botUserId);
   if (!context) {
     logger.debug("Skipped event — no valid context");
+    return;
+  }
+
+  // Gated-channel gate: for channels listed in the "gated_channels" setting,
+  // only proceed if Aura is explicitly @mentioned. This is a HARD, code-level
+  // rule that cannot be bypassed by an LLM gate or prompt (see issue #918).
+  const gatedChannels = new Set(
+    (await getSettingJSON<string[]>("gated_channels", [])) ?? [],
+  );
+  if (isChannelGatedOut(context, gatedChannels)) {
+    logger.info("gated_channel_skip", {
+      channelId: context.channelId,
+      userId: context.userId,
+      reason: "gated_channel_no_mention",
+    });
+    // Still store the message for long-term memory / search. Do NOT run
+    // conversation fetch, shouldRespond, invocation lock, or LLM.
+    await scheduleStoreUserMessage(context, event, waitUntil);
     return;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- adds a hard, code-level `gated_channels` gate in `runPipeline` immediately after `buildMessageContext` and null-check
- short-circuits before `shouldRespond`, conversation fetch, invocation lock, tool calls, or LLM when a non-DM message arrives in a gated channel without explicit `<@botUserId>` mention
- logs structured `logger.info("gated_channel_skip", ...)` events and still persists user messages via `scheduleStoreUserMessage`
- documents `gated_channels` behavior in `apps/api/src/pipeline/context.ts`
- adds unit tests for gate behavior via `isChannelGatedOut`

## Why
Prompt-level and LLM gating are not deterministic enough for `#bugs` and similar channels. This enforces the channel gate in code, before any LLM pipeline activity.

## Configuration / rollout
Default remains `[]` (no channels gated), so existing behavior is unchanged until configured.

To enable for `#bugs` (`C019605SSNN`), seed the workspace setting:

```sql
INSERT INTO settings (workspace_id, key, value, updated_at)
VALUES ('<workspace_id>', 'gated_channels', '["C019605SSNN"]', now())
ON CONFLICT (workspace_id, key)
DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
```

## Validation
- `pnpm typecheck` passes
- Added tests in `apps/api/src/pipeline/context.test.ts`:
  - gated channel + no mention => gated out
  - gated channel + mention => allowed
  - empty config => allowed
  - DM => allowed
- Focused test run: `pnpm --filter aura-api exec vitest run src/pipeline/context.test.ts`

Closes #918
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43030e1a-76fe-4525-9087-702fa2b1e3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43030e1a-76fe-4525-9087-702fa2b1e3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

