### PR TITLE
Surface sandbox credential capabilities in prompts

### DIFF
--- a/apps/api/src/lib/sandbox.test.ts
+++ b/apps/api/src/lib/sandbox.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+  credentialRows: [] as Array<{
+    id: string;
+    name: string;
+    value: string;
+    ownerId: string;
+    scope: string;
+    sandboxEnvName: string | null;
+  }>,
+  grantRows: [] as Array<{ credentialId: string }>,
+}));
+
+const mocks = vi.hoisted(() => ({
+  dbSelect: vi.fn(),
+  decryptCredential: vi.fn((value: string) => `decrypted:${value}`),
+  resolveUserCredentials: vi.fn(),
+}));
+
+vi.mock("../db/client.js", () => {
+  mocks.dbSelect.mockImplementation((selection: Record<string, unknown>) => {
+    const keys = Object.keys(selection ?? {});
+    return {
+      from: vi.fn(() => {
+        if (keys.length === 1 && keys[0] === "credentialId") {
+          return { where: vi.fn(async () => mockState.grantRows) };
+        }
+        return Promise.resolve(mockState.credentialRows);
+      }),
+    };
+  });
+
+  return {
+    db: {
+      select: mocks.dbSelect,
+    },
+  };
+});
+
+vi.mock("./credentials.js", () => ({
+  decryptCredential: mocks.decryptCredential,
+}));
+
+vi.mock("./permissions.js", () => ({
+  resolveUserCredentials: mocks.resolveUserCredentials,
+}));
+
+vi.mock("./settings.js", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { getSandboxEnvNames } from "./sandbox.js";
+
+describe("getSandboxEnvNames", () => {
+  beforeEach(() => {
+    mockState.credentialRows = [];
+    mockState.grantRows = [];
+    mocks.dbSelect.mockClear();
+    mocks.decryptCredential.mockClear();
+    mocks.resolveUserCredentials.mockReset();
+    mocks.resolveUserCredentials.mockResolvedValue(new Set<string>());
+  });
+
+  it("applies the owner-scoped gate for owned, granted, and ungranted credentials", async () => {
+    mockState.credentialRows = [
+      {
+        id: "owned",
+        name: "github_token",
+        value: "owned-secret-value",
+        ownerId: "U_CALLER",
+        scope: "owner",
+        sandboxEnvName: "GITHUB_TOKEN",
+      },
+      {
+        id: "granted",
+        name: "notion_api_key",
+        value: "granted-secret-value",
+        ownerId: "U_OTHER",
+        scope: "owner",
+        sandboxEnvName: "NOTION_API_KEY",
+      },
+      {
+        id: "blocked",
+        name: "linear_api_key",
+        value: "blocked-secret-value",
+        ownerId: "U_OTHER",
+        scope: "owner",
+        sandboxEnvName: "LINEAR_API_KEY",
+      },
+    ];
+    mockState.grantRows = [{ credentialId: "granted" }];
+    mocks.resolveUserCredentials.mockResolvedValue(
+      new Set(["github_token", "notion_api_key", "linear_api_key"]),
+    );
+
+    await expect(getSandboxEnvNames("U_CALLER")).resolves.toEqual([
+      "GITHUB_TOKEN",
+      "NOTION_API_KEY",
+    ]);
+  });
+
+  it("honors Gate 1 for per_user-scoped credentials with and without grants", async () => {
+    mockState.credentialRows = [
+      {
+        id: "per-user",
+        name: "notion_api_key",
+        value: "notion-secret-value",
+        ownerId: "U_OWNER",
+        scope: "per_user",
+        sandboxEnvName: "NOTION_API_KEY",
+      },
+    ];
+
+    mocks.resolveUserCredentials.mockResolvedValue(new Set<string>());
+    await expect(getSandboxEnvNames("U_CALLER")).resolves.toEqual([]);
+
+    mocks.dbSelect.mockClear();
+    mockState.grantRows = [{ credentialId: "per-user" }];
+    mocks.resolveUserCredentials.mockResolvedValue(new Set(["notion_api_key"]));
+
+    await expect(getSandboxEnvNames("U_CALLER")).resolves.toEqual([
+      "NOTION_API_KEY",
+    ]);
+  });
+
+  it("honors resolved role-tier credential access and falls back to uppercase names", async () => {
+    mockState.credentialRows = [
+      {
+        id: "member",
+        name: "member_token",
+        value: "member-secret-value",
+        ownerId: "U_OWNER",
+        scope: "member",
+        sandboxEnvName: "MEMBER_TOKEN",
+      },
+      {
+        id: "power",
+        name: "power_token",
+        value: "power-secret-value",
+        ownerId: "U_OWNER",
+        scope: "power_user",
+        sandboxEnvName: null,
+      },
+      {
+        id: "admin",
+        name: "admin_token",
+        value: "admin-secret-value",
+        ownerId: "U_OWNER",
+        scope: "admin",
+        sandboxEnvName: "ADMIN_TOKEN",
+      },
+    ];
+    mocks.resolveUserCredentials.mockResolvedValue(
+      new Set(["member_token", "power_token"]),
+    );
+
+    await expect(getSandboxEnvNames("U_CALLER")).resolves.toEqual([
+      "MEMBER_TOKEN",
+      "POWER_TOKEN",
+    ]);
+  });
+
+  it("does not select or decrypt credential values", async () => {
+    mockState.credentialRows = [
+      {
+        id: "secret",
+        name: "secret_token",
+        value: "super-secret-value",
+        ownerId: "U_CALLER",
+        scope: "owner",
+        sandboxEnvName: "SECRET_TOKEN",
+      },
+    ];
+    mocks.resolveUserCredentials.mockResolvedValue(new Set(["secret_token"]));
+
+    await expect(getSandboxEnvNames("U_CALLER")).resolves.toEqual([
+      "SECRET_TOKEN",
+    ]);
+
+    const selectedValue = mocks.dbSelect.mock.calls.some(([selection]) =>
+      Object.keys(selection ?? {}).includes("value"),
+    );
+    expect(selectedValue).toBe(false);
+    expect(mocks.decryptCredential).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -12,6 +12,18 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 /** Per-invocation cache -- reuse the same sandbox within a single request */
 let cachedSandbox: any | null = null;
 
+interface SandboxCredentialRow {
+  id: string;
+  name: string;
+  ownerId: string;
+  scope: string;
+  sandboxEnvName: string | null;
+}
+
+interface SandboxCredentialValueRow extends SandboxCredentialRow {
+  value: string;
+}
+
 /**
  * Clear the cached sandbox reference so the next call to
  * getOrCreateSandbox() creates a fresh instance. Call this when a
@@ -37,34 +49,33 @@ async function loadE2B() {
   return Sandbox;
 }
 
-/**
- * Build the env vars map for sandbox commands from the credentials DB.
- *
- * Resolves which credentials the user can access, decrypts them, and
- * returns a flat NAME → value map. Uses `sandboxEnvName` when set on the
- * credential row, otherwise falls back to uppercasing the credential name.
- *
- * Owner-aware: for `owner` scoped credentials, only the calling user's
- * row is injected. This prevents collisions when multiple users store a
- * credential with the same name (e.g. `github_token`).
- *
- * Must be passed to every `commands.run({ envs })` call — E2B does NOT
- * persist envs across pause/resume (see e2b-dev/E2B#884).
- */
-export async function getSandboxEnvs(userId?: string): Promise<Record<string, string>> {
-  const envs: Record<string, string> = {};
+function resolveSandboxEnvName(row: SandboxCredentialRow): string {
+  return row.sandboxEnvName || row.name.toUpperCase();
+}
 
+async function resolveSandboxCredentialRows(
+  userId: string | undefined,
+  includeValue: true,
+): Promise<SandboxCredentialValueRow[]>;
+async function resolveSandboxCredentialRows(
+  userId?: string,
+  includeValue?: false,
+): Promise<SandboxCredentialRow[]>;
+async function resolveSandboxCredentialRows(
+  userId?: string,
+  includeValue = false,
+): Promise<SandboxCredentialRow[]> {
   let userCredNames: Set<string> | null = null;
   if (userId) {
     try {
       const { resolveUserCredentials } = await import("./permissions.js");
       userCredNames = await resolveUserCredentials(userId);
     } catch (e: any) {
-      logger.warn("getSandboxEnvs: credential resolution failed", {
+      logger.warn("resolveSandboxCredentialRows: credential resolution failed", {
         userId,
         error: e.message,
       });
-      return envs;
+      return [];
     }
   }
 
@@ -86,17 +97,23 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
       for (const g of grants) grantedCredentialIds.add(g.credentialId);
     }
 
-    const rows = await db
-      .select({
-        id: credentials.id,
-        name: credentials.name,
-        value: credentials.value,
-        ownerId: credentials.ownerId,
-        scope: credentials.scope,
-        sandboxEnvName: credentials.sandboxEnvName,
-      })
-      .from(credentials);
+    const baseSelection = {
+      id: credentials.id,
+      name: credentials.name,
+      ownerId: credentials.ownerId,
+      scope: credentials.scope,
+      sandboxEnvName: credentials.sandboxEnvName,
+    };
+    const rows = includeValue
+      ? await db
+          .select({
+            ...baseSelection,
+            value: credentials.value,
+          })
+          .from(credentials)
+      : await db.select(baseSelection).from(credentials);
 
+    const accessibleRows: SandboxCredentialRow[] = [];
     for (const row of rows) {
       // Gate 1: user must have access to this credential name
       if (userCredNames && !userCredNames.has(row.name)) continue;
@@ -112,20 +129,46 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
         if (row.ownerId !== userId && !grantedCredentialIds.has(row.id)) continue;
       }
 
-      // Use the explicit sandboxEnvName if set, otherwise uppercase the name
-      const envName = row.sandboxEnvName || row.name.toUpperCase();
-      try {
-        envs[envName] = decryptCredential(row.value);
-      } catch (e: any) {
-        logger.warn("Failed to decrypt credential for sandbox injection", {
-          name: row.name,
-          envName,
-          error: e.message,
-        });
-      }
+      accessibleRows.push(row);
     }
+
+    return accessibleRows;
   } catch (e: any) {
     logger.warn("Failed to query credentials for sandbox injection", { error: e.message });
+    return [];
+  }
+}
+
+/**
+ * Build the env vars map for sandbox commands from the credentials DB.
+ *
+ * Resolves which credentials the user can access, decrypts them, and
+ * returns a flat NAME → value map. Uses `sandboxEnvName` when set on the
+ * credential row, otherwise falls back to uppercasing the credential name.
+ *
+ * Owner-aware: for `owner` scoped credentials, only the calling user's
+ * row is injected. This prevents collisions when multiple users store a
+ * credential with the same name (e.g. `github_token`).
+ *
+ * Must be passed to every `commands.run({ envs })` call — E2B does NOT
+ * persist envs across pause/resume (see e2b-dev/E2B#884).
+ */
+export async function getSandboxEnvs(userId?: string): Promise<Record<string, string>> {
+  const envs: Record<string, string> = {};
+  const rows = await resolveSandboxCredentialRows(userId, true);
+
+  for (const row of rows) {
+    // Use the explicit sandboxEnvName if set, otherwise uppercase the name
+    const envName = resolveSandboxEnvName(row);
+    try {
+      envs[envName] = decryptCredential(row.value);
+    } catch (e: any) {
+      logger.warn("Failed to decrypt credential for sandbox injection", {
+        name: row.name,
+        envName,
+        error: e.message,
+      });
+    }
   }
 
   if (envs.GITHUB_TOKEN && !envs.GH_TOKEN) {
@@ -133,6 +176,18 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
   }
 
   return envs;
+}
+
+/**
+ * Return the sandbox env var names available to the user.
+ *
+ * Mirrors getSandboxEnvs() access control without selecting, decrypting, or
+ * returning credential values. Used to make the LLM aware of available
+ * sandbox capabilities without exposing secrets.
+ */
+export async function getSandboxEnvNames(userId?: string): Promise<string[]> {
+  const rows = await resolveSandboxCredentialRows(userId, false);
+  return [...new Set(rows.map(resolveSandboxEnvName))].sort();
 }
 
 /**

--- a/apps/api/src/personality/system-prompt.test.ts
+++ b/apps/api/src/personality/system-prompt.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {},
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { buildDynamicContext } from "./system-prompt.js";
+
+function extractCapabilitiesBlock(prompt: string): string {
+  const match = prompt.match(/<capabilities>[\s\S]*<\/capabilities>/);
+  return match?.[0] ?? "";
+}
+
+describe("buildDynamicContext capabilities", () => {
+  it("renders sorted sandbox credential names in the expected format", () => {
+    const prompt = buildDynamicContext({
+      sandboxEnvNames: ["NOTION_API_KEY", "GITHUB_TOKEN"],
+    });
+
+    const expected = `<capabilities>
+You have these credentials/API keys available in your sandbox env (run_command, etc.). Names only — never paste or log values. Use them when relevant; don't claim you "don't have access" without checking first.
+- GITHUB_TOKEN
+- NOTION_API_KEY
+</capabilities>`;
+
+    expect(extractCapabilitiesBlock(prompt)).toBe(expected);
+    expect(prompt.indexOf("</runtime>")).toBeLessThan(
+      prompt.indexOf("<capabilities>"),
+    );
+  });
+
+  it("does not include credential values in the capabilities block", () => {
+    const secretValue = "secret_notion_value_123";
+    const prompt = buildDynamicContext({
+      usageStats: `debug value that must not be in capabilities: ${secretValue}`,
+      sandboxEnvNames: ["NOTION_API_KEY"],
+    });
+
+    const block = extractCapabilitiesBlock(prompt);
+    expect(block).toContain("- NOTION_API_KEY");
+    expect(block).not.toContain(secretValue);
+  });
+
+  it("omits the capabilities block when no credential names are available", () => {
+    expect(buildDynamicContext({ sandboxEnvNames: [] })).not.toContain(
+      "<capabilities>",
+    );
+    expect(buildDynamicContext({})).not.toContain("<capabilities>");
+  });
+});

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -388,6 +388,16 @@ function formatConversations(conversations: ConversationThread[]): string {
   return `<related_threads>\n${threads}\n</related_threads>`;
 }
 
+function formatCapabilities(envNames: string[]): string {
+  const names = [...new Set(envNames)].sort();
+  if (names.length === 0) return "";
+
+  return `<capabilities>
+You have these credentials/API keys available in your sandbox env (run_command, etc.). Names only — never paste or log values. Use them when relevant; don't claim you "don't have access" without checking first.
+${names.map((name) => `- ${name}`).join("\n")}
+</capabilities>`;
+}
+
 export interface SystemPromptLayers {
   /** Stable across ALL requests: personality + self-directive + auto-generated notes index */
   stablePrefix: string;
@@ -569,6 +579,7 @@ export function buildDynamicContext(context: {
   channelId?: string;
   threadTs?: string;
   usageStats?: string;
+  sandboxEnvNames?: string[];
 }): string {
   let s = `<runtime>\n## Current context\n\n${getCurrentTimeContext(context.userTimezone)}`;
   if (context.modelId) s += `\nActive model: \`${context.modelId}\``;
@@ -576,5 +587,7 @@ export function buildDynamicContext(context: {
   if (context.threadTs) s += `\nCurrent thread_ts: ${context.threadTs}`;
   if (context.usageStats) s += `\n\n${context.usageStats}`;
   s += "\n</runtime>";
+  const capabilities = formatCapabilities(context.sandboxEnvNames ?? []);
+  if (capabilities) s += `\n\n${capabilities}`;
   return s;
 }

--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -12,6 +12,7 @@ import {
 import { embedText } from "../lib/embeddings.js";
 import { getProfile } from "../users/profiles.js";
 import { getMainModelId } from "../lib/ai.js";
+import { getSandboxEnvNames } from "../lib/sandbox.js";
 import type { Memory, UserProfile } from "@aura/db/schema";
 import { users, entities } from "@aura/db/schema";
 import { db } from "../db/client.js";
@@ -271,7 +272,7 @@ export async function buildCorePrompt(
     .filter((id) => id !== session.userId)
     .slice(0, 10);
 
-  const [memories, conversations, userProfile, mentionedPeople, interlocutor, usageStats, interlocutorEntity] =
+  const [memories, conversations, userProfile, mentionedPeople, interlocutor, usageStats, interlocutorEntity, sandboxEnvNames] =
     await Promise.all([
       queryEmbedding
         ? retrieveMemories({
@@ -298,6 +299,7 @@ export async function buildCorePrompt(
       lookupPerson(session.userId),
       getUsageStats(),
       fetchInterlocutorEntity(session.userId),
+      getSandboxEnvNames(session.userId),
     ]);
 
   // Build entity summaries (related-entities lookup depends on retrieved memories)
@@ -332,6 +334,7 @@ export async function buildCorePrompt(
     channelId: session.conversationId,
     threadTs: session.threadId,
     usageStats,
+    sandboxEnvNames,
   });
 
   if (session.channel === "dashboard") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `getSandboxEnvNames(userId)` to expose accessible sandbox env var names without selecting/decrypting values.
- Injects a dynamic `<capabilities>` prompt block listing sorted credential env names when available.
- Adds tests for sandbox env-name access gates and capabilities prompt rendering.
- Merges latest `main` credential-scope changes, preserving `per_user` row gating and caller-owned env collision precedence.

References #951

## Notes
- Self-edit: updates Aura's own system prompt context so she is aware of credentials available to sandbox tools.
- Conflict review: `apps/api/src/lib/sandbox.ts` and `apps/api/src/lib/sandbox.test.ts` were simple overlapping edits, not conflicting intent. No complicated conflicts remain.

## Testing
- `DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm --filter aura-api test`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm --filter aura-api test -- sandbox.test.ts credential-scope-migration.test.ts permissions.test.ts system-prompt.test.ts`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npx tsc --noEmit` (from `apps/api`)
- `DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e760c8e-b8b9-4e92-8237-dc9b3410ceda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e760c8e-b8b9-4e92-8237-dc9b3410ceda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

