### PR TITLE
fix(sandbox): per-user lifecycle with autoPause (#569)

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -5,12 +5,16 @@ import { db } from "../db/client.js";
 import { credentials, credentialGrants } from "@aura/db/schema";
 import { logger } from "./logger.js";
 
-const SANDBOX_NOTE_KEY = "e2b_sandbox_id";
-const SANDBOX_TEMPLATE_KEY = "e2b_sandbox_template_id";
-const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const sandboxNoteKey = (userId?: string) =>
+  userId ? `e2b_sandbox_id:${userId}` : "e2b_sandbox_id";
+const sandboxTemplateKey = (userId?: string) =>
+  userId ? `e2b_sandbox_template_id:${userId}` : "e2b_sandbox_template_id";
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour -- autoPause handles inactivity
 
-/** Per-invocation cache -- reuse the same sandbox within a single request */
+/** Per-invocation cache -- reuse the same sandbox within a single request.
+ *  Keyed by userId so concurrent invocations for different users don't share state. */
 let cachedSandbox: any | null = null;
+let cachedSandboxUserId: string | undefined;
 
 interface SandboxCredentialRow {
   id: string;
@@ -35,6 +39,7 @@ export function clearCachedSandbox(): void {
       sandboxId: cachedSandbox.sandboxId,
     });
     cachedSandbox = null;
+    cachedSandboxUserId = undefined;
   }
   userHomeReady.clear();
 }
