### PR TITLE
fix(bigquery): sanitize Big.js NUMERIC rows at tool boundary (#938)

### DIFF
--- a/apps/api/src/tools/bigquery.test.ts
+++ b/apps/api/src/tools/bigquery.test.ts
@@ -1,8 +1,53 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   augmentBigQueryErrorMessage,
   getBigQueryErrorHints,
 } from "../lib/bigquery-errors.js";
+
+const queryMock = vi.fn();
+const getMetadataMock = vi.fn();
+
+vi.mock("../db/client.js", () => ({
+  db: {},
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/bigquery.js", () => ({
+  getBigQueryClient: vi.fn(async () => ({
+    query: queryMock,
+    dataset: vi.fn(() => ({
+      getMetadata: getMetadataMock,
+      table: vi.fn(() => ({
+        getMetadata: getMetadataMock,
+      })),
+    })),
+  })),
+}));
+
+class BigLikeNumeric {
+  constructor(private readonly value: string) {}
+
+  toJSON() {
+    return this.value;
+  }
+
+  plus() {
+    return this;
+  }
+}
+
+beforeEach(() => {
+  queryMock.mockReset();
+  getMetadataMock.mockReset();
+});
 
 describe("BigQuery error hint augmentation", () => {
   it("adds access-denied guidance for permission-style errors", () => {
@@ -50,5 +95,32 @@ describe("BigQuery error hint augmentation", () => {
     const augmented = augmentBigQueryErrorMessage(message);
 
     expect(augmented).toBe(message);
+  });
+});
+
+describe("BigQuery row sanitization", () => {
+  it("returns structured-cloneable rows from bq_execute_query", async () => {
+    const numericValue = new BigLikeNumeric("1.23");
+    expect(() => structuredClone(numericValue)).toThrow();
+    queryMock.mockResolvedValueOnce([
+      [{ x: numericValue }],
+      undefined,
+      { schema: { fields: [{ name: "x" }] }, totalBytesProcessed: "0" },
+    ]);
+
+    const { createBigQueryTools } = await import("./bigquery.js");
+    const tools = createBigQueryTools();
+    const result = await (tools.bq_execute_query as any).execute({
+      sql: "SELECT CAST(1.23 AS NUMERIC) AS x",
+      max_rows: 10,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      columns: ["x"],
+      rows: [{ x: "1.23" }],
+      total_rows: 1,
+    });
+    expect(() => structuredClone(result)).not.toThrow();
   });
 });

--- a/apps/api/src/tools/bigquery.test.ts
+++ b/apps/api/src/tools/bigquery.test.ts
@@ -33,6 +33,8 @@ vi.mock("../lib/bigquery.js", () => ({
 }));
 
 class BigLikeNumeric {
+  private readonly cloneBreaker = () => this.value;
+
   constructor(private readonly value: string) {}
 
   toJSON() {

--- a/apps/api/src/tools/bigquery.ts
+++ b/apps/api/src/tools/bigquery.ts
@@ -267,7 +267,7 @@ export function createBigQueryTools(context?: ScheduleContext) {
             maximumBytesBilled: String(1e9),
             location,
           });
-          samples = rows;
+          samples = JSON.parse(JSON.stringify(rows));
         } catch (sampleError: unknown) {
           logger.warn(`${toolName} sample query failed`, {
             dataset,
@@ -363,20 +363,21 @@ export function createBigQueryTools(context?: ScheduleContext) {
         location,
       });
       const rows = queryResult[0];
+      const cleanRows = JSON.parse(JSON.stringify(rows));
       const responseMeta = (queryResult as any)[2];
       const columns =
         responseMeta?.schema?.fields?.map((f: any) => f.name) ??
-        (rows.length > 0 ? Object.keys(rows[0]) : []);
-      const totalRows = rows.length;
+        (cleanRows.length > 0 ? Object.keys(cleanRows[0]) : []);
+      const totalRows = cleanRows.length;
       const bytesProcessed = responseMeta?.totalBytesProcessed ?? null;
 
       logger.info(`${toolName} called`, {
         sqlLength: sql.length,
-        rowCount: rows.length,
+        rowCount: cleanRows.length,
         bytesProcessed,
       });
 
-      const resultRows = rows.slice(0, max_rows);
+      const resultRows = cleanRows.slice(0, max_rows);
       const result = {
         ok: true as const,
         columns,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes #938 by JSON-sanitizing BigQuery query rows immediately after `client.query(...)` returns them.
- Applies the same row sanitization to `bq_inspect_table` sample rows.
- Adds a regression test that mocks a Big.js-like NUMERIC value and verifies the `bq_execute_query` result is `structuredClone`-safe.

## Verification
- `pnpm --dir apps/api exec vitest run src/tools/bigquery.test.ts`
- `npx tsc --noEmit` from `apps/api/`
- Pre-push hook: root `pnpm typecheck` passed for API and dashboard
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1169b187-737b-4799-8e00-3f81b9f548cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1169b187-737b-4799-8e00-3f81b9f548cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

