### PR TITLE
Reject invalid DM thread titles

### DIFF
--- a/apps/api/src/pipeline/__tests__/dm-title.test.ts
+++ b/apps/api/src/pipeline/__tests__/dm-title.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isValidTitle, sanitizeTitle } from "../dm-title.js";
+
+describe("DM thread title helpers", () => {
+  it("strips wrapping quotes and trailing punctuation", () => {
+    expect(sanitizeTitle('"Stripe webhook deduplication."')).toBe(
+      "Stripe webhook deduplication",
+    );
+  });
+
+  it.each([
+    "I don't have enough context to identify the core topics...",
+    "I'm not sure what to call this",
+    "User frustration with excessive automated messaging",
+    "Assistant AI profiling and user information retrieval",
+    "Sorry, I can't summarize this",
+    "SKIP",
+    "",
+  ])("rejects invalid title: %s", (title) => {
+    expect(isValidTitle(title)).toBe(false);
+  });
+
+  it.each([
+    "FR React crash recap",
+    "Outbound BDR reminder",
+    "Stripe webhook deduplication",
+    "Assistant deployment status",
+  ])("accepts valid title: %s", (title) => {
+    expect(isValidTitle(title)).toBe(true);
+  });
+});

--- a/apps/api/src/pipeline/dm-title.ts
+++ b/apps/api/src/pipeline/dm-title.ts
@@ -1,0 +1,25 @@
+/** Strip wrapping quotes and trailing punctuation that LLMs sometimes add despite instructions. */
+export function sanitizeTitle(raw: string): string {
+  return raw.trim().replace(/^["'""]+|["'""]+$/g, "").replace(/[.!;:]+$/, "").trim();
+}
+
+const REFUSAL_START_RE =
+  /^(?:i\s|i'm|i\sdon|i\scannot|i\scan't|sorry[,\s]|unfortunately|as an ai|as an assistant)/i;
+
+const REFUSAL_PHRASE_RE =
+  /(?:enough context|unable to|don't have|not sure what|cannot determine|can't determine|no clear topic)/i;
+
+const META_DESCRIPTION_RE =
+  /^(?:user|assistant)\s+(?:ai\s+)?(?:frustration|confusion|profiling|inquiry|asking|asks|wants|needs|requests?)\b/i;
+
+export function isValidTitle(title: string): boolean {
+  const sanitized = sanitizeTitle(title);
+
+  if (!sanitized || sanitized.length < 3) return false;
+  if (/^skip$/i.test(sanitized)) return false;
+  if (REFUSAL_START_RE.test(sanitized)) return false;
+  if (REFUSAL_PHRASE_RE.test(sanitized)) return false;
+  if (META_DESCRIPTION_RE.test(sanitized)) return false;
+
+  return true;
+}

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -35,6 +35,7 @@ import { logger } from "../lib/logger.js";
 import { logError } from "../lib/error-logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
 import { trySetAssistantThreadStatus } from "../lib/slack-status.js";
+import { isValidTitle, sanitizeTitle } from "./dm-title.js";
 import {
   createConversationTrace,
   persistConversationInputs,
@@ -989,11 +990,6 @@ async function runBackgroundTasks(params: {
   }
 }
 
-/** Strip wrapping quotes and trailing punctuation that LLMs sometimes add despite instructions. */
-function sanitizeTitle(raw: string): string {
-  return raw.trim().replace(/^["'""]+|["'""]+$/g, "").replace(/[.!;:]+$/, "").trim();
-}
-
 /**
  * Generate and set the initial title for a DM thread.
  * Triggered after the first assistant response so both sides of the
@@ -1014,10 +1010,13 @@ async function setInitialDmThreadTitle(params: {
     const { text: raw } = await generateText({
       model: fastModel,
       maxOutputTokens: 40,
-      prompt: `What is this conversation about? Name the core topic in 3-8 words. No quotes, no punctuation at the end.\n\nUser: "${userMessage.slice(0, 300)}"\n\nAssistant: "${assistantResponse.slice(0, 500)}"`,
+      prompt: `What is this conversation about? Name the core topic in 3-8 words. No quotes, no punctuation at the end.\n\nUser: "${userMessage.slice(0, 300)}"\n\nAssistant: "${assistantResponse.slice(0, 500)}"\n\nRules: Never start with 'I', 'User', 'Assistant', or 'Sorry'. Never describe the user's emotional state. Just name the topic. If unclear, respond with the single word: SKIP`,
     });
     const title = sanitizeTitle(raw).slice(0, 100);
-    if (!title) return;
+    if (!isValidTitle(title)) {
+      logger.warn("Rejected invalid DM thread title", { rawTitle: raw, channelId });
+      return;
+    }
     await client.assistant.threads.setTitle({
       channel_id: channelId,
       thread_ts: threadTs,
@@ -1076,22 +1075,24 @@ async function maybeUpdateDmThreadTitle(params: {
     const { text: raw } = await generateText({
       model: fastModel,
       maxOutputTokens: 40,
-      prompt: `What are the 1-3 core topics discussed in this Slack DM conversation? Express as a short title (5-10 words). If multiple distinct topics, separate them with " / ". Capture the essence of the whole conversation arc, not just the latest messages. No quotes, no punctuation at the end.\n\nConversation:\n${messagesContext}\n\nLatest assistant response: "${assistantResponse.slice(0, 300)}"`,
+      prompt: `What are the 1-3 core topics discussed in this Slack DM conversation? Express as a short title (5-10 words). If multiple distinct topics, separate them with " / ". Capture the essence of the whole conversation arc, not just the latest messages. No quotes, no punctuation at the end.\n\nConversation:\n${messagesContext}\n\nLatest assistant response: "${assistantResponse.slice(0, 300)}"\n\nRules: Never start with 'I', 'User', 'Assistant', or 'Sorry'. Never describe the user's emotional state. Just name the topic. If unclear, respond with the single word: SKIP`,
     });
 
-    const newTitle = sanitizeTitle(raw).slice(0, 100);
-    if (newTitle) {
-      await client.assistant.threads.setTitle({
-        channel_id: channelId,
-        thread_ts: threadTs,
-        title: newTitle,
-      });
-      logger.info("Updated DM thread title at checkpoint", {
-        newTitle,
-        channelId,
-        messageCount: totalMessages,
-      });
+    const title = sanitizeTitle(raw).slice(0, 100);
+    if (!isValidTitle(title)) {
+      logger.warn("Rejected invalid DM thread title", { rawTitle: raw, channelId });
+      return;
     }
+    await client.assistant.threads.setTitle({
+      channel_id: channelId,
+      thread_ts: threadTs,
+      title,
+    });
+    logger.info("Updated DM thread title at checkpoint", {
+      newTitle: title,
+      channelId,
+      messageCount: totalMessages,
+    });
   } catch (error: any) {
     logger.warn("Failed to update DM thread title", {
       error: error?.message || String(error),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #945.

- Extracted DM title helpers into `apps/api/src/pipeline/dm-title.ts` for focused validation tests.
- Added `isValidTitle()` to reject LLM refusals, hedges, `SKIP`, empty/too-short titles, and meta-descriptions before calling `assistant.threads.setTitle()`.
- Tightened both DM title generation prompts with explicit rules to avoid `I`, `User`, `Assistant`, `Sorry`, emotional-state descriptions, and to return `SKIP` when unclear.

## Production bad title strings summarized

This blocks the observed bad title patterns from being written verbatim to Slack thread titles, including:

- `I don't have enough context to identify the core topics...`
- `I'm not sure what to call this`
- `User frustration with excessive automated messaging`
- `Assistant AI profiling and user information retrieval`

## Tests

Added `apps/api/src/pipeline/__tests__/dm-title.test.ts` with cases that:

- Reject: `I don't have enough context to identify the core topics...`
- Reject: `I'm not sure what to call this`
- Reject: `User frustration with excessive automated messaging`
- Reject: `Assistant AI profiling and user information retrieval`
- Reject: `Sorry, I can't summarize this`
- Reject: `SKIP`
- Reject: empty string
- Accept: `FR React crash recap`
- Accept: `Outbound BDR reminder`
- Accept: `Stripe webhook deduplication`
- Accept: `Assistant deployment status`

Verification run:

- `pnpm --filter aura-api exec vitest run src/pipeline/__tests__/dm-title.test.ts`
- `npx tsc --noEmit` from `apps/api`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11437415-0c16-4da1-a864-ab47f1c358e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11437415-0c16-4da1-a864-ab47f1c358e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