@@ -336,17 +341,26 @@ export async function ensureUserHome(
  * Get or create a sandbox. Tries to resume a previously paused sandbox,
  * creates a new one if none exists or resume fails.
  */
-export async function getOrCreateSandbox(): Promise<any> {
-  // Return cached instance within the same invocation
-  if (cachedSandbox) {
+export async function getOrCreateSandbox(userId?: string): Promise<any> {
+  // Return cached instance within the same invocation IF it's for the same user.
+  // Per-invocation caches must not be shared across users -- a warm Vercel instance
+  // serving two different users back-to-back must hit fresh per-user sandboxes.
+  if (cachedSandbox && cachedSandboxUserId === userId) {
     try {
       // Reset timeout to keep it alive
       await cachedSandbox.setTimeout(DEFAULT_TIMEOUT_MS);
       return cachedSandbox;
     } catch {
       cachedSandbox = null;
+      cachedSandboxUserId = undefined;
       userHomeReady.clear();
     }
+  } else if (cachedSandbox && cachedSandboxUserId !== userId) {
+    // Different user this invocation -- drop the cache reference (don't kill the sandbox,
+    // it stays running/paused under its own ID for that other user).
+    cachedSandbox = null;
+    cachedSandboxUserId = undefined;
+    userHomeReady.clear();
   }
 
   const Sandbox = await loadE2B();
@@ -359,9 +373,11 @@ export async function getOrCreateSandbox(): Promise<any> {
     );
   }
 
-  // Try to resume a previously paused sandbox
-  let savedId = await getSetting(SANDBOX_NOTE_KEY);
-  const savedTemplateId = await getSetting(SANDBOX_TEMPLATE_KEY);
+  // Try to resume a previously paused sandbox (per-user key).
+  const noteKey = sandboxNoteKey(userId);
+  const templateKey = sandboxTemplateKey(userId);
+  let savedId = await getSetting(noteKey);
+  const savedTemplateId = await getSetting(templateKey);
   const currentTemplateId = envs.E2B_TEMPLATE_ID || process.env.E2B_TEMPLATE_ID || undefined;
 
   // If the template was upgraded, kill the old sandbox so we create a fresh one
@@ -396,7 +412,8 @@ export async function getOrCreateSandbox(): Promise<any> {
       }
 
       cachedSandbox = sandbox;
-      logger.info("E2B sandbox resumed", { sandboxId: savedId });
+      cachedSandboxUserId = userId;
+      logger.info("E2B sandbox resumed", { sandboxId: savedId, userId });
     } catch (error: any) {
       logger.warn("Failed to resume sandbox, creating new one", {
         savedId,
@@ -414,17 +431,22 @@ export async function getOrCreateSandbox(): Promise<any> {
   const templateId = envs.E2B_TEMPLATE_ID || process.env.E2B_TEMPLATE_ID || undefined;
   logger.info("Creating new E2B sandbox", { templateId: templateId || "default" });
 
-  const createOptions: any = { apiKey, timeoutMs: DEFAULT_TIMEOUT_MS };
+  // autoPause: E2B pauses the sandbox after DEFAULT_TIMEOUT_MS of inactivity
+  // and Sandbox.connect() will auto-resume it on the next call. This removes
+  // our need to manually pauseSandbox() (which triggered E2B bug #884 -- file
+  // state loss after 2+ pause/resume cycles on the legacy betaPause path).
+  const createOptions: any = { apiKey, timeoutMs: DEFAULT_TIMEOUT_MS, autoPause: true };
   const sandbox = templateId
     ? await Sandbox.create(templateId, createOptions)
     : await Sandbox.create(createOptions);
 
-  // Save the sandbox ID for future resumption
-  await setSetting(SANDBOX_NOTE_KEY, sandbox.sandboxId, "aura");
-  await setSetting(SANDBOX_TEMPLATE_KEY, templateId || "", "aura");
+  // Save the sandbox ID for future resumption (per-user keys)
+  await setSetting(noteKey, sandbox.sandboxId, "aura");
+  await setSetting(templateKey, templateId || "", "aura");
 
   cachedSandbox = sandbox;
-  logger.info("E2B sandbox created", { sandboxId: sandbox.sandboxId });
+  cachedSandboxUserId = userId;
+  logger.info("E2B sandbox created", { sandboxId: sandbox.sandboxId, userId });
 
   // Ensure the downloads directory exists for file-to-disk tools
   try {
@@ -468,27 +490,6 @@ export async function getOrCreateSandbox(): Promise<any> {
   return sandbox;
 }
 
-/**
- * Pause the sandbox to save credits. The sandbox state (filesystem, memory)
- * is preserved and can be resumed later.
- */
-export async function pauseSandbox(): Promise<void> {
-  if (!cachedSandbox) return;
-
-  try {
-    const sandboxId = cachedSandbox.sandboxId;
-    await cachedSandbox.betaPause();
-    // Save the sandbox ID so we can resume it later
-    await setSetting(SANDBOX_NOTE_KEY, sandboxId, "aura");
-    logger.info("E2B sandbox paused", { sandboxId });
-  } catch (error: any) {
-    logger.warn("Failed to pause sandbox", { error: error.message });
-    throw error;
-  } finally {
-    cachedSandbox = null;
-    userHomeReady.clear();
-  }
-}
 
 /**
  * Write binary data (as a Buffer) to the sandbox filesystem.
@@ -501,7 +502,7 @@ export async function writeToSandbox(
   subdir: string = "downloads",
   userId?: string,
 ): Promise<string> {
-  const sandbox = await getOrCreateSandbox();
+  const sandbox = await getOrCreateSandbox(userId);
 
   let base = "/home/user";
   if (userId) {

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -29,7 +29,6 @@ import {
   updateProfileFromConversation,
 } from "../users/profiles.js";
 import { downloadEventFiles } from "../lib/files.js";
-import { pauseSandbox } from "../lib/sandbox.js";
 import { getSettingJSON } from "../lib/settings.js";
 import { logger } from "../lib/logger.js";
 import { logError } from "../lib/error-logger.js";
@@ -374,7 +373,6 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       logger.info("Pipeline interrupted — invocation superseded", {
         channelId: context.channelId,
       });
-      await pauseSandbox().catch(() => {});
       await scheduleStoreUserMessage(context, event, waitUntil);
       await persistInterruptedResponse({
         context,
@@ -386,22 +384,9 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       return;
     }
 
-    // Pause sandbox once after all tool calls are complete for this turn.
-    // This avoids the e2b multi-resume bug (e2b-dev/E2B#884) that causes
-    // filesystem state loss when pause/resume is called between every tool.
-    await pauseSandbox().catch((err: any) => {
-      logger.warn("Failed to pause sandbox after response", {
-        error: err.message,
-      });
-      logError({
-        errorName: "SandboxPauseError",
-        errorMessage: err?.message || String(err),
-        errorCode: "sandbox_pause_failed",
-        userId: context.userId,
-        channelId: context.channelId,
-        channelType: context.channelType,
-      });
-    });
+    // Sandbox lifecycle is now managed by E2B autoPause: the sandbox pauses
+    // itself after DEFAULT_TIMEOUT_MS of inactivity and auto-resumes on the next
+    // Sandbox.connect(). No manual pause needed here.
 
     // Response is already posted to Slack via streaming updates
 
@@ -461,9 +446,8 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       await backgroundTasks;
     }
   } catch (error: any) {
-    // Ensure sandbox is paused even on pipeline errors
-    await pauseSandbox().catch(() => {});
-
+    // No manual sandbox pause -- autoPause handles inactivity, and a sandbox
+    // that just errored is more useful kept warm for the user's retry.
     if (error instanceof InvocationSupersededError) {
       logger.info("Pipeline interrupted — invocation superseded", {
         invocationId: error.invocationId,

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -3,7 +3,6 @@ import {
   getOrCreateSandbox,
   getSandboxEnvs,
   truncateOutput,
-  clearCachedSandbox,
   ensureUserHome,
 } from "../lib/sandbox.js";
 import { logger } from "../lib/logger.js";
@@ -44,9 +43,9 @@ export function createSandboxTools(context?: ScheduleContext) {
           ),
       }),
       execute: async ({ command, workdir, timeout_seconds }) => {
+        const userId = context?.userId || "aura";
         try {
-          const sandbox = await getOrCreateSandbox();
-          const userId = context?.userId || "aura";
+          const sandbox = await getOrCreateSandbox(userId);
           const envs = await getSandboxEnvs(userId);
           const userHome = await ensureUserHome(sandbox, userId, envs);
 
@@ -104,7 +103,9 @@ export function createSandboxTools(context?: ScheduleContext) {
           });
 
           if (error.message?.includes("timed out")) {
-            clearCachedSandbox();
+            // Don't clear the cache on timeout -- a slow sandbox is not a dead
+            // sandbox. autoPause will reclaim it after inactivity, and the next
+            // invocation will Sandbox.connect() to resume it.
             return {
               ok: false,
               error: `Command timed out after ${timeout_seconds} seconds. Try increasing timeout_seconds or breaking the command into smaller steps.`,

--- a/apps/api/src/tools/slack.ts
+++ b/apps/api/src/tools/slack.ts
@@ -2400,7 +2400,7 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
               };
             }
             const { getOrCreateSandbox } = await import("../lib/sandbox.js");
-            const sandbox = await getOrCreateSandbox();
+            const sandbox = await getOrCreateSandbox(context?.userId);
             const fileBytes = await sandbox.files.read(file_path, { format: "bytes" });
             fileBuffer = Buffer.from(fileBytes);
           } else {


### PR DESCRIPTION
Closes #569.

## Why

The legacy lifecycle (single shared sandbox, manual `pauseSandbox()` after every command, 5-minute timeout) caused two of Aura's most frequent failure modes:

1. **Cross-user state corruption** -- two users hitting Aura concurrently share the same sandbox; one's repo checkout / DB state overwrites the other's.
2. **File persistence loss** -- our aggressive pause/resume pattern triggers [e2b-dev/E2B#884](https://github.com/e2b-dev/E2B/issues/884), where filesystem state breaks after 2+ pause/resume cycles. Manifests as missing files, broken Claude Code installs, repo working trees getting wiped.

## What

### Lifecycle
- \`Sandbox.create({ autoPause: true, timeoutMs: 1h })\` -- E2B handles pause/resume itself. \`Sandbox.connect()\` auto-resumes a paused sandbox transparently.
- \`DEFAULT_TIMEOUT_MS\`: 5 min → **1 hour**. Inactivity reclaim is now E2B's job.
- Dropped \`pauseSandbox()\` entirely and its three callers in \`pipeline/index.ts\` (post-response, interrupted, error). Manual pause is gone.
- Dropped \`clearCachedSandbox()\` on command timeout. A slow sandbox is not a dead sandbox; the cache is only cleared when \`Sandbox.connect()\` actually fails.

### Per-user sandboxes
- Settings key changed from \`e2b_sandbox_id\` to \`e2b_sandbox_id:{userId}\`. One long-lived sandbox per Slack user.
- Per-invocation \`cachedSandboxUserId\` so warm Vercel instances serving different users back-to-back don't share a sandbox handle. If \`userId\` mismatches the cache, drop the reference (the sandbox stays alive under its own ID for the other user).
- Threaded \`userId\` through \`run_command\` and the \`upload_file\` sandbox read in \`tools/slack.ts\`.

### Storage model
No async-sync layer added. The paused E2B snapshot **is** the persistent SSD: filesystem and memory state preserved, no TTL per current E2B docs, paused sandboxes don't accrue compute charges. \`ensureUserHome\` continues to provide \`/home/{userId}\` directories within each per-user sandbox -- belt-and-braces but harmless. GCS FUSE stays mounted as a read-only cross-user shared layer; no longer on the hot path.

## How this differs from the original #569 branch

The original Cursor branch (\`cursor/fix-github-issue-569-rethink-e2b-sandbox\`, March 3) was 389 commits behind main and could not be rebased -- the repo went through a major restructure (\`src/\` → \`apps/api/src/\`) and \`sandbox.ts\` gained ~400 lines of per-user credential scoping logic in #954 and earlier PRs. I reapplied the conceptual changes manually on top of current main. Same approach, same semantics, but compatible with the current credential-injection code path.

## Validation

- \`pnpm tsc --noEmit\` clean across api + dashboard.
- \`pnpm vitest run\`: 84 passed, 0 failed (11 test files including \`sandbox.test.ts\`).
- No changes to credential injection, GCS mount, or user-home setup -- those paths were not touched.

## Risk / rollout

- E2B bug #884 risk: current pattern pauses dozens of times per user per day; new pattern pauses ~once per idle period. ~50x reduction in pause/resume cycles. If the bug still reproduces under autoPause, follow-up is a sentinel-file integrity check on resume with fallback to fresh sandbox.
- Pro tier concurrency: paused sandboxes don't count against the 100-concurrent-running cap. ~200 weekly active users × 1 sandbox each = ~200 paused at steady state, $0 storage on current pricing.