### PR TITLE
fix: draw_table falls back to monospace in MPIM (group DM) channels

### DIFF
--- a/apps/api/src/memory/store.ts
+++ b/apps/api/src/memory/store.ts
@@ -11,6 +11,7 @@ export type DbChannelType = "dm" | "public_channel" | "private_channel" | "dashb
 
 export function toDbChannelType(ct: ChannelType | "dashboard"): DbChannelType {
   if (ct === "dm" || ct === "public_channel" || ct === "private_channel" || ct === "dashboard") return ct;
+  if (ct === "mpim") return "dm";
   return "public_channel";
 }
 

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -514,7 +514,9 @@ export async function buildSystemPrompt(
   // Setting (channel/DM + current time)
   const settingText = context.channelType === "dm"
     ? `You're in a private DM. Be conversational and personal.`
-    : `You're in the ${context.channelContext} channel. Respond in-thread. Adapt your tone to the channel.`;
+    : context.channelType === "mpim"
+      ? `You're in a group DM (MPIM). Be conversational and personal.`
+      : `You're in the ${context.channelContext} channel. Respond in-thread. Adapt your tone to the channel.`;
   contextParts.push(`  <setting>\n${settingText}\n  </setting>`);
 
   // User profile

--- a/apps/api/src/pipeline/context.ts
+++ b/apps/api/src/pipeline/context.ts
@@ -42,7 +42,7 @@ export interface SlackAppMentionEvent {
 
 export type SlackEvent = SlackMessageEvent | SlackAppMentionEvent;
 
-export type ChannelType = "dm" | "dashboard" | "public_channel" | "private_channel" | "slack_list_item";
+export type ChannelType = "dm" | "mpim" | "dashboard" | "public_channel" | "private_channel" | "slack_list_item";
 
 export interface SlackListItemContext {
   /** The message ts that doubles as the list item's thread_ts */
@@ -152,7 +152,7 @@ export function buildMessageContext(
     channelType,
     threadTs,
     messageTs,
-    isDm: channelType === "dm",
+    isDm: channelType === "dm" || channelType === "mpim",
     isMentioned,
     isAddressedByName,
   };
@@ -343,7 +343,8 @@ function resolveChannelType(
   if ("channel_type" in event) {
     const ct = (event as any).channel_type;
     if (ct === "im") return "dm";
-    if (ct === "group" || ct === "mpim") return "private_channel";
+    if (ct === "mpim") return "mpim";
+    if (ct === "group") return "private_channel";
     if (ct === "slack_list_item") return "slack_list_item";
     return "public_channel";
   }

--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -24,7 +24,7 @@ export type { PersonProfile };
 
 // ── Channel Session ──────────────────────────────────────────────────────────
 
-export type ChannelType = "dm" | "dashboard" | "public_channel" | "private_channel";
+export type ChannelType = "dm" | "mpim" | "dashboard" | "public_channel" | "private_channel";
 
 export interface ChannelSession {
   channel: "slack" | "dashboard";

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -1090,6 +1090,24 @@ export async function generateResponse(
           } catch {
             // Stream may already be finalized
           }
+          // Deliver the table block via chat.postMessage as a follow-up
+          // when the stream rejected it (e.g. MPIMs, some channel types).
+          if (pendingTableBlock) {
+            try {
+              await slackClient.chat.postMessage({
+                channel: channelId,
+                text: "Here's a table:",
+                blocks: [pendingTableBlock as any],
+                thread_ts: threadTs,
+              });
+              pendingTableBlock = null;
+            } catch (tablePostErr: any) {
+              logger.warn("Failed to post table block via chat.postMessage fallback", {
+                channelId,
+                error: tablePostErr?.message,
+              });
+            }
+          }
         } else if (isMsgTooLong(stopErr)) {
           logger.warn("streamer.stop() returned msg_too_long, finalizing without payload", {
             channelId,
@@ -1103,6 +1121,22 @@ export async function generateResponse(
             context: { currentStreamLength },
           });
           try { await streamer.stop(); } catch { /* already finalized */ }
+          if (pendingTableBlock) {
+            try {
+              await slackClient.chat.postMessage({
+                channel: channelId,
+                text: "Here's a table:",
+                blocks: [pendingTableBlock as any],
+                thread_ts: threadTs,
+              });
+              pendingTableBlock = null;
+            } catch (tablePostErr: any) {
+              logger.warn("Failed to post table block via chat.postMessage fallback", {
+                channelId,
+                error: tablePostErr?.message,
+              });
+            }
+          }
         } else if (isChannelTypeNotSupported(stopErr)) {
           streamingUnsupportedChannels.add(channelId);
           logger.warn("streamer.stop() hit channel_type_not_supported, finalizing without payload", {
@@ -1115,6 +1149,22 @@ export async function generateResponse(
             channelId,
           });
           try { await streamer.stop(); } catch { /* already finalized */ }
+          if (pendingTableBlock) {
+            try {
+              await slackClient.chat.postMessage({
+                channel: channelId,
+                text: "Here's a table:",
+                blocks: [pendingTableBlock as any],
+                thread_ts: threadTs,
+              });
+              pendingTableBlock = null;
+            } catch (tablePostErr: any) {
+              logger.warn("Failed to post table block via chat.postMessage fallback", {
+                channelId,
+                error: tablePostErr?.message,
+              });
+            }
+          }
         } else {
           throw stopErr;
         }

--- a/apps/api/src/tools/table.test.ts
+++ b/apps/api/src/tools/table.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { TABLE_BLOCK_KEY, createTableTools } from "./table.js";
+import { buildMessageContext } from "../pipeline/context.js";
+
+vi.mock("../db/client.js", () => ({
+  db: {},
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("draw_table inline mode", () => {
+  it("returns a native table block (not monospace)", async () => {
+    const fakeClient = {} as any;
+    const tools = createTableTools(fakeClient);
+    const result = await (tools.draw_table as any).execute({
+      rows: [
+        ["Name", "Score"],
+        ["Alice", "95"],
+        ["Bob", "87"],
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result[TABLE_BLOCK_KEY]).toBeDefined();
+    expect(result[TABLE_BLOCK_KEY].type).toBe("table");
+    expect(result[TABLE_BLOCK_KEY].rows).toHaveLength(3);
+  });
+
+  it("returns a native table block regardless of channel type context", async () => {
+    const fakeClient = {} as any;
+    // Simulate MPIM context
+    const mpimContext = { channelId: "G01ABCDEF", threadTs: "1234.5678", timezone: "UTC" };
+    const tools = createTableTools(fakeClient, mpimContext as any);
+    const result = await (tools.draw_table as any).execute({
+      rows: [
+        ["Metric", "Value"],
+        ["Revenue", "$100k"],
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result[TABLE_BLOCK_KEY]).toBeDefined();
+    expect(result[TABLE_BLOCK_KEY].type).toBe("table");
+  });
+});
+
+describe("MPIM channel type resolution", () => {
+  it("resolves mpim channel_type to 'mpim' ChannelType", () => {
+    const event = {
+      type: "message" as const,
+      channel: "G01ABCDEF",
+      ts: "1234.5678",
+      text: "hello",
+      user: "U_USER",
+      channel_type: "mpim",
+    };
+    const ctx = buildMessageContext(event, "U_BOT");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.channelType).toBe("mpim");
+  });
+
+  it("sets isDm to true for mpim channels", () => {
+    const event = {
+      type: "message" as const,
+      channel: "G01ABCDEF",
+      ts: "1234.5678",
+      text: "hello",
+      user: "U_USER",
+      channel_type: "mpim",
+    };
+    const ctx = buildMessageContext(event, "U_BOT");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.isDm).toBe(true);
+  });
+
+  it("resolves im channel_type to dm with isDm true", () => {
+    const event = {
+      type: "message" as const,
+      channel: "D01ABCDEF",
+      ts: "1234.5678",
+      text: "hello",
+      user: "U_USER",
+      channel_type: "im",
+    };
+    const ctx = buildMessageContext(event, "U_BOT");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.channelType).toBe("dm");
+    expect(ctx!.isDm).toBe(true);
+  });
+
+  it("resolves group channel_type to private_channel with isDm false", () => {
+    const event = {
+      type: "message" as const,
+      channel: "G01ABCDEF",
+      ts: "1234.5678",
+      text: "hello",
+      user: "U_USER",
+      channel_type: "group",
+    };
+    const ctx = buildMessageContext(event, "U_BOT");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.channelType).toBe("private_channel");
+    expect(ctx!.isDm).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`draw_table` rendered tables as monospace code blocks in multi-user group DMs (MPIMs) instead of using the native Slack table widget. This was caused by two issues:

1. **Channel type misclassification**: `resolveChannelType` collapsed `"mpim"` into `"private_channel"`, losing the MPIM identity entirely. MPIMs weren't treated as DMs, meaning Aura wouldn't always respond in them and thread titles weren't set.

2. **Table block delivery gap**: When `streamer.stop()` rejected table blocks with `invalid_blocks` (which happens when chatStream doesn't support table block chunks for certain channel types), the retry path dropped all blocks, silently losing the table. The LLM would then output a text version of the table, which got wrapped in code fences.

## Changes

- **Add `"mpim"` as a distinct `ChannelType`** in `context.ts` and `core-prompt.ts`, instead of collapsing to `"private_channel"`
- **Set `isDm: true` for MPIM channels** — MPIMs should behave like DMs (always respond, set thread titles, etc.)
- **Map `"mpim"` → `"dm"` in DB storage** (`DbChannelType` doesn't have an mpim variant)
- **Add MPIM-specific system prompt** ("You're in a group DM") so the LLM adapts tone appropriately
- **Add `chat.postMessage` fallback** in `respond.ts` when `streamer.stop()` rejects table blocks — ensures `draw_table` tables are always delivered via native block, even when the streaming API rejects them
- **Add 6 tests** covering channel type resolution for mpim/im/group and `draw_table` inline mode

## Testing

- All 6 new tests pass (channel type resolution + draw_table inline mode)
- All 65 existing tests pass
- `pnpm typecheck` passes cleanly for both `apps/api` and `apps/dashboard`

Closes #939
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72008553-a342-4ffc-870b-51b46e323232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72008553-a342-4ffc-870b-51b46e323232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

