### PR TITLE
docs+prompt: document MongoDB Atlas as ephemeral storage layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Built with TypeScript, Hono, Vercel serverless functions, Vercel AI SDK v6, and 
 
 **Voice** — Outbound phone calls and SMS via ElevenLabs + Twilio, text-to-speech voice notes
 
-**Sandbox** — Persistent Linux VM (E2B) with pre-baked tools: `psql`, `jq`, `rg`, `gcloud`, `claude`, `pdftotext`
+**Sandbox** — Persistent Linux VM (E2B) with pre-baked tools: `psql`, `jq`, `rg`, `gcloud`, `claude`, `pdftotext`, `mongosh`
 
 **Coding agents** — Dispatch, monitor, and follow up on Cursor Cloud Agents; also Claude and Codex agents
 
@@ -50,7 +50,9 @@ Slack event → Vercel serverless function → embed query → pgvector similari
 
 **Memory:** Every exchange triggers a fast-model LLM call that extracts structured memories (facts, decisions, relationships, open threads). Each memory is a 1536-dimensional pgvector embedding. Top ~10 most similar memories are retrieved on each response. DM-sourced memories are private by default.
 
-**Sandbox:** Persistent E2B VM attached to each user. Survives across conversations within a session. Has git, psql, gcloud, the GitHub CLI, and more. Build the custom template with `node sandbox/build-tsx.ts`.
+**Sandbox:** Persistent E2B VM attached to each user. Survives across conversations within a session. Has git, psql, gcloud, the GitHub CLI, `mongosh`, the `mongodb` node driver, and more. Build the custom template with `node sandbox/build-tsx.ts`.
+
+**Scratch storage:** When `MONGODB_ATLAS_URI` is set, Aura uses MongoDB Atlas as a schema-less scratch layer for arbitrary per-task collections (cross-session job state, dumps, staging). Postgres stays mission-critical and schema-managed; Mongo is the ad-hoc workspace. See `content/docs/tools/sandbox.mdx`.
 
 **Jobs/heartbeat:** A cron runs every 30 minutes. One-shot jobs fire at their scheduled time. Recurring jobs evaluate against their cron expression and frequency limits. Failed jobs retry 3× with 30-minute backoff.
 

--- a/apps/api/src/personality/system-prompt.test.ts
+++ b/apps/api/src/personality/system-prompt.test.ts
@@ -57,3 +57,30 @@ You have these credentials/API keys available in your sandbox env (run_command, 
     expect(buildDynamicContext({})).not.toContain("<capabilities>");
   });
 });
+
+describe("buildDynamicContext storage block", () => {
+  it("includes the MongoDB storage block when MONGODB_ATLAS_URI is in env names", () => {
+    const prompt = buildDynamicContext({
+      sandboxEnvNames: ["MONGODB_ATLAS_URI", "GITHUB_TOKEN"],
+    });
+    expect(prompt).toContain("<storage>");
+    expect(prompt).toContain("MongoDB Atlas");
+    expect(prompt).toContain("fb_comments");
+    expect(prompt).toContain("DATABASE_URL");
+  });
+
+  it("omits the storage block when MONGODB_ATLAS_URI is not present", () => {
+    const prompt = buildDynamicContext({
+      sandboxEnvNames: ["GITHUB_TOKEN", "NOTION_API_KEY"],
+    });
+    expect(prompt).not.toContain("<storage>");
+    expect(prompt).not.toContain("MongoDB Atlas");
+  });
+
+  it("omits the storage block when sandboxEnvNames is empty", () => {
+    expect(buildDynamicContext({ sandboxEnvNames: [] })).not.toContain(
+      "<storage>",
+    );
+    expect(buildDynamicContext({})).not.toContain("<storage>");
+  });
+});

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -388,6 +388,32 @@ function formatConversations(conversations: ConversationThread[]): string {
   return `<related_threads>\n${threads}\n</related_threads>`;
 }
 
