### PR TITLE
fix: propagate script failure status in job execution

### DIFF
--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { detectScriptOutputError } from "./script-output.js";
+
+describe("detectScriptOutputError", () => {
+  it("returns null for clean stdout with no error envelope", () => {
+    const output = '{"status": "ok", "count": 42}\nDone processing.';
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+
+  it("returns null for empty output", () => {
+    expect(detectScriptOutputError("")).toBeNull();
+  });
+
+  it('detects {"error": "..."} envelope', () => {
+    const output = 'Starting job...\n{"error": "connection refused"}\n';
+    const result = detectScriptOutputError(output);
+    expect(result).toBe("connection refused");
+  });
+
+  it('detects {"error": {...}} envelope with object value', () => {
+    const output = '{"error": {"code": 500, "message": "internal"}}';
+    const result = detectScriptOutputError(output);
+    expect(result).toContain("500");
+    expect(result).toContain("internal");
+  });
+
+  it('detects {"ok": false} envelope', () => {
+    const output = '{"ok": false, "error": "timeout exceeded"}';
+    const result = detectScriptOutputError(output);
+    expect(result).toBe("timeout exceeded");
+  });
+
+  it('detects {"ok": false} without error field', () => {
+    const output = '{"ok": false, "data": null}';
+    const result = detectScriptOutputError(output);
+    expect(result).toBe("Script returned {ok: false}");
+  });
+
+  it("ignores ok: true even with error-like fields", () => {
+    const output = '{"ok": true, "error": null}';
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+
+  it("ignores non-JSON lines", () => {
+    const output = "ERROR: something went wrong\nTraceback follows...";
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+
+  it("ignores arrays and non-object JSON", () => {
+    const output = '[{"error": "inside array"}]\n"just a string"';
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+
+  it("picks up the first error line when multiple exist", () => {
+    const output = '{"ok": true}\n{"error": "first error"}\n{"error": "second"}';
+    expect(detectScriptOutputError(output)).toBe("first error");
+  });
+
+  it("ignores malformed JSON that starts with {", () => {
+    const output = '{not valid json at all}\n{"status": "ok"}';
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+
+  it('does not treat {"error": ""} (empty string) as an error', () => {
+    const output = '{"error": ""}';
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+
+  it('does not treat {"error": 0} (falsy) as an error', () => {
+    const output = '{"error": 0}';
+    expect(detectScriptOutputError(output)).toBeNull();
+  });
+});

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -16,6 +16,7 @@ import {
   updateConversationTraceUsage,
   buildConversationSteps,
 } from "./persist-conversation.js";
+import { detectScriptOutputError } from "./script-output.js";
 import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
 import { resolveSlackDestination } from "../tools/slack.js";
@@ -195,8 +196,35 @@ export async function executeJob(
           envs,
         });
 
-        if (scriptResult.exitCode === 0) {
-          scriptOutput = truncateOutput(scriptResult.stdout, 50_000);
+        const exitCode = scriptResult.exitCode;
+        const stdout = scriptResult.stdout || "";
+        const stderr = scriptResult.stderr || "";
+
+        if (exitCode !== 0) {
+          if (job.playbook) {
+            logger.warn("executeJob: script failed, falling through to LLM", {
+              jobId,
+              jobName: job.name,
+              exitCode,
+              stderr: stderr.slice(0, 500),
+            });
+          } else {
+            const outputTail = (stderr || stdout).slice(-2000);
+            throw new Error(
+              `Script exited with code ${exitCode}:\n${outputTail}`,
+            );
+          }
+        } else {
+          scriptOutput = truncateOutput(stdout, 50_000);
+
+          const outputError = detectScriptOutputError(stdout);
+
+          if (outputError && !job.playbook) {
+            const outputTail = stdout.slice(-2000);
+            throw new Error(
+              `Script reported error: ${outputError}\n${outputTail}`,
+            );
+          }
 
           if (!job.playbook) {
             const resultText = scriptOutput || "(script produced no output)";
@@ -240,16 +268,20 @@ export async function executeJob(
             logger.info("executeJob: script-only job completed", { jobId, jobName: job.name });
             return true;
           }
-        } else {
-          logger.warn("executeJob: script failed, falling through to LLM", {
-            jobId,
-            jobName: job.name,
-            exitCode: scriptResult.exitCode,
-            stderr: scriptResult.stderr?.slice(0, 500),
-          });
+
+          if (outputError) {
+            logger.warn("executeJob: script output contains error JSON, falling through to LLM", {
+              jobId,
+              jobName: job.name,
+              outputError,
+            });
+          }
         }
       } catch (scriptErr: any) {
         if (scriptOutput) {
+          throw scriptErr;
+        }
+        if (!job.playbook) {
           throw scriptErr;
         }
         logger.warn("executeJob: script execution error, falling through to LLM", {

--- a/apps/api/src/cron/script-output.ts
+++ b/apps/api/src/cron/script-output.ts
@@ -1,0 +1,30 @@
+/**
+ * Scan stdout/stderr for a JSON error envelope that signals a logical failure
+ * even when the process exited 0. Matches:
+ *   - {"error": "..."}  or  {"error": {...}}
+ *   - {"ok": false, ...}
+ * Only top-level JSON lines are inspected (one per line).
+ */
+export function detectScriptOutputError(output: string): string | null {
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
+
+      if ("error" in parsed && parsed.error) {
+        const msg = typeof parsed.error === "string" ? parsed.error : JSON.stringify(parsed.error);
+        return msg;
+      }
+
+      if (parsed.ok === false) {
+        const msg = typeof parsed.error === "string" ? parsed.error : "Script returned {ok: false}";
+        return msg;
+      }
+    } catch {
+      // not valid JSON — skip
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Script-only jobs (jobs with a `script` field but no `playbook`) always reported `status = 'completed'` in the heartbeat, even when:
- The script exited with a non-zero exit code
- The script's stdout contained a JSON error envelope like `{"error": "..."}` or `{"ok": false, ...}`

This masked real failures — e.g. gap #158 where `sync-meta-comments-daily` failed due to stale SQLite + wrong runner path, but the heartbeat reported "Done".

## Solution

### 1. Capture and propagate non-zero exit codes
For script-only jobs, a non-zero exit code now throws an error with the stderr/stdout tail. This is caught by the existing `catch` block which handles:
- Retry logic (up to 3 attempts with 30-minute delays)
- DM escalation to the job requester on final failure
- Setting both `jobs.status` and `jobExecutions.status` to `'failed'`

### 2. Detect error JSON envelopes in stdout
New `detectScriptOutputError()` function scans stdout line-by-line for:
- `{"error": "..."}` — top-level error field with truthy value
- `{"ok": false, ...}` — explicit failure signal

If found on a script-only job (exit code 0), throws to trigger the same retry/DM path.

### 3. Preserve playbook fallthrough behavior
Jobs that have both a `script` and a `playbook` retain the existing behavior: script failures fall through to the LLM agent for intelligent error handling.

## Files changed
- **`apps/api/src/cron/script-output.ts`** — New module with `detectScriptOutputError()` (zero dependencies, easily testable)
- **`apps/api/src/cron/execute-job.ts`** — Updated script execution branch to propagate failures for script-only jobs
- **`apps/api/src/cron/execute-job.test.ts`** — 13 unit tests for `detectScriptOutputError` covering clean output, error envelopes, edge cases

## Test coverage
All 13 new tests pass. Covers:
- Clean stdout → `null` (no error)
- `{"error": "connection refused"}` → detected
- `{"error": {"code": 500, ...}}` → detected (object error values)
- `{"ok": false, "error": "timeout"}` → detected
- `{"ok": false}` without error field → detected with default message
- `{"ok": true, "error": null}` → not treated as error
- Non-JSON lines, arrays, malformed JSON → ignored
- Empty/falsy error values → not treated as errors

Closes #940
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9899d49a-75ec-472a-8910-9efac41b18db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9899d49a-75ec-472a-8910-9efac41b18db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

