### PR TITLE
Scope dashboard memory access by principal

### DIFF
--- a/apps/api/src/routes/dashboard/index.ts
+++ b/apps/api/src/routes/dashboard/index.ts
@@ -14,12 +14,17 @@ import { dashboardSettingsApp } from "./settings.js";
 import { dashboardModelsApp } from "./models.js";
 import { dashboardEntitiesApp } from "./entities.js";
 import { createDashboardApp } from "./schemas.js";
+import { setDashboardPrincipal } from "./principal.js";
 import { jwtVerify } from "jose";
+import { eq } from "drizzle-orm";
+import { users } from "@aura/db/schema";
+import { db } from "../../db/client.js";
 
 export const dashboardApp = createDashboardApp();
 
 const PUBLIC_PREFIX_PATHS = ["/auth/login", "/auth/callback"];
 const PUBLIC_EXACT_PATHS = ["/openapi.json"];
+const ALLOWED_ROLES = new Set(["admin", "power_user"]);
 
 dashboardApp.use("*", async (c, next) => {
   const path = new URL(c.req.url).pathname.replace("/api/dashboard", "");
@@ -37,6 +42,7 @@ dashboardApp.use("*", async (c, next) => {
   // Accept static DASHBOARD_API_SECRET (Next.js dashboard server-side calls)
   const apiSecret = process.env.DASHBOARD_API_SECRET;
   if (apiSecret && candidate === apiSecret) {
+    setDashboardPrincipal(c, { authType: "service", role: "admin" });
     return next();
   }
 
@@ -49,7 +55,27 @@ dashboardApp.use("*", async (c, next) => {
         new TextEncoder().encode(sessionSecret),
       );
       if (payload.purpose) throw new Error("Invalid token type");
-      c.set("userId" as never, payload.slackUserId as never);
+      const slackUserId = payload.slackUserId;
+      if (typeof slackUserId !== "string" || !slackUserId) {
+        throw new Error("Missing Slack user ID");
+      }
+
+      const [user] = await db
+        .select({ role: users.role })
+        .from(users)
+        .where(eq(users.slackUserId, slackUserId))
+        .limit(1);
+
+      if (!user || !ALLOWED_ROLES.has(user.role)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+
+      setDashboardPrincipal(c, {
+        authType: "jwt",
+        slackUserId,
+        role: user.role,
+      });
+      c.set("userId" as never, slackUserId as never);
       c.set("userName" as never, payload.name as never);
       return next();
     } catch {

--- a/apps/api/src/routes/dashboard/memories.ts
+++ b/apps/api/src/routes/dashboard/memories.ts
@@ -1,9 +1,16 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { eq, desc, count, inArray, sql } from "drizzle-orm";
+import { and, eq, desc, count, inArray, sql, type SQL } from "drizzle-orm";
 import { memories, messages, users, memoryEntities, entities } from "@aura/db/schema";
 import { db } from "../../db/client.js";
 import { logger } from "../../lib/logger.js";
 import { errorSchema, idParamSchema, createDashboardApp } from "./schemas.js";
+import {
+  canAuditAllMemories,
+  getDashboardPrincipal,
+  getEffectiveMemoryScope,
+  type DashboardPrincipal,
+  type MemoryScope,
+} from "./principal.js";
 
 export const dashboardMemoriesApp = createDashboardApp();
 
@@ -23,6 +30,31 @@ const memoryColumns = {
   updatedAt: memories.updatedAt,
 } as const;
 
+function canUseAllScope(principal: DashboardPrincipal | undefined): boolean {
+  return canAuditAllMemories(principal);
+}
+
+function userMemoryCondition(slackUserId: string): SQL {
+  return sql`${memories.relatedUserIds} @> ARRAY[${slackUserId}]::text[]`;
+}
+
+function getMemoryAccessCondition(
+  principal: DashboardPrincipal | undefined,
+  scope: MemoryScope = "all",
+): SQL | undefined {
+  if (scope === "all" && canUseAllScope(principal)) return undefined;
+  if (principal?.slackUserId) return userMemoryCondition(principal.slackUserId);
+  return sql`FALSE`;
+}
+
+function getScopedMemoryIdCondition(
+  id: string,
+  principal: DashboardPrincipal | undefined,
+): SQL | undefined {
+  const accessCondition = getMemoryAccessCondition(principal);
+  return accessCondition ? and(eq(memories.id, id), accessCondition) : eq(memories.id, id);
+}
+
 const listMemoriesRoute = createRoute({
   method: "get",
   path: "/",
@@ -32,6 +64,7 @@ const listMemoriesRoute = createRoute({
     query: z.object({
       search: z.string().optional(),
       type: z.string().optional(),
+      scope: z.enum(["mine", "all"]).optional(),
       page: z.coerce.number().optional(),
       limit: z.coerce.number().optional(),
     }),
@@ -59,11 +92,13 @@ dashboardMemoriesApp.openapi(listMemoriesRoute, async (c) => {
   try {
     const search = c.req.query("search");
     const type = c.req.query("type");
+    const principal = getDashboardPrincipal(c);
+    const scope = getEffectiveMemoryScope(principal, c.req.query("scope"));
     const page = Math.max(1, Number(c.req.query("page")) || 1);
     const limit = Math.max(1, Math.min(500, Number(c.req.query("limit")) || 100));
     const offset = (page - 1) * limit;
 
-    if (search) {
+    if (search && scope === "all") {
       try {
         const { retrieveMemories } = await import("../../memory/retrieve.js");
         const results = await retrieveMemories({
@@ -83,7 +118,9 @@ dashboardMemoriesApp.openapi(listMemoriesRoute, async (c) => {
       }
     }
 
-    const conditions = [];
+    const conditions: SQL[] = [];
+    const accessCondition = getMemoryAccessCondition(principal, scope);
+    if (accessCondition) conditions.push(accessCondition);
     if (search) {
       conditions.push(
         sql`to_tsvector('english', coalesce(${memories.content}, '')) @@ plainto_tsquery('english', ${search})`,
@@ -91,11 +128,7 @@ dashboardMemoriesApp.openapi(listMemoriesRoute, async (c) => {
     }
     if (type) conditions.push(eq(memories.type, type as any));
 
-    const where = conditions.length > 0
-      ? conditions.length === 1
-        ? conditions[0]
-        : sql`${conditions[0]} AND ${conditions[1]}`
-      : undefined;
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
 
     const [items, [totalRow]] = await Promise.all([
       db
@@ -142,10 +175,12 @@ const getMemoryRoute = createRoute({
 dashboardMemoriesApp.openapi(getMemoryRoute, async (c) => {
   try {
     const id = c.req.param("id");
+    const principal = getDashboardPrincipal(c);
+    const where = getScopedMemoryIdCondition(id, principal);
     const [memory] = await db
       .select(memoryColumns)
       .from(memories)
-      .where(eq(memories.id, id));
+      .where(where);
 
     if (!memory) return c.json({ error: "Memory not found" }, 404);
 
@@ -230,6 +265,7 @@ const updateMemoryRoute = createRoute({
 dashboardMemoriesApp.openapi(updateMemoryRoute, async (c) => {
   try {
     const id = c.req.param("id");
+    const principal = getDashboardPrincipal(c);
     const body = await c.req.json<{
       content?: string;
       relevanceScore?: number;
@@ -244,7 +280,7 @@ dashboardMemoriesApp.openapi(updateMemoryRoute, async (c) => {
     const [updated] = await db
       .update(memories)
       .set(updates)
-      .where(eq(memories.id, id))
+      .where(getScopedMemoryIdCondition(id, principal))
       .returning(memoryColumns);
 
     if (!updated) return c.json({ error: "Memory not found" }, 404);
@@ -286,9 +322,10 @@ const deleteMemoryRoute = createRoute({
 dashboardMemoriesApp.openapi(deleteMemoryRoute, async (c) => {
   try {
     const id = c.req.param("id");
+    const principal = getDashboardPrincipal(c);
     const [deleted] = await db
       .delete(memories)
-      .where(eq(memories.id, id))
+      .where(getScopedMemoryIdCondition(id, principal))
       .returning({ id: memories.id });
 
     if (!deleted) return c.json({ error: "Memory not found" }, 404);

--- a/apps/api/src/routes/dashboard/principal.test.ts
+++ b/apps/api/src/routes/dashboard/principal.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  canAuditAllMemories,
+  getEffectiveMemoryScope,
+  type DashboardPrincipal,
+} from "./principal.js";
+
+describe("dashboard principal memory access", () => {
+  const admin: DashboardPrincipal = {
+    authType: "jwt",
+    slackUserId: "U_ADMIN",
+    role: "admin",
+  };
+  const powerUser: DashboardPrincipal = {
+    authType: "jwt",
+    slackUserId: "U_POWER",
+    role: "power_user",
+  };
+  const service: DashboardPrincipal = {
+    authType: "service",
+    role: "admin",
+  };
+  const nonAdminService: DashboardPrincipal = {
+    authType: "service",
+    role: "power_user",
+  };
+
+  it("allows admins and service callers to audit all memories", () => {
+    expect(canAuditAllMemories(admin)).toBe(true);
+    expect(canAuditAllMemories(service)).toBe(true);
+    expect(canAuditAllMemories(nonAdminService)).toBe(true);
+  });
+
+  it("does not allow power users to audit all memories", () => {
+    expect(canAuditAllMemories(powerUser)).toBe(false);
+  });
+
+  it("defaults admins and service callers to all scope", () => {
+    expect(getEffectiveMemoryScope(admin, undefined)).toBe("all");
+    expect(getEffectiveMemoryScope(service, undefined)).toBe("all");
+  });
+
+  it("allows admins with a Slack identity to request mine scope", () => {
+    expect(getEffectiveMemoryScope(admin, "mine")).toBe("mine");
+  });
+
+  it("forces non-admin users to mine scope", () => {
+    expect(getEffectiveMemoryScope(powerUser, "all")).toBe("mine");
+    expect(getEffectiveMemoryScope(powerUser, undefined)).toBe("mine");
+  });
+});

--- a/apps/api/src/routes/dashboard/principal.ts
+++ b/apps/api/src/routes/dashboard/principal.ts
@@ -1,0 +1,42 @@
+import type { Context } from "hono";
+
+export type DashboardAuthType = "jwt" | "service";
+
+export interface DashboardPrincipal {
+  authType: DashboardAuthType;
+  slackUserId?: string;
+  role: "admin" | "power_user" | string;
+}
+
+const PRINCIPAL_KEY = "dashboardPrincipal";
+
+export function setDashboardPrincipal(c: Context, principal: DashboardPrincipal): void {
+  c.set(PRINCIPAL_KEY as never, principal as never);
+}
+
+export function getDashboardPrincipal(c: Context): DashboardPrincipal | undefined {
+  return c.get(PRINCIPAL_KEY as never) as DashboardPrincipal | undefined;
+}
+
+export function isDashboardAdmin(principal: DashboardPrincipal | undefined): boolean {
+  return principal?.role === "admin";
+}
+
+export function isDashboardService(principal: DashboardPrincipal | undefined): boolean {
+  return principal?.authType === "service";
+}
+
+export function canAuditAllMemories(principal: DashboardPrincipal | undefined): boolean {
+  return isDashboardAdmin(principal) || isDashboardService(principal);
+}
+
+export type MemoryScope = "mine" | "all";
+
+export function getEffectiveMemoryScope(
+  principal: DashboardPrincipal | undefined,
+  requestedScope: string | undefined,
+): MemoryScope {
+  if (!canAuditAllMemories(principal)) return "mine";
+  if (requestedScope === "mine" && principal?.slackUserId) return "mine";
+  return "all";
+}

--- a/apps/dashboard/src/components/auth-provider.tsx
+++ b/apps/dashboard/src/components/auth-provider.tsx
@@ -8,6 +8,32 @@ import {
   type Session,
 } from "@/lib/auth";
 
+async function hydrateSessionRole(session: Session | null, token: string): Promise<Session | null> {
+  if (!session) return null;
+
+  try {
+    const res = await fetch("/api/dashboard/auth/check-role", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        slackUserId: session.slackUserId,
+        name: session.name,
+        picture: session.picture,
+      }),
+    });
+
+    if (!res.ok) return null;
+    const roleResult = await res.json() as { allowed?: boolean; role?: string };
+    if (!roleResult.allowed) return null;
+    return { ...session, role: roleResult.role };
+  } catch {
+    return null;
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
@@ -23,7 +49,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         ? `${window.location.pathname}?${params.toString()}`
         : window.location.pathname;
       window.history.replaceState({}, "", cleanUrl);
-      decodeToken(urlToken).then((s) => {
+      decodeToken(urlToken).then((s) => hydrateSessionRole(s, urlToken)).then((s) => {
+        if (!s) clearToken();
         setSession(s);
         setLoading(false);
       });
@@ -32,7 +59,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const token = getStoredToken();
     if (token) {
-      decodeToken(token).then((s) => {
+      decodeToken(token).then((s) => hydrateSessionRole(s, token)).then((s) => {
+        if (!s) clearToken();
         setSession(s);
         setLoading(false);
       });
@@ -43,8 +71,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback((token: string) => {
     storeToken(token);
-    decodeToken(token).then((s) => {
+    setLoading(true);
+    decodeToken(token).then((s) => hydrateSessionRole(s, token)).then((s) => {
+      if (!s) clearToken();
       setSession(s);
+      setLoading(false);
     });
   }, []);
 

--- a/apps/dashboard/src/lib/auth.ts
+++ b/apps/dashboard/src/lib/auth.ts
@@ -4,6 +4,7 @@ export interface Session {
   slackUserId: string;
   name: string;
   picture: string;
+  role?: string;
 }
 
 export interface AuthContextValue {
@@ -44,10 +45,14 @@ export async function decodeToken(token: string): Promise<Session | null> {
     if (parts.length !== 3) return null;
     const payload = JSON.parse(atob(parts[1]!));
     if (payload.purpose) return null;
+    const slackUserId = payload.slackUserId;
+    if (typeof slackUserId !== "string" || !slackUserId) return null;
+
     return {
-      slackUserId: payload.slackUserId as string,
+      slackUserId,
       name: (payload.name as string) || "User",
       picture: (payload.picture as string) || "",
+      role: typeof payload.role === "string" ? payload.role : undefined,
     };
   } catch {
     return null;

--- a/apps/dashboard/src/routes/memories/$id.tsx
+++ b/apps/dashboard/src/routes/memories/$id.tsx
@@ -80,7 +80,7 @@ function MemoryDetailPage() {
     <div className="space-y-4">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon-sm" asChild>
-          <Link to="/memories" search={{ search: undefined, type: undefined, page: undefined }}><ArrowLeft className="h-4 w-4" /></Link>
+          <Link to="/memories" search={{ search: undefined, type: undefined, scope: undefined, page: undefined }}><ArrowLeft className="h-4 w-4" /></Link>
         </Button>
         <div className="flex-1 flex items-center gap-2">
           <Badge variant="secondary">{memory.type}</Badge>

--- a/apps/dashboard/src/routes/memories/index.tsx
+++ b/apps/dashboard/src/routes/memories/index.tsx
@@ -10,6 +10,7 @@ import { TableRowsSkeleton } from "@/components/page-skeleton";
 import { Pagination } from "@/components/pagination";
 import { RouteTabs } from "@/components/route-tabs";
 import { cn, formatDate, truncate } from "@/lib/utils";
+import { useAuth } from "@/lib/auth";
 import { useEffect, useState } from "react";
 import { Search, Trash2, Brain, Network } from "lucide-react";
 
@@ -28,14 +29,23 @@ interface Memory {
 const PAGE_SIZE = 100;
 const MEMORY_TYPES = ["fact", "decision", "preference", "event", "open_thread"] as const;
 
-type MemoriesSearch = { search?: string; type?: string; page?: number };
+type MemoryScope = "mine" | "all";
+type MemoriesSearch = { search?: string; type?: string; scope?: MemoryScope; page?: number };
+
+function isMemoryScope(value: unknown): value is MemoryScope {
+  return value === "mine" || value === "all";
+}
 
 function MemoriesPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate({ from: Route.fullPath });
-  const { search, type, page } = Route.useSearch();
+  const { search, type, scope, page } = Route.useSearch();
+  const { session } = useAuth();
   const [searchInput, setSearchInput] = useState(search ?? "");
   const [deleteId, setDeleteId] = useState<string | null>(null);
+  const isAdmin = session?.role === "admin";
+  const requestedScope: MemoryScope | undefined = isMemoryScope(scope) ? scope : undefined;
+  const effectiveScope: MemoryScope = isAdmin ? (requestedScope ?? "all") : "mine";
 
   useEffect(() => {
     setSearchInput(search ?? "");
@@ -46,11 +56,12 @@ function MemoriesPage() {
   };
 
   const { data, isLoading, isFetching, error } = useQuery({
-    queryKey: ["memories", search, type, page],
+    queryKey: ["memories", search, type, effectiveScope, page],
     queryFn: () => {
       const params = new URLSearchParams();
       if (search) params.set("search", search);
       if (type) params.set("type", type);
+      params.set("scope", effectiveScope);
       params.set("page", String(page ?? 1));
       params.set("limit", String(PAGE_SIZE));
       return apiGet<{ items: Memory[]; total: number }>(`/memories?${params}`);
@@ -106,6 +117,23 @@ function MemoriesPage() {
             <option key={t} value={t}>{t}</option>
           ))}
         </select>
+        {isAdmin ? (
+          <select
+            value={effectiveScope}
+            onChange={(e) => setParams({
+              scope: e.target.value === "mine" ? "mine" : undefined,
+              page: undefined,
+            })}
+            className="h-8 rounded-md border border-input bg-transparent px-2.5 text-[13px]"
+          >
+            <option value="all">All memories</option>
+            <option value="mine">Mine</option>
+          </select>
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            Showing memories related to you.
+          </span>
+        )}
       </div>
 
       <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
@@ -132,7 +160,12 @@ function MemoriesPage() {
               memories.map((memory) => (
                 <TableRow key={memory.id}>
                   <TableCell>
-                    <Link to="/memories/$id" params={{ id: memory.id }} className="hover:underline">
+                    <Link
+                      to="/memories/$id"
+                      params={{ id: memory.id }}
+                      search={{ scope: isAdmin && effectiveScope === "mine" ? "mine" : undefined }}
+                      className="hover:underline"
+                    >
                       {truncate(memory.content, 80)}
                     </Link>
                   </TableCell>
@@ -182,6 +215,7 @@ export const Route = createFileRoute("/memories/")({
   validateSearch: (raw: Record<string, unknown>) => ({
     search: typeof raw.search === "string" ? raw.search : undefined,
     type: typeof raw.type === "string" ? raw.type : undefined,
+    scope: isMemoryScope(raw.scope) ? raw.scope : undefined,
     page: typeof raw.page === "number" ? raw.page : typeof raw.page === "string" ? Number(raw.page) || undefined : undefined,
   }),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Attach a dashboard auth principal for JWT and service-secret callers.
- Scope dashboard memory list/read/update/delete endpoints so non-admin users only access memories related to their Slack user ID, while admins/service callers can audit all memories.
- Persist dashboard session roles and add an admin-only Mine/All memory scope selector, with non-admin users shown a scoped “related to you” view.
- Add focused tests for dashboard principal memory scope decisions.

Closes #8

## Verification
- `pnpm typecheck`
- `npx tsc --noEmit` in `apps/api`
- `npx tsc --noEmit` in `apps/dashboard`
- `pnpm --filter aura-api exec vitest run src/routes/dashboard/principal.test.ts`

Note: `pnpm --filter aura-api test -- src/routes/dashboard/principal.test.ts` invoked the full API suite and hit the existing `DATABASE_URL environment variable is required` failure in `src/lib/permissions.test.ts`; the focused Vitest invocation above passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6274b16f-c998-414d-aef0-22317a992d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6274b16f-c998-414d-aef0-22317a992d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

