### PR TITLE
docs(email): reflect PR #933 access-control changes

### DIFF
--- a/content/docs/tools/email-sync.mdx
+++ b/content/docs/tools/email-sync.mdx
@@ -21,7 +21,7 @@ Every synced email thread has a state:
 
 ## How It Works
 
-1. **Sync** — Gmail inbox is periodically synced. New emails are stored with embeddings for semantic search.
+1. **Sync** — Gmail inbox is synced via `sync_emails`, or automatically when `email_digest` / `search_emails` detect a stale `emails_raw` (older than ~6h). New emails are stored with embeddings for semantic search.
 2. **Classify** — New threads are automatically classified into triage states based on content, sender, and patterns.
 3. **Digest** — Daily email digests summarize the inbox: what's new, what's aging, what needs attention.
 4. **Search** — Two modes: keyword (full-text) and semantic (meaning-based vector search).
@@ -43,6 +43,12 @@ Aura produces daily email digests that include:
 - **Aging threads** — Items awaiting reply for too long
 - **Deadlines** — Upcoming due dates extracted from email content
 - **Auto-resolved** — Threads automatically dismissed as noise
+
+## Access
+
+By default, every email tool operates on the caller's own connected Gmail account. Admins (users with the `admin` role) can additionally pass `user_name` to operate on another connected account. Non-admins cannot read or modify another user's inbox -- the tool returns an explicit access error.
+
+This is enforced at runtime by `assertCanAccessUserEmail` in `apps/api/src/tools/email-sync.ts` (added in PR #933).
 
 ## Privacy
 

--- a/content/docs/tools/email.mdx
+++ b/content/docs/tools/email.mdx
@@ -126,7 +126,9 @@ Generate a Google OAuth consent URL so a user can connect their Gmail account. D
 
 ---
 
-## Email Triage (Admin-only)
+## Email Triage
+
+Each tool below works for the caller's own Gmail account by default. Workspace admins can additionally operate on another user's synced inbox by passing `user_name`. The previous admin-only restriction was lifted in PR #933 (May 2026).
 
 ### `sync_emails`
 Sync emails from a user's Gmail into Aura's staging pipeline. Supports date windows and Gmail query syntax. Resumable — re-running skips already-synced emails.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Updates email triage docs to reflect that PR #933 lifted the admin-only restriction on email triage tools.
- Documents that `email_digest` and `search_emails` can auto-sync when `emails_raw` is stale.

## Context

The docs were stale after PR #933 added access-control changes and auto-sync-on-stale behavior. This is a P0 accuracy fix found by the daily docs-maintenance job.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd67bfab-d84a-4973-8bc2-d1d9252d7ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd67bfab-d84a-4973-8bc2-d1d9252d7ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

