### PR TITLE
sandbox: bake mongosh + mongodb driver into template

### DIFF
--- a/sandbox/e2b.Dockerfile
+++ b/sandbox/e2b.Dockerfile
@@ -78,6 +78,21 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
 # Enable allow_other for FUSE mounts by non-root users
 RUN echo "user_allow_other" >> /etc/fuse.conf
 
+# MongoDB shell (mongosh) — for interactive Atlas debugging
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc \
+    | gpg --dearmor -o /usr/share/keyrings/mongodb-org.gpg \
+    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-org.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" \
+    | tee /etc/apt/sources.list.d/mongodb-org-7.0.list > /dev/null \
+    && apt-get update -qq && apt-get install -y mongodb-mongosh \
+    && rm -rf /var/lib/apt/lists/*
+
+# MongoDB node driver — pre-installed at /home/user so scripts can `require('mongodb')`
+# without a per-job `npm install` cold-start cost (~3-5s saved).
+RUN mkdir -p /home/user && cd /home/user \
+    && npm init -y > /dev/null \
+    && npm install --silent mongodb \
+    && chown -R user:user /home/user
+
 # Working dirs
 RUN mkdir -p /home/user/downloads /home/user/data /home/user/aura \
     && chown -R user:user /home/user


### PR DESCRIPTION
Closes part of #957.

Adds MongoDB tooling to the e2b sandbox template so jobs can use Atlas without per-run install cost:

- `mongosh` (MongoDB 7.0 apt package) — interactive shell for debugging
- `mongodb` node driver pre-installed at `/home/user/node_modules` — scripts can `require('mongodb')` directly

## Why bake vs install-on-demand
Reversed my earlier recommendation per Joan: if MongoDB is going to be the standard ephemeral storage layer, every job that touches it pays a 3–5s `npm install` tax. Baking is cleaner.

## After merge
The `sandbox-build.yml` workflow fires on `sandbox/**` changes, rebuilds the template, pushes the new `E2B_TEMPLATE_ID` to Vercel and redeploys. No manual steps.

## Followup
`MONGODB_ATLAS_URI` credential still needs to be provisioned in Vercel env vars before jobs can connect — Joan owns the Atlas setup.