### PR TITLE
Allow cancelling failed one-shot jobs

### DIFF
--- a/apps/api/src/tools/jobs.ts
+++ b/apps/api/src/tools/jobs.ts
@@ -348,7 +348,7 @@ export function createJobTools(
 
     cancel_job: defineTool({
       description:
-        "Cancel a pending one-shot job, or disable a recurring job (preserves its definition for re-enabling later). Accepts a job ID or name.",
+        "Cancel a pending or failed one-shot job, or disable a recurring job (preserves its definition for re-enabling later). Accepts a job ID or name.",
       inputSchema: z.object({
         job_id: z
           .string()

--- a/apps/api/src/tools/jobs.ts
+++ b/apps/api/src/tools/jobs.ts
@@ -394,8 +394,8 @@ export function createJobTools(
               message: `Recurring job "${job.name}" disabled. Use create_job with the same name to re-enable.`,
             };
           } else {
-            // One-shot: only cancel if still pending
-            if (job.status !== "pending") {
+            // One-shot: allow pending jobs and failed zombies to be cancelled.
+            if (job.status !== "pending" && job.status !== "failed") {
               return {
                 ok: false,
                 error: `Job "${job.name}" is already ${job.status} and cannot be cancelled.`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow `cancel_job` to transition failed one-shot jobs to `cancelled`.
- Update the `cancel_job` tool description so guidance matches the new pending-or-failed one-shot behavior.
- Leave recurring job handling unchanged so recurring jobs are still disabled instead of cancelled.

## Verification
- `npx tsc --noEmit` attempted from repo root; npm resolved the wrong `tsc` package because dependencies were not installed.
- `pnpm install`
- `pnpm typecheck`
- Pre-push typecheck hook passed for `apps/api` and `apps/dashboard`.

## Not run
- Live `list_jobs(status: "failed")` -> `cancel_job` scenario; this cloud workspace does not have `.env.local` or `.env.production` / `DATABASE_URL` available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a4ffaf1-1921-4e29-aaae-454253cefb15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a4ffaf1-1921-4e29-aaae-454253cefb15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

