### PR TITLE
Enable reasoning tokens in dashboard chat end-to-end

### DIFF
--- a/apps/api/src/pipeline/generate.ts
+++ b/apps/api/src/pipeline/generate.ts
@@ -35,6 +35,7 @@ export interface AgenticStreamOptions {
   dynamicContext: string;
   messages: ModelMessage[];
   maxSteps?: number;
+  thinkingBudget?: number;
   userId?: string;
   channelId?: string;
   threadTs?: string;
@@ -53,6 +54,7 @@ export function createAgenticStream(options: AgenticStreamOptions) {
     stablePrefix: options.stablePrefix,
     conversationContext: options.conversationContext,
     dynamicContext: options.dynamicContext,
+    thinkingBudget: options.thinkingBudget ?? 8000,
     modelId: options.modelId,
     recordStepModelId: (stepNumber, stepModelId) => {
       stepModelIds[stepNumber - 1] = stepModelId ?? options.modelId;

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -253,12 +253,29 @@ function sanitizeAssistantPartOrder(messages: UIMessage[]): UIMessage[] {
   return messages.map((msg, index) => {
     if (msg.role !== "assistant" || !msg.parts) return msg;
     const isLastAssistantMessage = index === lastAssistantIndex;
+    const rawParts = msg.parts as any[];
+    const hasToolParts = rawParts.some(
+      (part) =>
+        part.type === "dynamic-tool" ||
+        (typeof part.type === "string" && part.type.startsWith("tool-")),
+    );
+
+    if (!hasToolParts) {
+      const filteredParts = rawParts.filter((part) => {
+        if (part.type === "step-start") return false;
+        if (part.type === "reasoning" && !isLastAssistantMessage) return false;
+        return true;
+      });
+      return filteredParts.length === rawParts.length
+        ? msg
+        : ({ ...msg, parts: filteredParts } as UIMessage);
+    }
 
     const textParts: any[] = [];
     const toolParts: any[] = [];
     const otherParts: any[] = [];
 
-    for (const part of msg.parts as any[]) {
+    for (const part of rawParts) {
       if (part.type === "text") textParts.push(part);
       else if (part.type === "dynamic-tool" || (typeof part.type === "string" && part.type.startsWith("tool-")))
         toolParts.push(part);
@@ -270,7 +287,6 @@ function sanitizeAssistantPartOrder(messages: UIMessage[]): UIMessage[] {
       } else otherParts.push(part);
     }
 
-    if (toolParts.length === 0) return msg;
     return { ...msg, parts: [...otherParts, ...textParts, ...toolParts] } as UIMessage;
   });
 }
@@ -295,7 +311,7 @@ function partsToUIParts(
         break;
       case "reasoning":
         if (part.textValue) {
-          textParts.push({ type: "reasoning", reasoning: part.textValue });
+          textParts.push({ type: "reasoning", text: part.textValue });
         }
         break;
       case "tool-invocation":

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -242,8 +242,17 @@ dashboardChatApp.openapi(getThreadMessagesRoute, async (c) => {
  * provider metadata that we don't persist).
  */
 function sanitizeAssistantPartOrder(messages: UIMessage[]): UIMessage[] {
-  return messages.map((msg) => {
+  let lastAssistantIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
+
+  return messages.map((msg, index) => {
     if (msg.role !== "assistant" || !msg.parts) return msg;
+    const isLastAssistantMessage = index === lastAssistantIndex;
 
     const textParts: any[] = [];
     const toolParts: any[] = [];
@@ -253,8 +262,11 @@ function sanitizeAssistantPartOrder(messages: UIMessage[]): UIMessage[] {
       if (part.type === "text") textParts.push(part);
       else if (part.type === "dynamic-tool" || (typeof part.type === "string" && part.type.startsWith("tool-")))
         toolParts.push(part);
-      else if (part.type === "reasoning" || part.type === "step-start") {
-        // drop: reasoning needs signed metadata, step-start is UI-only
+      else if (part.type === "reasoning") {
+        // Preserve reasoning on the final assistant message so the dashboard can render it.
+        if (isLastAssistantMessage) otherParts.push(part);
+      } else if (part.type === "step-start") {
+        // drop: step-start is UI-only
       } else otherParts.push(part);
     }
 
@@ -281,6 +293,11 @@ function partsToUIParts(
           textParts.push({ type: "text", text: part.textValue });
         }
         break;
+      case "reasoning":
+        if (part.textValue) {
+          textParts.push({ type: "reasoning", reasoning: part.textValue });
+        }
+        break;
       case "tool-invocation":
         if (part.toolCallId && part.toolName) {
           toolParts.push({
@@ -293,9 +310,7 @@ function partsToUIParts(
           });
         }
         break;
-      // "reasoning" and "step-start" parts are intentionally dropped on restore:
-      // reasoning requires signed provider metadata to re-send to Anthropic, and
-      // step-start is a UI-only marker. Dropping them is safe for follow-up turns.
+      // "step-start" parts are intentionally dropped on restore because they are UI-only.
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pass `thinkingBudget` through `createAgenticStream()` with a default of `8000`, so interactive prepare-step can enable thinking tokens
- restore persisted reasoning parts in dashboard thread hydration by mapping `conversationParts.type === "reasoning"` to UI reasoning parts
- update assistant-part sanitization to keep reasoning on the final assistant message while still stripping it from earlier assistant messages

## Root cause
`createAgenticStream()` did not provide `thinkingBudget` to `createInteractivePrepareStep()`. In `prepare-step.ts`, reasoning is gated behind a truthy `thinkingBudget`, so dashboard streaming never emitted reasoning tokens despite `sendReasoning: true`.

## Persistence verification
`apps/api/src/cron/persist-conversation.ts` already persists reasoning from `StepResult`:
- `buildConversationSteps()` carries `step.reasoning`
- `stepToParts()` writes `conversationParts` rows with `type: "reasoning"` and joined reasoning text

No changes were needed in this file.

## Validation
- `npx tsc --noEmit` in `apps/api` ✅
- `npx tsc --noEmit` in `apps/dashboard` ✅
- `git push` pre-push hook (`pnpm typecheck`) ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d5b5fb-09d1-489d-89ab-8c0d9fd02271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d5b5fb-09d1-489d-89ab-8c0d9fd02271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

