### PR TITLE
fix: truncate embedding vectors in error logger (#917)

### DIFF
--- a/apps/api/src/lib/error-logger.test.ts
+++ b/apps/api/src/lib/error-logger.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
+
+const { sanitizeErrorText } = await import("./error-logger.js");
+
+function numericArray(length: number): string {
+  return `[${Array.from({ length }, (_, i) => ((i + 1) / 1000).toFixed(4)).join(",")}]`;
+}
+
+describe("sanitizeErrorText", () => {
+  it("leaves clean text unchanged", () => {
+    const input = "duplicate key value violates unique constraint";
+
+    expect(sanitizeErrorText(input)).toBe(input);
+  });
+
+  it("leaves short numeric arrays unchanged", () => {
+    const input = "params: [1,2,3,4,5]";
+
+    expect(sanitizeErrorText(input)).toBe(input);
+  });
+
+  it("strips a Postgres embedding vector dump", () => {
+    const input = `Failed query: insert into messages values ($1) params: ${numericArray(1536)}`;
+    const output = sanitizeErrorText(input);
+
+    expect(output).toContain("floats omitted");
+    expect(output).toContain("1536 floats omitted");
+    expect(output.length).toBeLessThan(500);
+  });
+
+  it("strips multiple embeddings in one message", () => {
+    const input = `first=${numericArray(32)} second=${numericArray(64)}`;
+    const output = sanitizeErrorText(input);
+
+    expect(output.match(/floats omitted/g)).toHaveLength(2);
+    expect(output).toContain("32 floats omitted");
+    expect(output).toContain("64 floats omitted");
+  });
+
+  it("truncates long stack traces with a marker", () => {
+    const input = `Error: failed\n${"at frame\n".repeat(300)}`;
+    const output = sanitizeErrorText(input);
+
+    expect(output).toContain("truncated, original");
+    expect(output.length).toBeLessThan(input.length);
+  });
+
+  it("returns an empty string for nullish input", () => {
+    expect(sanitizeErrorText(null)).toBe("");
+    expect(sanitizeErrorText(undefined)).toBe("");
+  });
+});

--- a/apps/api/src/lib/error-logger.ts
+++ b/apps/api/src/lib/error-logger.ts
@@ -37,6 +37,41 @@ const slackWindows = new Map<
   { lastPostTime: number; batchedCount: number }
 >();
 
+/**
+ * Strip long numeric arrays from error messages.
+ * Postgres "Failed query: ... params: ... [0.012, -0.034, ...]" dumps
+ * full embedding vectors into error.message. Truncate them so #aura-errors
+ * stays readable. Keep first 4 + last 2 values for debuggability.
+ */
+export function sanitizeErrorText(
+  input: string | undefined | null,
+  maxLen = 2000,
+): string {
+  if (!input) return "";
+
+  // Match bracketed numeric arrays of >= 16 numeric items (signed floats incl. exp notation).
+  // Regex is intentionally narrow to avoid stripping legitimate JSON arrays of strings.
+  const NUM_ARRAY_RE =
+    /\[(?:\s*-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\s*,){15,}\s*-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\s*\]/g;
+
+  let out = input.replace(NUM_ARRAY_RE, (match) => {
+    const nums = match
+      .slice(1, -1)
+      .split(",")
+      .map((s) => s.trim());
+    const head = nums.slice(0, 4).join(",");
+    const tail = nums.slice(-2).join(",");
+
+    return `[${head},…(${nums.length} floats omitted)…,${tail}]`;
+  });
+
+  if (out.length > maxLen) {
+    out = out.slice(0, maxLen) + `…(truncated, original ${input.length} chars)`;
+  }
+
+  return out;
+}
+
 function isRateLimited(errorCode: string): boolean {
   const now = Date.now();
 
@@ -142,7 +177,7 @@ async function postToSlack(params: LogErrorParams): Promise<void> {
   const channelId = await getErrorsChannelId(slack);
   if (!channelId) return;
 
-  let text = `*${params.errorName}*: ${params.errorMessage}`;
+  let text = `*${params.errorName}*: ${sanitizeErrorText(params.errorMessage)}`;
   if (params.errorCode) text += `\n*Code*: \`${params.errorCode}\``;
   if (params.userId) text += `  |  *User*: \`${params.userId}\``;
   if (params.channelId) text += `  |  *Channel*: \`${params.channelId}\``;
@@ -174,13 +209,13 @@ export function logError(params: LogErrorParams): void {
     db.insert(errorEvents)
       .values({
         errorName: params.errorName,
-        errorMessage: params.errorMessage,
+        errorMessage: sanitizeErrorText(params.errorMessage),
         errorCode: params.errorCode,
         userId: params.userId,
         channelId: params.channelId,
         channelType: params.channelType,
         context: params.context,
-        stackTrace: params.stackTrace,
+        stackTrace: sanitizeErrorText(params.stackTrace),
       })
       .catch(() => {});
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #917

Adds centralized error text sanitization in `apps/api/src/lib/error-logger.ts` so long numeric arrays from Postgres/drizzle embedding parameter dumps are compacted before posting to `#aura-errors` or persisting `error_events`, with stack traces sanitized and length-limited as well. Includes focused Vitest coverage for clean messages, short arrays, large embeddings, multiple embeddings, truncation, and nullish input.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38c8b550-68ac-4b86-a721-8e05b9083115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38c8b550-68ac-4b86-a721-8e05b9083115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

