### PR TITLE
fix(slack-stream): don't send both markdown_text and chunks in appendStream

### DIFF
--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -352,18 +352,26 @@ function asAppendPayload(payload: {
     return chunk as unknown as LegacyKnownChunk;
   };
 
-  const result: Omit<ChatAppendStreamArguments, "channel" | "ts"> = {
-    ...(payload.chunks
-      ? {
-          chunks: payload.chunks.map(normalizeChunk) as ChatAppendStreamArguments["chunks"],
-        }
-      : {}),
-  };
-  if (payload.markdown_text != null) {
-    result.markdown_text = payload.markdown_text;
-    result.chunks = [...(result.chunks ?? []), toChunkMarkdownText(payload.markdown_text) as any];
+  // Slack's chat.appendStream accepts EITHER `markdown_text` OR `chunks` --
+  // not both. Sending both keys in the same payload is rejected with
+  // `invalid_arguments` and the entire chunk is dropped, which looks to the
+  // user like "silence, then a wall of text at the end". Prefer `chunks` when
+  // present (richer), otherwise fall back to `markdown_text`.
+  if (payload.chunks && payload.chunks.length > 0) {
+    const chunks = payload.chunks.map(normalizeChunk);
+    // If a caller passed both, fold the markdown_text into the chunks array
+    // as a markdown_text chunk so nothing is lost.
+    if (payload.markdown_text != null) {
+      chunks.push(toChunkMarkdownText(payload.markdown_text) as LegacyKnownChunk);
+    }
+    return {
+      chunks: chunks as ChatAppendStreamArguments["chunks"],
+    };
   }
-  return result;
+  if (payload.markdown_text != null) {
+    return { markdown_text: payload.markdown_text };
+  }
+  return {};
 }
 
 function buildPlanPreviewChunks(


### PR DESCRIPTION
## The actual PR #920 regression

PR #922 fixed the *symptom* (invalid_arguments was fatal). This fixes the *cause*: every plain-text chunk was being rejected by Slack.

### Root cause

Slack's `chat.appendStream` rejects payloads containing BOTH `markdown_text` AND `chunks` with `invalid_arguments`. `asAppendPayload` was emitting both keys for every `markdown_text` call after PR #920:

```ts
if (payload.markdown_text != null) {
  result.markdown_text = payload.markdown_text;
  result.chunks = [...(result.chunks ?? []), toChunkMarkdownText(payload.markdown_text)];
}
```

### Evidence

`error_events` for D0AFEC7BEMP during Joan's test session:

| timestamp | chunkTypes | payloadKeys |
|---|---|---|
| 12:22:55 | [markdown_text] | [markdown_text, chunks] |
| 12:22:09 | [markdown_text] | [markdown_text, chunks] |
| 12:18:20 | [markdown_text] | [markdown_text, chunks] |
| ... | ... | ... |

Every plain prose streaming response had 100% of its chunks rejected. User experience: thought forever, silence, wall of text at the end (safePostMessage fallback).

### Fix

Treat `markdown_text` and `chunks` as mutually exclusive:
- If `chunks` present → send chunks only (fold any markdown_text into the chunks array as a markdown_text chunk).
- Else if `markdown_text` present → send markdown_text only.

### Verification plan

After merge + deploy:
- Text-only reply should stream incrementally.
- Tool-call reply should show task cards streaming.
- `invalid_arguments` rate in `error_events` should drop to near-zero.