### PR TITLE
sandbox: auto-clone realadvisor/aura-tools on sandbox setup (fixes #960)

### DIFF
--- a/apps/api/src/lib/sandbox.test.ts
+++ b/apps/api/src/lib/sandbox.test.ts
@@ -52,7 +52,13 @@ vi.mock("./logger.js", () => ({
   },
 }));
 
-import { getSandboxEnvs, getSandboxEnvNames } from "./sandbox.js";
+import { logger } from "./logger.js";
+import {
+  clearCachedSandbox,
+  ensureAuraTools,
+  getSandboxEnvs,
+  getSandboxEnvNames,
+} from "./sandbox.js";
 
 interface CredentialRow {
   id: string;
@@ -66,6 +72,25 @@ interface CredentialRow {
 function queueDbResults(...results: unknown[][]) {
   dbMock.results = [...results];
 }
+
+type CommandResult = {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+};
+
+function createSandboxStub(sandboxId: string, results: CommandResult[]) {
+  return {
+    sandboxId,
+    commands: {
+      run: vi.fn().mockImplementation(() =>
+        Promise.resolve(results.shift() ?? { exitCode: 0, stdout: "", stderr: "" }),
+      ),
+    },
+  };
+}
+
+const auraToolsEnvs = { GITHUB_TOKEN: "github-token" };
 
 const callerCredential: CredentialRow = {
   id: "cred-caller",
@@ -255,5 +280,80 @@ describe("getSandboxEnvNames", () => {
     );
     expect(selectedValue).toBe(false);
     expect(decryptCredentialMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ensureAuraTools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCachedSandbox();
+  });
+
+  it("clones realadvisor/aura-tools when .git is absent", async () => {
+    const sandbox = createSandboxStub("sandbox-clone", [
+      { exitCode: 1, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+
+    await ensureAuraTools(sandbox, auraToolsEnvs);
+
+    expect(sandbox.commands.run).toHaveBeenNthCalledWith(
+      1,
+      "[ -d /home/user/aura-tools/.git ]",
+      { timeoutMs: 5_000, envs: auraToolsEnvs },
+    );
+    expect(sandbox.commands.run).toHaveBeenNthCalledWith(
+      2,
+      "git clone --depth=1 https://x-access-token:$GITHUB_TOKEN@github.com/realadvisor/aura-tools.git /home/user/aura-tools",
+      { timeoutMs: 60_000, envs: auraToolsEnvs },
+    );
+  });
+
+  it("pulls realadvisor/aura-tools when .git is present", async () => {
+    const sandbox = createSandboxStub("sandbox-pull", [
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+
+    await ensureAuraTools(sandbox, auraToolsEnvs);
+
+    expect(sandbox.commands.run).toHaveBeenNthCalledWith(
+      1,
+      "[ -d /home/user/aura-tools/.git ]",
+      { timeoutMs: 5_000, envs: auraToolsEnvs },
+    );
+    expect(sandbox.commands.run).toHaveBeenNthCalledWith(
+      2,
+      "git -C /home/user/aura-tools pull --quiet --ff-only origin main",
+      { timeoutMs: 30_000, envs: auraToolsEnvs },
+    );
+  });
+
+  it("does nothing on the second call for the same sandbox id", async () => {
+    const sandbox = createSandboxStub("sandbox-cache", [
+      { exitCode: 1, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+
+    await ensureAuraTools(sandbox, auraToolsEnvs);
+    await ensureAuraTools(sandbox, auraToolsEnvs);
+
+    expect(sandbox.commands.run).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs and swallows command failures", async () => {
+    const sandbox = createSandboxStub("sandbox-failure", [
+      { exitCode: 1, stdout: "", stderr: "" },
+      { exitCode: 128, stdout: "", stderr: "auth failed" },
+    ]);
+
+    await expect(ensureAuraTools(sandbox, auraToolsEnvs)).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith("Failed to bootstrap aura-tools in sandbox", {
+      sandboxId: "sandbox-failure",
+      action: "clone",
+      exitCode: 128,
+      stderr: "auth failed",
+    });
   });
 });

--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -42,6 +42,7 @@ export function clearCachedSandbox(): void {
     cachedSandboxUserId = undefined;
   }
   userHomeReady.clear();
+  auraToolsReady.clear();
 }
 
 /**
@@ -220,59 +221,125 @@ export async function getSandboxEnvNames(userId?: string): Promise<string[]> {
   return [...new Set(rows.map(resolveSandboxEnvName))].sort();
 }
 
+const auraToolsReady = new Set<string>();
+
+export async function ensureAuraTools(
+  sandbox: any,
+  envs: Record<string, string>,
+): Promise<void> {
+  const sandboxId = sandbox.sandboxId as string | undefined;
+  if (sandboxId && auraToolsReady.has(sandboxId)) {
+    return;
+  }
+
+  try {
+    const gitCheck = await sandbox.commands.run(
+      "[ -d /home/user/aura-tools/.git ]",
+      { timeoutMs: 5_000, envs },
+    );
+    const auraToolsExists = gitCheck.exitCode === 0;
+
+    const result = auraToolsExists
+      ? await sandbox.commands.run(
+          "git -C /home/user/aura-tools pull --quiet --ff-only origin main",
+          { timeoutMs: 30_000, envs },
+        )
+      : await sandbox.commands.run(
+          "git clone --depth=1 https://x-access-token:$GITHUB_TOKEN@github.com/realadvisor/aura-tools.git /home/user/aura-tools",
+          { timeoutMs: 60_000, envs },
+        );
+
+    if (result.exitCode !== 0) {
+      logger.warn("Failed to bootstrap aura-tools in sandbox", {
+        sandboxId,
+        action: auraToolsExists ? "pull" : "clone",
+        exitCode: result.exitCode,
+        stderr: result.stderr,
+      });
+      return;
+    }
+
+    if (sandboxId) {
+      auraToolsReady.add(sandboxId);
+    }
+    logger.info("aura-tools ready in sandbox", {
+      sandboxId,
+      action: auraToolsExists ? "pull" : "clone",
+    });
+  } catch (error: any) {
+    logger.warn("Failed to bootstrap aura-tools in sandbox", {
+      sandboxId,
+      error: error.message,
+    });
+  }
+}
+
 /**
  * Mount the GCS bucket `gs://aura-files` at `/mnt/aura-files`.
  * Installs gcsfuse if needed and uses the base64-encoded SA key from envs.
  * Non-fatal -- sandbox works fine without the mount.
  */
+async function mountGcsFilesystem(
+  sandbox: any,
+  envs: Record<string, string>,
+): Promise<void> {
+  const mountCheck = await sandbox.commands.run(
+    "mountpoint -q /mnt/aura-files && echo mounted || echo not",
+    { timeoutMs: 5_000, envs },
+  );
+  if (mountCheck.stdout?.trim() === "mounted") return;
+
+  if (!envs.GOOGLE_SA_KEY_B64) {
+    logger.info("Skipping GCS mount — GOOGLE_SA_KEY_B64 not available");
+    return;
+  }
+
+  const gcsfuseCheck = await sandbox.commands.run("which gcsfuse", {
+    timeoutMs: 5_000,
+  });
+  if (gcsfuseCheck.exitCode !== 0) {
+    const distro = "bookworm";
+    const installResult = await sandbox.commands.run(
+      `echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt gcsfuse-${distro} main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc > /dev/null && sudo apt-get update -qq && sudo apt-get install -y -qq gcsfuse && { grep -q user_allow_other /etc/fuse.conf 2>/dev/null || echo user_allow_other | sudo tee -a /etc/fuse.conf > /dev/null; }`,
+      { timeoutMs: 60_000, envs },
+    );
+    if (installResult.exitCode !== 0) {
+      logger.warn("gcsfuse install failed", {
+        exitCode: installResult.exitCode,
+        stderr: installResult.stderr,
+      });
+      return;
+    }
+  }
+
+  const mountResult = await sandbox.commands.run(
+    `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && sudo gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+    { timeoutMs: 30_000, envs },
+  );
+  if (mountResult.exitCode !== 0) {
+    logger.warn("gcsfuse mount failed", {
+      exitCode: mountResult.exitCode,
+      stderr: mountResult.stderr,
+    });
+    return;
+  }
+  logger.info("GCS bucket mounted at /mnt/aura-files");
+}
+
 async function setupSandboxFilesystem(
   sandbox: any,
   envs: Record<string, string>,
 ): Promise<void> {
   try {
-    const mountCheck = await sandbox.commands.run(
-      "mountpoint -q /mnt/aura-files && echo mounted || echo not",
-      { timeoutMs: 5_000, envs },
-    );
-    if (mountCheck.stdout?.trim() === "mounted") return;
-
-    if (!envs.GOOGLE_SA_KEY_B64) {
-      logger.info("Skipping GCS mount — GOOGLE_SA_KEY_B64 not available");
-      return;
-    }
-
-    const gcsfuseCheck = await sandbox.commands.run("which gcsfuse", {
-      timeoutMs: 5_000,
-    });
-    if (gcsfuseCheck.exitCode !== 0) {
-      const distro = "bookworm";
-      const installResult = await sandbox.commands.run(
-        `echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt gcsfuse-${distro} main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc > /dev/null && sudo apt-get update -qq && sudo apt-get install -y -qq gcsfuse && { grep -q user_allow_other /etc/fuse.conf 2>/dev/null || echo user_allow_other | sudo tee -a /etc/fuse.conf > /dev/null; }`,
-        { timeoutMs: 60_000, envs },
-      );
-      if (installResult.exitCode !== 0) {
-        logger.warn("gcsfuse install failed", {
-          exitCode: installResult.exitCode,
-          stderr: installResult.stderr,
-        });
-        return;
-      }
-    }
-
-    const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && sudo gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
-      { timeoutMs: 30_000, envs },
-    );
-    if (mountResult.exitCode !== 0) {
-      logger.warn("gcsfuse mount failed", {
-        exitCode: mountResult.exitCode,
-        stderr: mountResult.stderr,
-      });
-      return;
-    }
-    logger.info("GCS bucket mounted at /mnt/aura-files");
+    await mountGcsFilesystem(sandbox, envs);
   } catch (error: any) {
     logger.warn("Failed to mount GCS bucket", { error: error.message });
+  }
+
+  try {
+    await ensureAuraTools(sandbox, envs);
+  } catch (error: any) {
+    logger.warn("Failed to ensure aura-tools in sandbox", { error: error.message });
   }
 }
 

--- a/content/docs/tools/sandbox.mdx
+++ b/content/docs/tools/sandbox.mdx
@@ -69,6 +69,7 @@ The sandbox persists between messages **within a session** — files and state a
 Common paths:
 - `/home/user/` — working directory
 - `/home/user/downloads/` — files saved to disk via `download_slack_file` or `download_email_attachment`
+- `/home/user/aura-tools` — auto-cloned from `realadvisor/aura-tools` during sandbox setup and kept fresh with `git pull`
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add idempotent aura-tools sandbox bootstrap that clones or fast-forward pulls `realadvisor/aura-tools`.
- Run aura-tools setup independently after the GCS mount attempt during sandbox filesystem setup.
- Cover clone, pull, cache-hit, and swallowed failure behavior with Vitest tests.
- Document the `/home/user/aura-tools` sandbox path.

## Validation
- `pnpm --filter @aura/api typecheck` (no matching workspace package in this repo)
- `pnpm --filter aura-api typecheck`
- `pnpm --filter @aura/api test` (no matching workspace package in this repo)
- `pnpm --filter aura-api test`

Closes #960
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0fbdc02-3e3f-4bdc-a67b-acf26d499323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0fbdc02-3e3f-4bdc-a67b-acf26d499323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

