### PR TITLE
Fix stale email pipeline regression

### DIFF
--- a/apps/api/src/tools/email-sync.test.ts
+++ b/apps/api/src/tools/email-sync.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const userRows = new Map<string, Array<{ id: string; displayName: string; realName: string; username: string }>>();
+const selectQueues = new Map<string, unknown[][]>();
+const updateReturningQueue: unknown[][] = [];
+const syncEmailsMock = vi.fn();
+const computeThreadStatesMock = vi.fn();
+const hasRoleMock = vi.fn();
+
+const slackClient = {
+  users: {
+    list: vi.fn(async () => ({
+      members: [
+        {
+          id: "UJOAN",
+          name: "joan",
+          real_name: "Joan Rodriguez",
+          profile: { display_name: "Joan" },
+        },
+      ],
+    })),
+  },
+};
+
+function queueSelect(key: string, rows: unknown[]) {
+  const queue = selectQueues.get(key) ?? [];
+  queue.push(rows);
+  selectQueues.set(key, queue);
+}
+
+function takeSelectRows(key: string): unknown[] {
+  const queue = selectQueues.get(key);
+  if (!queue || queue.length === 0) return [];
+  return queue.shift() ?? [];
+}
+
+function createSelectBuilder(kind: "select" | "selectDistinct") {
+  const builder = {
+    from(table: unknown) {
+      const tableName = (table as any)?.[Symbol.for("drizzle:Name")];
+      if (tableName === "users") {
+        return {
+          where() {
+            return {
+              limit() {
+                return userRows.get("users") ?? [];
+              },
+            };
+          },
+        };
+      }
+
+      return {
+        where() {
+          return {
+            orderBy() {
+              return {
+                limit() {
+                  return takeSelectRows("emailRows");
+                },
+              };
+            },
+            groupBy() {
+              return takeSelectRows("threadCounts");
+            },
+            then(resolve: (rows: unknown[]) => unknown) {
+              const key = kind === "selectDistinct" ? "matchingThreads" : "latestDate";
+              return Promise.resolve(resolve(takeSelectRows(key)));
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return builder;
+}
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: vi.fn(() => createSelectBuilder("select")),
+    selectDistinct: vi.fn(() => createSelectBuilder("selectDistinct")),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => updateReturningQueue.shift() ?? []),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => [{ id: "action-log-id" }]),
+      })),
+    })),
+  },
+}));
+
+vi.mock("../lib/email-sync.js", () => ({
+  syncEmails: syncEmailsMock,
+}));
+
+vi.mock("../lib/email-triage.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/email-triage.js")>()),
+  computeThreadStates: computeThreadStatesMock,
+}));
+
+vi.mock("../lib/permissions.js", () => ({
+  hasRole: hasRoleMock,
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("email sync tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRows.clear();
+    selectQueues.clear();
+    updateReturningQueue.length = 0;
+    userRows.set("users", [
+      { id: "UJOAN", displayName: "Joan", realName: "Joan Rodriguez", username: "joan" },
+    ]);
+    syncEmailsMock.mockResolvedValue({
+      synced: 0,
+      skipped: 0,
+      errors: 0,
+      errorDetails: [],
+    });
+    computeThreadStatesMock.mockResolvedValue({ processed: 1, breakdown: {} });
+    hasRoleMock.mockResolvedValue(false);
+  });
+
+  it("exposes sync_emails, email_digest, and update_email_thread to OAuth-owning job users", async () => {
+    const { createEmailSyncTools } = await import("./email-sync.js");
+    const { filterToolsByCredentials } = await import("../lib/tool.js");
+
+    const tools = createEmailSyncTools(slackClient as any, { userId: "UJOAN" });
+    const visibleTools = filterToolsByCredentials(tools, new Set(["google_oauth"]));
+
+    expect(visibleTools).toHaveProperty("sync_emails");
+    expect(visibleTools).toHaveProperty("email_digest");
+    expect(visibleTools).toHaveProperty("update_email_thread");
+  });
+
+  it("does not expose email pipeline tools without Google OAuth", async () => {
+    const { createEmailSyncTools } = await import("./email-sync.js");
+    const { filterToolsByCredentials } = await import("../lib/tool.js");
+
+    const tools = createEmailSyncTools(slackClient as any, { userId: "UJOAN" });
+    const visibleTools = filterToolsByCredentials(tools, new Set());
+
+    expect(visibleTools).not.toHaveProperty("sync_emails");
+    expect(visibleTools).not.toHaveProperty("email_digest");
+    expect(visibleTools).not.toHaveProperty("update_email_thread");
+  });
+
+  it("refreshes stale email data before building a digest", async () => {
+    const { createEmailSyncTools } = await import("./email-sync.js");
+    const tools = createEmailSyncTools(slackClient as any, { userId: "UJOAN" });
+
+    queueSelect("latestDate", [{ latestDate: new Date("2026-03-26T05:28:46.000Z") }]);
+    queueSelect("emailRows", []);
+    queueSelect("threadCounts", []);
+
+    const result = await (tools.email_digest as any).execute({
+      user_name: "Joan",
+      include_fyi: false,
+    });
+
+    expect(syncEmailsMock).toHaveBeenCalledWith("UJOAN", {
+      query: "newer_than:30d",
+      maxMessages: 100,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.sync).toMatchObject({
+      attempted: true,
+      reason: "email_digest_stale_check",
+    });
+  });
+
+  it("syncs recent Gmail and retries when update_email_thread initially misses", async () => {
+    const { createEmailSyncTools } = await import("./email-sync.js");
+    const tools = createEmailSyncTools(slackClient as any, { userId: "UJOAN" });
+
+    queueSelect("matchingThreads", []);
+    queueSelect("matchingThreads", [{ gmailThreadId: "thread-123", subject: "Current thread" }]);
+    updateReturningQueue.push([{ gmailThreadId: "thread-123" }]);
+
+    const result = await (tools.update_email_thread as any).execute({
+      user_name: "Joan",
+      gmail_thread_id: "thread-123",
+      thread_state: "resolved",
+      reason: "handled",
+    });
+
+    expect(syncEmailsMock).toHaveBeenCalledWith("UJOAN", {
+      query: "newer_than:30d",
+      maxMessages: 200,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      updated: 1,
+      sync: {
+        attempted: true,
+        reason: "update_email_thread_not_found",
+      },
+    });
+  });
+
+  it("blocks cross-user email sync for non-admin callers", async () => {
+    const { createEmailSyncTools } = await import("./email-sync.js");
+    const tools = createEmailSyncTools(slackClient as any, { userId: "UOTHER" });
+
+    const result = await (tools.sync_emails as any).execute({
+      user_name: "Joan",
+      newer_than: "7d",
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.error).toContain("own email pipeline");
+    expect(syncEmailsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/tools/email-sync.ts
+++ b/apps/api/src/tools/email-sync.ts
@@ -424,7 +424,7 @@ export function createEmailSyncTools(
           return { ok: false, error: `Digest failed: ${error.message}` };
         }
       },
-      slack: { status: "Running email digest...", detail: (i) => i.user_name, output: (r) => r.ok === false ? r.error : `${r.threads?.length ?? 0} threads` },
+      slack: { status: "Running email digest...", detail: (i) => i.user_name, output: (r) => "error" in r ? r.error : `${r.threads.length} threads` },
     }),
 
     update_email_thread: defineTool({
@@ -682,7 +682,7 @@ export function createEmailSyncTools(
           };
         }
       },
-      slack: { status: "Updating email threads...", output: (r) => r.ok === false ? (r.error ?? r.message) : `${r.updated ?? 0} threads updated` },
+      slack: { status: "Updating email threads...", output: (r) => "error" in r ? r.error : ("message" in r && r.ok === false ? r.message : `${r.updated} threads updated`) },
     }),
 
     search_emails: defineTool({

--- a/apps/api/src/tools/email-sync.ts
+++ b/apps/api/src/tools/email-sync.ts
@@ -14,15 +14,115 @@ import { embedText } from "../lib/embeddings.js";
 
 // ── Tool Definitions ────────────────────────────────────────────────────────
 
+const RECENT_EMAIL_SYNC_QUERY = "newer_than:30d";
+const RECENT_EMAIL_SYNC_MAX_MESSAGES = 100;
+const UPDATE_FALLBACK_MAX_MESSAGES = 200;
+const EMAIL_SYNC_STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+
+type EmailSyncRefresh = {
+  attempted: boolean;
+  reason: string;
+  latest_synced_at?: string;
+  synced?: number;
+  skipped?: number;
+  errors?: number;
+  classified_threads?: number;
+  error?: string;
+};
+
+async function assertCanAccessUserEmail(
+  callerUserId: string | undefined,
+  targetUserId: string,
+) {
+  if (callerUserId && callerUserId === targetUserId) {
+    return { ok: true as const };
+  }
+
+  if (await hasRole(callerUserId, "admin")) {
+    return { ok: true as const };
+  }
+
+  return {
+    ok: false as const,
+    error:
+      "You can only access your own email pipeline. Ask an admin to work with another user's email.",
+  };
+}
+
+async function getLatestSyncedEmailDate(userId: string): Promise<Date | null> {
+  const rows = await db
+    .select({ latestDate: sql<Date | null>`max(${emailsRaw.date})` })
+    .from(emailsRaw)
+    .where(eq(emailsRaw.userId, userId));
+
+  const latest = rows[0]?.latestDate;
+  if (!latest) return null;
+  return latest instanceof Date ? latest : new Date(latest);
+}
+
+async function refreshRecentEmailsIfStale(
+  userId: string,
+  reason: string,
+  options: { force?: boolean; maxMessages?: number } = {},
+): Promise<EmailSyncRefresh> {
+  try {
+    let latest: Date | null = null;
+    if (!options.force) {
+      latest = await getLatestSyncedEmailDate(userId);
+      if (latest && Date.now() - latest.getTime() < EMAIL_SYNC_STALE_AFTER_MS) {
+        return {
+          attempted: false,
+          reason: "emails_raw_recent",
+          latest_synced_at: latest.toISOString(),
+        };
+      }
+    }
+
+    const { syncEmails } = await import("../lib/email-sync.js");
+    const syncResult = await syncEmails(userId, {
+      query: RECENT_EMAIL_SYNC_QUERY,
+      maxMessages: options.maxMessages ?? RECENT_EMAIL_SYNC_MAX_MESSAGES,
+    });
+
+    let classifiedThreads: number | undefined;
+    if (syncResult.synced > 0) {
+      const { computeThreadStates } = await import("../lib/email-triage.js");
+      const threadStates = await computeThreadStates(userId);
+      classifiedThreads = threadStates.processed;
+    }
+
+    return {
+      attempted: true,
+      reason,
+      ...(latest ? { latest_synced_at: latest.toISOString() } : {}),
+      synced: syncResult.synced,
+      skipped: syncResult.skipped,
+      errors: syncResult.errors,
+      classified_threads: classifiedThreads,
+    };
+  } catch (error: any) {
+    logger.warn("Email pipeline refresh failed", {
+      userId,
+      reason,
+      error: error.message,
+    });
+    return {
+      attempted: true,
+      reason,
+      error: error.message,
+    };
+  }
+}
+
 export function createEmailSyncTools(
   client: WebClient,
   context?: ScheduleContext,
 ) {
   return {
     sync_emails: defineTool({
-      requiredCredentials: ["admin_access"],
+      requiredCredentials: ["google_oauth"],
       description:
-        "Sync emails from a user's Gmail into the staging pipeline. Supports date windows (after/before), relative dates (newer_than), or raw Gmail queries. Resumable — re-running with the same query skips already-synced emails.",
+        "Sync emails from a user's Gmail into the staging pipeline. Users may sync their own authorized Gmail account; admins may sync another user's authorized account. Supports date windows (after/before), relative dates (newer_than), or raw Gmail queries. Resumable — re-running with the same query skips already-synced emails.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -81,6 +181,9 @@ export function createEmailSyncTools(
               error: `Could not resolve user '${user_name}'. They need to exist in the workspace.`,
             };
           }
+
+          const access = await assertCanAccessUserEmail(context?.userId, user.id);
+          if (!access.ok) return access;
 
           const { syncEmails } = await import("../lib/email-sync.js");
 
@@ -157,9 +260,9 @@ export function createEmailSyncTools(
     }),
 
     email_digest: defineTool({
-      requiredCredentials: ["admin_access"],
+      requiredCredentials: ["google_oauth"],
       description:
-        "Get an email digest for a user: returns structured data with counts and thread objects (each with gmail_thread_id). Use threads[].gmail_thread_id for follow-up actions.",
+        "Get an email digest for a user's synced Gmail pipeline. Users may read their own digest; admins may read another user's digest. Automatically performs a bounded recent Gmail sync when emails_raw is stale so counts and gmail_thread_id values are current. Use threads[].gmail_thread_id for follow-up actions.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -182,6 +285,13 @@ export function createEmailSyncTools(
           }
 
           const userId = user.id;
+          const access = await assertCanAccessUserEmail(context?.userId, userId);
+          if (!access.ok) return access;
+
+          const syncRefresh = await refreshRecentEmailsIfStale(
+            userId,
+            "email_digest_stale_check",
+          );
 
           const stateFilter = include_fyi
             ? sql`(${emailsRaw.threadState} IS NULL OR ${emailsRaw.threadState} != 'junk')`
@@ -239,19 +349,21 @@ export function createEmailSyncTools(
 
           // Get actual message counts per thread
           const threadIds = [...threadMap.keys()];
-          const threadCounts = await db
-            .select({
-              gmailThreadId: emailsRaw.gmailThreadId,
-              messageCount: sql<number>`count(*)::int`,
-            })
-            .from(emailsRaw)
-            .where(
-              and(
-                eq(emailsRaw.userId, userId),
-                inArray(emailsRaw.gmailThreadId, threadIds)
-              )
-            )
-            .groupBy(emailsRaw.gmailThreadId);
+          const threadCounts = threadIds.length > 0
+            ? await db
+                .select({
+                  gmailThreadId: emailsRaw.gmailThreadId,
+                  messageCount: sql<number>`count(*)::int`,
+                })
+                .from(emailsRaw)
+                .where(
+                  and(
+                    eq(emailsRaw.userId, userId),
+                    inArray(emailsRaw.gmailThreadId, threadIds)
+                  )
+                )
+                .groupBy(emailsRaw.gmailThreadId)
+            : [];
 
           const threadCountMap = new Map<string, number>();
           for (const tc of threadCounts) {
@@ -299,6 +411,10 @@ export function createEmailSyncTools(
               total: threads.length,
             },
             threads,
+            sync: syncRefresh,
+            ...(syncRefresh.error
+              ? { warning: `Email digest may be stale: ${syncRefresh.error}` }
+              : {}),
           };
         } catch (error: any) {
           logger.error("email_digest tool failed", {
@@ -312,8 +428,9 @@ export function createEmailSyncTools(
     }),
 
     update_email_thread: defineTool({
+      requiredCredentials: ["google_oauth"],
       description:
-        "Update the triage state of an email thread by gmail_thread_id. Get the thread ID from email_digest or search_emails. Any user can update their own threads.",
+        "Update the triage state of an email thread by gmail_thread_id. Get the thread ID from email_digest or search_emails. Users may update their own threads; admins may update another user's threads. If the thread is missing from emails_raw, this performs a bounded recent Gmail sync and retries once.",
       inputSchema: z
         .object({
           user_name: z
@@ -347,30 +464,41 @@ export function createEmailSyncTools(
             };
           }
 
-          if (user.id !== context?.userId && !(await hasRole(context?.userId, "admin"))) {
-            return {
-              ok: false as const,
-              error:
-                "You can only update your own email threads. Ask an admin to update other users' threads.",
-            };
-          }
-
           const userId = user.id;
+          const access = await assertCanAccessUserEmail(context?.userId, userId);
+          if (!access.ok) return access;
 
           const conditions = [eq(emailsRaw.userId, userId)];
 
           conditions.push(eq(emailsRaw.gmailThreadId, gmail_thread_id));
 
           // Find distinct threads that match
-          const matchingThreads = await db
+          let matchingThreads = await db
             .selectDistinct({ gmailThreadId: emailsRaw.gmailThreadId, subject: emailsRaw.subject })
             .from(emailsRaw)
             .where(and(...conditions));
 
+          let syncRefresh: EmailSyncRefresh | undefined;
+          if (matchingThreads.length === 0) {
+            syncRefresh = await refreshRecentEmailsIfStale(
+              userId,
+              "update_email_thread_not_found",
+              { force: true, maxMessages: UPDATE_FALLBACK_MAX_MESSAGES },
+            );
+
+            matchingThreads = await db
+              .selectDistinct({ gmailThreadId: emailsRaw.gmailThreadId, subject: emailsRaw.subject })
+              .from(emailsRaw)
+              .where(and(...conditions));
+          }
+
           if (matchingThreads.length === 0) {
             return {
               ok: false as const,
-              error: `No emails found for thread ID '${gmail_thread_id}'.`,
+              error: syncRefresh?.error
+                ? `No emails found for thread ID '${gmail_thread_id}'. A recent Gmail sync was attempted but failed: ${syncRefresh.error}`
+                : `No emails found for thread ID '${gmail_thread_id}'. A recent Gmail sync was attempted but the thread is still absent from emails_raw.`,
+              sync: syncRefresh,
             };
           }
 
@@ -412,6 +540,7 @@ export function createEmailSyncTools(
             updated: result.length,
             threads: subjects,
             thread_state,
+            ...(syncRefresh ? { sync: syncRefresh } : {}),
             message: `Updated ${result.length} email(s) across ${threadIds.length} thread(s) to '${thread_state}': ${subjects.join(", ")}`,
           };
         } catch (error: any) {
@@ -429,9 +558,9 @@ export function createEmailSyncTools(
     }),
 
     update_email_threads: defineTool({
-      requiredCredentials: ["admin_access"],
+      requiredCredentials: ["google_oauth"],
       description:
-        "Batch-update triage states for multiple email threads at once. Accepts an array of {gmail_thread_id, thread_state, reason?}. Use after email_digest to dismiss/resolve/reclassify several threads in one call.",
+        "Batch-update triage states for multiple email threads at once. Users may update their own threads; admins may update another user's threads. Accepts an array of {gmail_thread_id, thread_state, reason?}. Use after email_digest to dismiss/resolve/reclassify several threads in one call.",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -465,6 +594,9 @@ export function createEmailSyncTools(
           }
 
           const userId = user.id;
+          const access = await assertCanAccessUserEmail(context?.userId, userId);
+          if (!access.ok) return access;
+
           let totalUpdated = 0;
           let totalFailed = 0;
           const details: Array<{
@@ -554,9 +686,9 @@ export function createEmailSyncTools(
     }),
 
     search_emails: defineTool({
-      requiredCredentials: ["admin_access"],
+      requiredCredentials: ["google_oauth"],
       description:
-        "Search synced emails by keyword (text mode) or meaning (semantic mode). Text mode uses PostgreSQL full-text search on subject + body. Semantic mode embeds the query and finds similar email threads via cosine similarity. Returns one result per thread (latest email).",
+        "Search a user's synced Gmail pipeline by keyword (text mode) or meaning (semantic mode). Users may search their own email; admins may search another user's email. Automatically performs a bounded recent Gmail sync when emails_raw is stale. Text mode uses PostgreSQL full-text search on subject + body. Semantic mode embeds the query and finds similar email threads via cosine similarity. Returns one result per thread (latest email).",
       inputSchema: z.object({
         user_name: z
           .string()
@@ -592,6 +724,14 @@ export function createEmailSyncTools(
           }
 
           const userId = user.id;
+          const access = await assertCanAccessUserEmail(context?.userId, userId);
+          if (!access.ok) return access;
+
+          const syncRefresh = await refreshRecentEmailsIfStale(
+            userId,
+            "search_emails_stale_check",
+          );
+
           const conditions = [eq(emailsRaw.userId, userId)];
 
           if (thread_state) {
@@ -739,6 +879,10 @@ export function createEmailSyncTools(
             mode,
             count: formatted.length,
             results: formatted,
+            sync: syncRefresh,
+            ...(syncRefresh.error
+              ? { warning: `Email search may be stale: ${syncRefresh.error}` }
+              : {}),
             message: `Found ${formatted.length} thread(s) matching "${query}" (${mode} search)`,
           };
         } catch (error: any) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #931

## Root cause

- `sync_emails`, `email_digest`, `search_emails`, and batch email updates were registered, but their tool schemas were gated by the `admin_access` credential.
- In scheduled job execution for Joan, the caller had Google OAuth access but not that admin credential, so `sync_emails` and `email_digest` were filtered out of the callable schema.
- `update_email_thread` was callable, but it only looked up `gmail_thread_id` in `emails_raw`. Joan's `emails_raw` data was stale (issue reproduction showed max date `2026-03-26`), so current Gmail thread IDs from live Gmail reads could not be found.

## Reproduction before fix

1. Run a scheduled job as Joan and inspect callable tools: `sync_emails` and `email_digest` are absent, while `update_email_thread` is present.
2. Read current Gmail thread IDs via live Gmail tooling.
3. Call `update_email_thread` with one of those current `gmail_thread_id` values.
4. The tool returns `ok=false` / `No emails found for thread ID ...` because it queries stale `emails_raw` only.

## Changes

- Gate DB-backed email pipeline tools on `google_oauth` instead of `admin_access`, so OAuth-owning users can discover and call their own email pipeline tools in job execution mode.
- Added explicit runtime access checks: users can operate on their own email pipeline, admins can operate on another user's pipeline, and non-admin cross-user access is rejected before Gmail sync or DB mutation.
- Added bounded recent Gmail refreshes:
  - `email_digest` and `search_emails` sync `newer_than:30d` with `maxMessages:100` when `emails_raw` is stale (>6 hours).
  - `update_email_thread` syncs `newer_than:30d` with `maxMessages:200` and retries once when a thread ID is missing.
- Return sync metadata/warnings so stale-data behavior is visible in tool results without exposing email contents beyond the authorized user boundary.
- Added regression tests for OAuth-based tool exposure, non-OAuth hiding, stale digest refresh, update retry after not-found, and cross-user privacy blocking.

## Verification

- `pnpm --filter aura-api exec vitest run src/tools/email-sync.test.ts`
- `pnpm --filter aura-api typecheck`
- `pnpm typecheck`

## Privacy/OAuth boundaries

The fix does not introduce global email ingestion. Gmail sync still uses `getGmailClientForUser(userId)` and therefore only works for the target user's stored OAuth token. Cross-user operations require admin role checks before sync/search/update runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e318b593-a65d-4f33-be18-4c6541e86437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e318b593-a65d-4f33-be18-4c6541e86437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

