### PR TITLE
fix(slack-stream): treat invalid_arguments as non-fatal on chunk append

### DIFF
--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -8,6 +8,7 @@ import { TABLE_BLOCK_KEY } from "../tools/table.js";
 import {
   safePostMessage,
   isChannelTypeNotSupported,
+  isInvalidArguments,
   isInvalidBlocks,
   isInvalidChunks,
   isMsgTooLong,
@@ -467,20 +468,32 @@ export async function generateResponse(
           channelId,
           context: { fallback: "postMessage" },
         });
-      } else if (isInvalidChunks(err)) {
-        // Non-fatal: some chunk shapes may not be supported in older Slack
-        // clients/SDKs. Continue streaming text and keep block fallback paths.
-        logger.warn("chatStream append returned invalid_chunks; skipping this chunk", {
+      } else if (isInvalidChunks(err) || isInvalidArguments(err)) {
+        // Non-fatal: some chunk shapes (e.g. the 2026 `plan` / `url_source` /
+        // `blocks` chunk types) may be rejected by the Slack API with either
+        // `invalid_chunks` or `invalid_arguments` depending on which
+        // validation layer trips. Skip the offending payload, keep streaming,
+        // and let the rest of the response land as normal `task_update` /
+        // `markdown_text` chunks.
+        const errCode = err?.data?.error || (isInvalidArguments(err) ? "invalid_arguments" : "invalid_chunks");
+        const chunkTypes = Array.isArray((payload as any)?.chunks)
+          ? (payload as any).chunks.map((c: any) => c?.type).filter(Boolean)
+          : [];
+        logger.warn("chatStream append returned recoverable validation error; skipping this chunk", {
           channelId,
-          slackError: err?.data?.error,
+          slackError: errCode,
           payloadKeys: Object.keys(payload as Record<string, unknown>),
+          chunkTypes,
         });
         logError({
-          errorName: "InvalidChunks",
-          errorMessage: err?.message || "invalid_chunks on stream append",
-          errorCode: err?.data?.error || "invalid_chunks",
+          errorName: isInvalidArguments(err) ? "InvalidArguments" : "InvalidChunks",
+          errorMessage: err?.message || `${errCode} on stream append`,
+          errorCode: errCode,
           channelId,
-          context: { payloadKeys: Object.keys(payload as Record<string, unknown>) },
+          context: {
+            payloadKeys: Object.keys(payload as Record<string, unknown>),
+            chunkTypes,
+          },
         });
         return false;
       } else if (isInvalidBlocks(err)) {


### PR DESCRIPTION
## Problem

PR #920 introduced a prod regression in streaming when `slack_task_display_mode` was flipped to `hybrid`: long silence, then a single blob via `postMessage` fallback with no tool cards.

## Root cause

Slack's 2026 task chunk types (`plan`, `url_source`, `blocks`) can be rejected with either `invalid_chunks` or `invalid_arguments` depending on which validation layer trips first. #920 only special-cased `invalid_chunks` as non-fatal; `invalid_arguments` fell through to the generic `UnexpectedStreamError` branch which set `streamingFailed = true` and abandoned the stream for the rest of the response.

Telemetry since 09:49 UTC deploy: 11x `UnexpectedStreamError` / `invalid_arguments` events, every one on `D*`/`C*` channels.

```
 error_name            | error_code        | count
 UnexpectedStreamError | invalid_arguments |    11
```

## Fix

Fold `invalid_arguments` into the same non-fatal branch as `invalid_chunks`:
- skip the offending chunk
- log which chunk types were in the payload (so we can see which 2026 type Slack is rejecting)
- keep streaming text

Matches the existing pattern in `safePostMessage` (`slack-messaging.ts:140`) which already treats `invalid_arguments` as recoverable for block payloads.

## Mitigation already in place

`slack_task_display_mode` setting flipped back to `timeline` in prod. With this fix merged, `hybrid` / `plan` can be re-enabled safely -- rejected plan/url_source chunks will just be skipped instead of killing the whole stream.

## Follow-ups (not in this PR)

- Figure out which specific chunk type(s) Slack is rejecting and either remove them or wait for API support to catch up.
- Keep `timeline` as default until we confirm `plan`/`hybrid` chunks land cleanly.