### PR TITLE
Fix credential scope isolation

### DIFF
--- a/apps/api/src/lib/credential-scope-migration.test.ts
+++ b/apps/api/src/lib/credential-scope-migration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const migrationSql = readFileSync(
+  new URL("../../../../packages/db/drizzle/0064_enforce_credential_scope_check.sql", import.meta.url),
+  "utf8",
+);
+
+describe("credential scope migration", () => {
+  it("reinstalls the scope check constraint idempotently", () => {
+    expect(migrationSql).toContain('DROP CONSTRAINT IF EXISTS "credentials_scope_check"');
+    expect(migrationSql).toContain('ADD CONSTRAINT "credentials_scope_check"');
+  });
+
+  it("allows only known credential scopes", () => {
+    expect(migrationSql).toContain(
+      "\"scope\" IN ('member', 'power_user', 'admin', 'owner', 'per_user')",
+    );
+    expect(migrationSql).not.toContain("typo_scope");
+  });
+});

--- a/apps/api/src/lib/permissions.test.ts
+++ b/apps/api/src/lib/permissions.test.ts
@@ -1,11 +1,55 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { isAdmin } from "./permissions.js";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { logger } from "./logger.js";
+
+const dbMock = vi.hoisted(() => {
+  const state = {
+    results: [] as unknown[][],
+    select: vi.fn(),
+  };
+
+  function createQuery() {
+    const query: any = {
+      from: vi.fn(() => query),
+      innerJoin: vi.fn(() => query),
+      where: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(state.results.shift() ?? []).then(onFulfilled, onRejected),
+    };
+    return query;
+  }
+
+  state.select.mockImplementation(() => createQuery());
+
+  return state;
+});
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: dbMock.select,
+  },
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function queueDbResults(...results: unknown[][]) {
+  dbMock.results = [...results];
+}
 
 describe("isAdmin", () => {
   const originalEnv = process.env.AURA_ADMIN_USER_IDS;
 
   beforeEach(() => {
     delete process.env.AURA_ADMIN_USER_IDS;
+    queueDbResults();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -16,22 +60,135 @@ describe("isAdmin", () => {
     }
   });
 
-  it("returns false when env var is unset", () => {
+  it("returns false when env var is unset", async () => {
+    const { isAdmin } = await import("./permissions.js");
     expect(isAdmin("U123")).toBe(false);
   });
 
-  it("returns true for a matching admin ID", () => {
+  it("returns true for a matching admin ID", async () => {
+    const { isAdmin } = await import("./permissions.js");
     process.env.AURA_ADMIN_USER_IDS = "U123,U456";
     expect(isAdmin("U123")).toBe(true);
   });
 
-  it("returns false for a non-matching ID", () => {
+  it("returns false for a non-matching ID", async () => {
+    const { isAdmin } = await import("./permissions.js");
     process.env.AURA_ADMIN_USER_IDS = "U123,U456";
     expect(isAdmin("U999")).toBe(false);
   });
 
-  it("returns false for undefined userId", () => {
+  it("returns false for undefined userId", async () => {
+    const { isAdmin } = await import("./permissions.js");
     process.env.AURA_ADMIN_USER_IDS = "U123";
     expect(isAdmin(undefined)).toBe(false);
+  });
+});
+
+describe("resolveUserCredentials", () => {
+  const originalEnv = process.env.AURA_ADMIN_USER_IDS;
+
+  beforeEach(() => {
+    delete process.env.AURA_ADMIN_USER_IDS;
+    queueDbResults();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.AURA_ADMIN_USER_IDS = originalEnv;
+    } else {
+      delete process.env.AURA_ADMIN_USER_IDS;
+    }
+  });
+
+  it("does not grant per_user credentials without ownership or an active grant, even for admins", async () => {
+    process.env.AURA_ADMIN_USER_IDS = "U_ADMIN";
+    queueDbResults(
+      [],
+      [
+        {
+          id: "cred-1",
+          name: "github_token",
+          scope: "per_user",
+          ownerId: "U_OWNER",
+        },
+      ],
+      [],
+    );
+
+    const { resolveUserCredentials } = await import("./permissions.js");
+    const result = await resolveUserCredentials("U_ADMIN");
+
+    expect(result.has("github_token")).toBe(false);
+  });
+
+  it("grants per_user credentials with an active grant", async () => {
+    queueDbResults(
+      [],
+      [{ credentialId: "cred-1", credentialName: "github_token" }],
+      [
+        {
+          id: "cred-1",
+          name: "github_token",
+          scope: "per_user",
+          ownerId: "U_OWNER",
+        },
+      ],
+      [],
+    );
+
+    const { resolveUserCredentials } = await import("./permissions.js");
+    const result = await resolveUserCredentials("U_GRANTEE");
+
+    expect(result.has("github_token")).toBe(true);
+  });
+
+  it("grants per_user credentials owned by the caller", async () => {
+    queueDbResults(
+      [],
+      [],
+      [
+        {
+          id: "cred-1",
+          name: "github_token",
+          scope: "per_user",
+          ownerId: "U_OWNER",
+        },
+      ],
+      [],
+    );
+
+    const { resolveUserCredentials } = await import("./permissions.js");
+    const result = await resolveUserCredentials("U_OWNER");
+
+    expect(result.has("github_token")).toBe(true);
+  });
+
+  it("fails closed and logs for unknown credential scopes", async () => {
+    queueDbResults(
+      [],
+      [],
+      [
+        {
+          id: "cred-1",
+          name: "github_token",
+          scope: "typo_scope",
+          ownerId: "U_OWNER",
+        },
+      ],
+      [],
+    );
+
+    const { resolveUserCredentials } = await import("./permissions.js");
+    const result = await resolveUserCredentials("U_OWNER");
+
+    expect(result.has("github_token")).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "resolveUserCredentials: unknown credential scope",
+      expect.objectContaining({
+        credentialName: "github_token",
+        scope: "typo_scope",
+      }),
+    );
   });
 });

--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -117,6 +117,7 @@ async function getUserRole(userId: string): Promise<Role> {
  * - 'power_user' -> power_user, admin
  * - 'admin' -> admin only
  * - 'owner' -> only the credential owner (owner_id must match)
+ * - 'per_user' -> only the credential owner or an explicit active grant
  *
  * Plus explicit grants and synthetic env-var-based credentials.
  */
@@ -132,27 +133,8 @@ export async function resolveUserCredentials(
   const userLevel = ROLE_HIERARCHY[userRole] ?? 0;
 
   try {
-    const allCreds = await db
-      .select({ name: credentials.name, scope: credentials.scope, ownerId: credentials.ownerId })
-      .from(credentials);
-
-    for (const cred of allCreds) {
-      const scope = (cred.scope || "member") as Role | "owner";
-      if (scope === "owner") {
-        if (cred.ownerId === effectiveUserId) {
-          result.add(cred.name);
-        }
-      } else {
-        const requiredLevel = ROLE_HIERARCHY[scope as Role] ?? 0;
-        if (userLevel >= requiredLevel) {
-          result.add(cred.name);
-        }
-      }
-    }
-
-    // Explicit grants always work regardless of scope
     const grants = await db
-      .select({ credentialName: credentials.name })
+      .select({ credentialId: credentialGrants.credentialId, credentialName: credentials.name })
       .from(credentialGrants)
       .innerJoin(credentials, eq(credentialGrants.credentialId, credentials.id))
       .where(
@@ -162,6 +144,44 @@ export async function resolveUserCredentials(
         ),
       );
 
+    const grantedCredentialIds = new Set(grants.map((grant) => grant.credentialId));
+
+    const allCreds = await db
+      .select({
+        id: credentials.id,
+        name: credentials.name,
+        scope: credentials.scope,
+        ownerId: credentials.ownerId,
+      })
+      .from(credentials);
+
+    for (const cred of allCreds) {
+      const scope = cred.scope || "member";
+      if (scope === "owner") {
+        if (cred.ownerId === effectiveUserId) {
+          result.add(cred.name);
+        }
+      } else if (scope === "per_user") {
+        if (cred.ownerId === effectiveUserId || grantedCredentialIds.has(cred.id)) {
+          result.add(cred.name);
+        }
+      } else {
+        const requiredLevel = ROLE_HIERARCHY[scope as Role];
+        if (requiredLevel === undefined) {
+          logger.warn("resolveUserCredentials: unknown credential scope", {
+            userId: effectiveUserId,
+            credentialName: cred.name,
+            scope,
+          });
+          continue;
+        }
+        if (userLevel >= requiredLevel) {
+          result.add(cred.name);
+        }
+      }
+    }
+
+    // Explicit grants always work regardless of scope
     for (const grant of grants) {
       result.add(grant.credentialName);
     }

--- a/apps/api/src/lib/sandbox.test.ts
+++ b/apps/api/src/lib/sandbox.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => {
+  const state = {
+    results: [] as unknown[][],
+    select: vi.fn(),
+  };
+
+  function createQuery() {
+    const query: any = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(state.results.shift() ?? []).then(onFulfilled, onRejected),
+    };
+    return query;
+  }
+
+  state.select.mockImplementation(() => createQuery());
+
+  return state;
+});
+
+const resolveUserCredentialsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: dbMock.select,
+  },
+}));
+
+vi.mock("./credentials.js", () => ({
+  decryptCredential: vi.fn((value: string) => value),
+}));
+
+vi.mock("./permissions.js", () => ({
+  resolveUserCredentials: resolveUserCredentialsMock,
+}));
+
+vi.mock("./settings.js", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function queueDbResults(...results: unknown[][]) {
+  dbMock.results = [...results];
+}
+
+const callerCredential = {
+  id: "cred-caller",
+  name: "github_token",
+  value: "caller-token",
+  ownerId: "U_CALLER",
+  scope: "owner",
+  sandboxEnvName: null,
+};
+
+const otherCredential = {
+  id: "cred-other",
+  name: "github_token",
+  value: "other-token",
+  ownerId: "U_OTHER",
+  scope: "member",
+  sandboxEnvName: null,
+};
+
+describe("getSandboxEnvs", () => {
+  beforeEach(() => {
+    queueDbResults();
+    vi.clearAllMocks();
+    resolveUserCredentialsMock.mockResolvedValue(new Set(["github_token"]));
+  });
+
+  it.each([
+    [[callerCredential, otherCredential], "caller row first"],
+    [[otherCredential, callerCredential], "caller row last"],
+  ])("prefers caller-owned credentials on env name collisions (%s)", async (rows) => {
+    queueDbResults([], rows);
+
+    const { getSandboxEnvs } = await import("./sandbox.js");
+    const envs = await getSandboxEnvs("U_CALLER");
+
+    expect(envs.GITHUB_TOKEN).toBe("caller-token");
+    expect(envs.GH_TOKEN).toBe("caller-token");
+  });
+
+  it("does not inject another user's per_user credential with the same name", async () => {
+    queueDbResults(
+      [],
+      [
+        callerCredential,
+        {
+          ...otherCredential,
+          id: "cred-per-user",
+          value: "other-per-user-token",
+          scope: "per_user",
+        },
+      ],
+    );
+
+    const { getSandboxEnvs } = await import("./sandbox.js");
+    const envs = await getSandboxEnvs("U_CALLER");
+
+    expect(envs.GITHUB_TOKEN).toBe("caller-token");
+  });
+});

--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -53,6 +53,7 @@ async function loadE2B() {
  */
 export async function getSandboxEnvs(userId?: string): Promise<Record<string, string>> {
   const envs: Record<string, string> = {};
+  const envOwnedByCaller = new Set<string>();
 
   let userCredNames: Set<string> | null = null;
   if (userId) {
@@ -101,21 +102,45 @@ export async function getSandboxEnvs(userId?: string): Promise<Record<string, st
       // Gate 1: user must have access to this credential name
       if (userCredNames && !userCredNames.has(row.name)) continue;
 
-      // Gate 2: for owner-scoped credentials, only inject the calling user's
+      // Gate 2: for row-scoped credentials, only inject the calling user's
       // own row OR rows they've been explicitly granted access to.
       // Without this, two users with the same credential name (e.g.
       // `github_token`) would collide and the last row wins silently.
-      // When userId is omitted, skip ALL owner-scoped credentials to prevent
+      // When userId is omitted, skip ALL row-scoped credentials to prevent
       // leaking every user's secrets into an anonymous sandbox.
-      if (row.scope === "owner") {
+      const scope = row.scope || "member";
+      if (scope === "owner") {
         if (!userId) continue;
         if (row.ownerId !== userId && !grantedCredentialIds.has(row.id)) continue;
+      } else if (scope === "per_user") {
+        if (!userId) continue;
+        if (row.ownerId !== userId && !grantedCredentialIds.has(row.id)) continue;
+      } else if (
+        scope !== "member" &&
+        scope !== "power_user" &&
+        scope !== "admin"
+      ) {
+        logger.warn("getSandboxEnvs: unknown credential scope", {
+          userId,
+          credentialName: row.name,
+          scope,
+        });
+        continue;
       }
 
       // Use the explicit sandboxEnvName if set, otherwise uppercase the name
       const envName = row.sandboxEnvName || row.name.toUpperCase();
+      const ownedByCaller = !!userId && row.ownerId === userId;
+      // Caller-owned credentials always win name/env-name collisions, even if
+      // another accessible row with the same env var is processed later.
+      if (envs[envName] !== undefined && envOwnedByCaller.has(envName) && !ownedByCaller) {
+        continue;
+      }
       try {
         envs[envName] = decryptCredential(row.value);
+        if (ownedByCaller) {
+          envOwnedByCaller.add(envName);
+        }
       } catch (e: any) {
         logger.warn("Failed to decrypt credential for sandbox injection", {
           name: row.name,

--- a/packages/db/drizzle/0064_enforce_credential_scope_check.sql
+++ b/packages/db/drizzle/0064_enforce_credential_scope_check.sql
@@ -1,0 +1,5 @@
+DO $$
+BEGIN
+  ALTER TABLE "credentials" DROP CONSTRAINT IF EXISTS "credentials_scope_check";
+  ALTER TABLE "credentials" ADD CONSTRAINT "credentials_scope_check" CHECK ("scope" IN ('member', 'power_user', 'admin', 'owner', 'per_user'));
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1775923200000,
       "tag": "0063_anthropic_model_id_alignment",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1779222720000,
+      "tag": "0064_enforce_credential_scope_check",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix `per_user` credential resolution to require ownership or an active credential grant.
- Fail closed and warn on unknown credential scopes.
- Ensure sandbox env name collisions prefer the caller-owned credential row.
- Add an idempotent migration to enforce the allowed credential scope check constraint.

Fixes #952.

## Testing
- `pnpm --filter aura-api test -- src/lib/permissions.test.ts src/lib/sandbox.test.ts src/lib/credential-scope-migration.test.ts`
- `pnpm typecheck`
- `npx tsc --noEmit` (from `apps/api`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-197a5acd-e3e1-4c62-8f84-4d5c8817c8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197a5acd-e3e1-4c62-8f84-4d5c8817c8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

