### PR TITLE
docs(credentials): document per_user scope and fail-closed behavior

### DIFF
--- a/content/docs/tools/credentials.mdx
+++ b/content/docs/tools/credentials.mdx
@@ -53,9 +53,12 @@ Defines the minimum role required to use this credential. This is a floor, not a
 | Scope | Who can access |
 |-------|---------------|
 | `owner` | Only the credential owner (and explicit grantees) |
+| `per_user` | Only the credential owner or users with an active explicit grant |
 | `admin` | Any user with the `admin` role |
 | `power_user` | Any user with `power_user` or above |
 | `member` | Any authenticated user |
+
+Unknown scope values are rejected (fail-closed): the credential is skipped and a warning is logged.
 
 ### 3. Grants
 
@@ -66,9 +69,10 @@ Explicit per-user access grants. Each grant specifies a `grantee_id` (Slack user
 When Aura needs a credential for a specific user, the `getSandboxEnvs` and `resolveUserCredentials` functions apply this logic:
 
 1. If `scope === "owner"` — only inject if the calling user is the credential's `owner_id`
-2. If the user has an explicit grant — inject regardless of scope
-3. If the user's role meets the `minRole` (scope) threshold — inject
-4. Otherwise — skip
+2. If `scope === "per_user"` — only inject if the calling user is the owner or has an active (non-revoked) grant
+3. If the user has an explicit grant — inject regardless of scope
+4. If the user's role meets the `minRole` (scope) threshold — inject
+5. Otherwise — skip (unknown scopes also fall through here and log a warning)
 
 When multiple credentials share the same name (e.g. three different `github_token` entries from different owners), only the one belonging to the calling user is injected. No more "last row wins" collisions.
 


### PR DESCRIPTION
## Summary

PR #954 added a `per_user` credential scope and fail-closed handling of unknown scopes in `apps/api/src/lib/permissions.ts`, but `content/docs/tools/credentials.mdx` still listed only `owner`/`admin`/`power_user`/`member`. The docs were factually incomplete.

## Changes

- Add `per_user` row to the scope access-control table
- Note that unknown scopes are now rejected with a warning (fail-closed)
- Update the resolution-logic numbered list to include the `per_user` branch

## Verification

- Behavior matches `resolveUserCredentials` in `apps/api/src/lib/permissions.ts` (lines 158-180 on main)
- No code changes, docs-only

Found via daily docs-maintenance audit.