+function formatStorage(envNames: string[]): string {
+  const has = (name: string) => envNames.includes(name);
+  const lines: string[] = [];
+
+  if (has("MONGODB_ATLAS_URI")) {
+    lines.push(
+      "**MongoDB Atlas** is wired up as your scratch/staging storage layer. Use it whenever a job needs to persist or retrieve arbitrary structured data across sessions -- especially when you'd otherwise reinvent storage in the sandbox.",
+      "",
+      "When to reach for it (not exhaustive):",
+      "- Cross-session task state: e.g. moderating Facebook/Meta comments daily and tracking which IDs you've already seen and what action you took (`pending`, `approved`, `hidden`, `deleted`, `reported`).",
+      "- Staging area between two systems: e.g. dumping a Notion workspace, scraping listings, enriching contacts -- anything where fetch and load happen in different jobs.",
+      "- Per-task collections that don't deserve a Postgres schema and outlive a single sandbox session.",
+      "",
+      "Rules:",
+      "- The URI is in `MONGODB_ATLAS_URI` (sandbox env). The `mongodb` node driver and `mongosh` are pre-baked into the sandbox template.",
+      "- Schemaless by design -- create collections on demand, no migrations, no DDL approvals needed. Name them `<domain>_<purpose>` (e.g. `fb_comments`, `notion_dump_2026_05_20`).",
+      "- This is NOT a replacement for Postgres. Postgres (`DATABASE_URL`) is mission-critical, schema-managed core state (memories, messages, entities, jobs, notes) -- you do not write DDL or mutate it without Joan's approval. Mongo is your scratch space; Postgres is the system's spine.",
+      "- Prefer Mongo over SQLite-in-sandbox or GCS FUSE for anything that needs to survive sandbox resets or be queried later. SQLite can vanish on e2b pause/resume; GCS FUSE is slow and not query-shaped.",
+    );
+  }
+
+  if (lines.length === 0) return "";
+
+  return `<storage>\n${lines.join("\n")}\n</storage>`;
+}
+
 function formatCapabilities(envNames: string[]): string {
   const names = [...new Set(envNames)].sort();
   if (names.length === 0) return "";
@@ -589,5 +615,7 @@ export function buildDynamicContext(context: {
   s += "\n</runtime>";
   const capabilities = formatCapabilities(context.sandboxEnvNames ?? []);
   if (capabilities) s += `\n\n${capabilities}`;
+  const storage = formatStorage(context.sandboxEnvNames ?? []);
+  if (storage) s += `\n\n${storage}`;
   return s;
 }

--- a/content/docs/tools/sandbox.mdx
+++ b/content/docs/tools/sandbox.mdx
@@ -40,6 +40,8 @@ The sandbox template includes:
 | `rg` (ripgrep) | Fast code search |
 | `curl`, `jq` | HTTP requests and JSON processing |
 | `claude` | Claude Code for agentic code tasks |
+| `mongosh` | MongoDB Atlas shell (when `MONGODB_ATLAS_URI` is set) |
+| `mongodb` (node driver) | Programmatic Mongo access -- `require('mongodb')` with zero install cost |
 | `pdftotext` | PDF text extraction |
 
 Install additional packages with `apt-get install` or `pip install`.
@@ -76,8 +78,27 @@ Each user gets a persistent home directory backed by Google Cloud Storage (GCS) 
 
 Use persistent storage for:
 - Long-running work that spans multiple conversations (large datasets, intermediate results)
-- SQLite databases for complex analysis
+- SQLite databases for complex analysis (note: SQLite files can be lost on sandbox pause/resume edge cases -- prefer MongoDB Atlas for anything that must survive)
 - Downloaded files you need to reference later
+
+### MongoDB Atlas (recommended for structured cross-session state)
+
+When `MONGODB_ATLAS_URI` is configured, Aura has a dedicated schema-less scratch database for ad-hoc per-task collections. This is the preferred storage layer for anything that needs structured CRUD across sessions -- it's faster than GCS FUSE, more durable than SQLite-in-sandbox, and doesn't require schema migrations.
+
+**Typical uses:**
+- Tracking state for daily/recurring jobs (e.g. Facebook comment moderation: which comment IDs have been classified and what action was taken).
+- Staging area between fetch and load jobs (Notion dumps, scraping, enrichment pipelines).
+- Long-lived task collections that don't deserve a Postgres schema.
+
+**Conventions:**
+- One DB (default `aura`), many collections.
+- Collection naming: `<domain>_<purpose>` (e.g. `fb_comments`, `notion_dump_2026_05_20`).
+- `mongosh` and the `mongodb` node driver are pre-installed in the sandbox template.
+- The Mongo URI is injected per-job via the credential system -- never logged or echoed.
+
+**Boundary with Postgres:**
+- Postgres (`DATABASE_URL`) is the system's mission-critical spine: memories, messages, entities, jobs, notes. Aura does not write DDL or mutate Postgres without explicit owner approval.
+- MongoDB Atlas is Aura's scratch space. Create collections freely.
 
 The mount is set up automatically when `run_command` executes. If the mount isn't available (e.g. GCS credentials not configured), Aura falls back to `/home/user/` with a warning.
 


### PR DESCRIPTION
Follows #957 (proposal) and #958 (sandbox template bake).

## What

Three coordinated edits so the new MongoDB Atlas storage layer actually shows up where it matters -- in my own context, in the docs, and in the README.

### 1. System prompt (conditional on env var)

`apps/api/src/personality/system-prompt.ts` -- new `formatStorage()` helper, invoked from `buildDynamicContext`. Renders a `<storage>` block **only when `MONGODB_ATLAS_URI` is present in `sandboxEnvNames`**. The block:

- Tells me when to reach for Mongo: cross-session job state (e.g. Facebook comment moderation tracking which IDs were classified as ``pending`` / ``approved`` / ``hidden`` / ``deleted`` / ``reported``), staging between fetch/load jobs, per-task collections that don't deserve a Postgres schema.
- Pins the boundary: Postgres is mission-critical core state (memories, messages, entities, jobs, notes); Mongo is the ad-hoc scratch space. No DDL on Postgres without owner approval.
- Names the conventions: one DB, many collections, ``<domain>_<purpose>`` naming.

Conditional injection means there's zero prompt bloat for instances where Mongo isn't configured -- and the moment the env var lands, the guidance turns on by itself.

### 2. Docs (`content/docs/tools/sandbox.mdx`)

- Adds `mongosh` and the `mongodb` node driver to the pre-installed table.
- Adds a new ``MongoDB Atlas (recommended for structured cross-session state)`` subsection under Persistent storage, covering typical uses, conventions, and the Postgres/Mongo boundary.
- Adds a caveat next to the SQLite bullet pointing users to Mongo for anything that must survive sandbox resets.

### 3. README

- Sandbox bullet now lists ``mongosh`` alongside the other pre-baked tools.
- Architecture section gets a ``Scratch storage`` paragraph that names the boundary and points at the docs.

## Tests

Three new cases in ``system-prompt.test.ts``:
- Block renders when `MONGODB_ATLAS_URI` is in env names.
- Block is omitted when it isn't.
- Block is omitted when ``sandboxEnvNames`` is empty / undefined.

All 6 system-prompt tests pass, plus the rest of the API test suite (87/87). ``pnpm typecheck`` clean.

## Why this matters

This is the failure mode I keep hitting: knowing a capability exists in the abstract isn't enough -- the routing rule needs to fire at decision time. Documenting it in the docs is necessary but not sufficient; the system prompt block makes the trigger explicit at the point of action ("you need persistent CRUD across sessions ⇒ Mongo"). The conditional gate means no false positives in instances where the URI hasn't been provisioned yet.