### PR TITLE
cron: auto-recover recurring jobs from stale-exhaustion and notify on failure (fixes #962)

### DIFF
--- a/apps/api/src/cron/cron-utils.ts
+++ b/apps/api/src/cron/cron-utils.ts
@@ -1,0 +1,14 @@
+import { CronExpressionParser } from "cron-parser";
+
+export function computeNextCronTick(
+  cronSchedule: string,
+  timezone: string | null | undefined,
+  now: Date,
+): Date {
+  const interval = CronExpressionParser.parse(cronSchedule, {
+    currentDate: now,
+    tz: timezone || undefined,
+  });
+
+  return interval.next().toDate();
+}

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -1,7 +1,9 @@
+import { WebClient } from "@slack/web-api";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
+import { safePostMessage } from "../lib/slack-messaging.js";
 import { createHeadlessAgent } from "../lib/agents.js";
 import { executionContext } from "../lib/tool.js";
 import { getCurrentTimeContext } from "../lib/temporal.js";
@@ -18,6 +20,9 @@ import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
 import { sendJobFailureDm } from "./job-notifications.js";
+
+const botToken = process.env.SLACK_BOT_TOKEN || "";
+const slackClient = new WebClient(botToken);
 
 /** Max retries before marking as failed */
 export const MAX_RETRIES = 3;

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -1,9 +1,7 @@
-import { WebClient } from "@slack/web-api";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
-import { safePostMessage } from "../lib/slack-messaging.js";
 import { createHeadlessAgent } from "../lib/agents.js";
 import { executionContext } from "../lib/tool.js";
 import { getCurrentTimeContext } from "../lib/temporal.js";
@@ -18,11 +16,8 @@ import {
 } from "./persist-conversation.js";
 import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
-import { resolveSlackDestination } from "../tools/slack.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
-
-const botToken = process.env.SLACK_BOT_TOKEN || "";
-const slackClient = new WebClient(botToken);
+import { sendJobFailureDm } from "./job-notifications.js";
 
 /** Max retries before marking as failed */
 export const MAX_RETRIES = 3;
@@ -452,20 +447,13 @@ export async function executeJob(
         })
         .where(eq(jobs.id, jobId));
 
-      // Escalate: DM the requester
-      try {
-        if (job.requestedBy && job.requestedBy !== "aura") {
-          const dmChannelId = await resolveSlackDestination(slackClient, job.requestedBy);
-          if (dmChannelId) {
-            await safePostMessage(slackClient, {
-              channel: dmChannelId,
-              text: `I tried 3 times but couldn't complete this job: "${job.description}"\n\nError: ${error.message}`,
-            });
-          }
-        }
-      } catch {
-        logger.error("Heartbeat: failed to send escalation DM", { jobId, executionId });
-      }
+      await sendJobFailureDm({
+        jobId,
+        requestedBy: job.requestedBy,
+        fallbackToAdmin: false,
+        text: `I tried 3 times but couldn't complete this job: "${job.description}"\n\nError: ${error.message}`,
+        logContext: { executionId },
+      });
 
       logger.error("Heartbeat: job failed permanently", {
         jobName: job.name,

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => {
+  type Operation = {
+    kind: "select" | "update" | "delete";
+    setArg?: Record<string, unknown>;
+  };
+
+  const state = {
+    results: [] as unknown[][],
+    operations: [] as Operation[],
+    select: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  function nextResult() {
+    return state.results.shift() ?? [];
+  }
+
+  function createQuery(operation: Operation) {
+    const query: any = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      set: vi.fn((setArg: Record<string, unknown>) => {
+        operation.setArg = setArg;
+        return query;
+      }),
+      returning: vi.fn(() => {
+        state.operations.push(operation);
+        return Promise.resolve(nextResult());
+      }),
+      then: (onFulfilled: any, onRejected: any) => {
+        state.operations.push(operation);
+        return Promise.resolve(nextResult()).then(onFulfilled, onRejected);
+      },
+    };
+
+    return query;
+  }
+
+  state.select.mockImplementation(() => createQuery({ kind: "select" }));
+  state.update.mockImplementation(() => createQuery({ kind: "update" }));
+  state.delete.mockImplementation(() => createQuery({ kind: "delete" }));
+
+  return state;
+});
+
+const executeJobMock = vi.hoisted(() => vi.fn());
+const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: dbMock.select,
+    update: dbMock.update,
+    delete: dbMock.delete,
+  },
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("./execute-job.js", () => ({
+  MAX_RETRIES: 3,
+  executeJob: executeJobMock,
+}));
+
+vi.mock("./job-notifications.js", () => ({
+  sendJobFailureDm: sendJobFailureDmMock,
+  truncateJobFailureText: (value: string | null | undefined, maxChars = 400) => {
+    const text = value?.trim() || "unknown";
+    return text.length <= maxChars ? text : `${text.slice(0, maxChars - 3)}...`;
+  },
+}));
+
+function queueDbResults(...results: unknown[][]) {
+  dbMock.results = [...results];
+}
+
+function updateSets() {
+  return dbMock.operations
+    .filter((operation) => operation.kind === "update")
+    .map((operation) => operation.setArg ?? {});
+}
+
+function baseJob(overrides: Record<string, unknown>) {
+  return {
+    id: "job-1",
+    workspaceId: "default",
+    name: "test-job",
+    description: "do the thing",
+    playbook: null,
+    script: null,
+    cronSchedule: null,
+    frequencyConfig: null,
+    channelId: null,
+    threadTs: null,
+    executeAt: null,
+    requestedBy: "U_REQUESTER",
+    priority: "normal",
+    status: "running",
+    timezone: "UTC",
+    result: null,
+    retries: 3,
+    lastExecutedAt: null,
+    lastResult: "last failure",
+    executionCount: 0,
+    todayExecutions: 0,
+    lastExecutionDate: null,
+    enabled: 1,
+    requiredCredentialIds: [],
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-20T08:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("heartbeat stale running recovery", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = "test-secret";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T08:59:00.000Z"));
+    dbMock.results = [];
+    dbMock.operations = [];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  it("auto-recovers stale exhausted recurring jobs and sends a DM", async () => {
+    const recurringJob = baseJob({
+      cronSchedule: "0 10 * * *",
+      name: "sync-meta-comments-daily",
+      lastResult: "upstream API failed",
+    });
+
+    queueDbResults(
+      [], // pending jobs
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // stale running jobs below max retries
+      [recurringJob], // stale exhausted jobs
+      [], // recurring recovery update
+      [], // running execution cleanup
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    const recoveredUpdate = updateSets().find(
+      (set) => set.status === "pending" && set.retries === 0,
+    );
+    expect(recoveredUpdate).toMatchObject({
+      status: "pending",
+      retries: 0,
+    });
+    expect((recoveredUpdate?.executeAt as Date).toISOString()).toBe(
+      "2026-05-20T10:00:00.000Z",
+    );
+    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
+    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        requestedBy: "U_REQUESTER",
+        text: expect.stringContaining("Auto-recovered. Next attempt: 2026-05-20T10:00:00.000Z."),
+      }),
+    );
+  });
+
+  it("fails stale exhausted one-shot jobs and sends a DM", async () => {
+    const oneShotJob = baseJob({
+      cronSchedule: null,
+      name: "one-shot-followup",
+      lastResult: "tool failed",
+    });
+
+    queueDbResults(
+      [],
+      [],
+      [],
+      [],
+      [oneShotJob],
+      [], // one-shot failure update
+      [], // running execution cleanup
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    const failedUpdate = updateSets().find((set) => set.status === "failed");
+    expect(failedUpdate).toMatchObject({
+      status: "failed",
+      result: "Failed: job stuck in running state and exceeded retry limit",
+    });
+    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
+    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        requestedBy: "U_REQUESTER",
+        text: "Job one-shot-followup exhausted retries. Last error: tool failed.",
+      }),
+    );
+  });
+
+  it("keeps healthy stale recovery for jobs below the retry limit", async () => {
+    queueDbResults(
+      [],
+      [],
+      [],
+      [{ id: "job-healthy", name: "healthy-retry" }],
+      [], // no stale exhausted jobs
+      [], // running execution cleanup
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(updateSets()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "pending",
+        }),
+      ]),
+    );
+    expect(updateSets().some((set) => set.status === "failed")).toBe(false);
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -248,7 +248,11 @@ describe("heartbeat stale running recovery", () => {
         }),
       ]),
     );
-    expect(updateSets().some((set) => set.status === "failed")).toBe(false);
+    expect(
+      updateSets().some(
+        (set) => set.result === "Failed: job stuck in running state and exceeded retry limit",
+      ),
+    ).toBe(false);
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -1,11 +1,13 @@
 import { Hono } from "hono";
-import { eq, and, lt, lte, sql, isNull, or, inArray } from "drizzle-orm";
+import { eq, and, lt, lte, gte, sql, isNull, or, inArray } from "drizzle-orm";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "@aura/db/schema";
 import type { FrequencyConfig } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
 import { executeJob, MAX_RETRIES } from "./execute-job.js";
+import { computeNextCronTick } from "./cron-utils.js";
+import { sendJobFailureDm, truncateJobFailureText } from "./job-notifications.js";
 
 /** Max jobs to process per heartbeat sweep */
 const MAX_JOBS_PER_SWEEP = 10;
@@ -192,7 +194,7 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
 
     // ── 5. Recover jobs stuck in "running" ─────────────────────────────
 
-    const staleRunningCutoff = new Date(Date.now() - STALE_RUNNING_THRESHOLD_MS);
+    const staleRunningCutoff = new Date(now.getTime() - STALE_RUNNING_THRESHOLD_MS);
     const staleRunning = await db
       .update(jobs)
       .set({
@@ -210,19 +212,97 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       .returning({ id: jobs.id, name: jobs.name });
 
     const staleExhausted = await db
-      .update(jobs)
-      .set({
-        status: "failed",
-        result: "Failed: job stuck in running state and exceeded retry limit",
-        updatedAt: new Date(),
-      })
+      .select()
+      .from(jobs)
       .where(
         and(
           eq(jobs.status, "running"),
           lt(jobs.updatedAt, staleRunningCutoff),
+          gte(jobs.retries, MAX_RETRIES),
         ),
-      )
-      .returning({ id: jobs.id, name: jobs.name });
+      );
+
+    const recoveredRecurringJobs: Array<{ id: string; name: string; executeAt: Date }> = [];
+    const failedExhaustedJobs: Array<{ id: string; name: string }> = [];
+
+    for (const job of staleExhausted) {
+      const lastError = truncateJobFailureText(job.lastResult);
+
+      if (job.cronSchedule != null) {
+        try {
+          const executeAt = computeNextCronTick(job.cronSchedule, job.timezone, now);
+
+          await db
+            .update(jobs)
+            .set({
+              status: "pending",
+              retries: 0,
+              executeAt,
+              updatedAt: new Date(),
+            })
+            .where(eq(jobs.id, job.id));
+
+          recoveredRecurringJobs.push({ id: job.id, name: job.name, executeAt });
+          logger.warn("recurring_job_recovered_after_exhaustion", {
+            jobId: job.id,
+            jobName: job.name,
+            cronSchedule: job.cronSchedule,
+            timezone: job.timezone,
+            executeAt: executeAt.toISOString(),
+          });
+
+          await sendJobFailureDm({
+            jobId: job.id,
+            requestedBy: job.requestedBy,
+            text: `Recurring job \`${job.name}\` exhausted retries (last error: ${lastError}). Auto-recovered. Next attempt: ${executeAt.toISOString()}.`,
+            logContext: { event: "recurring_job_recovered_after_exhaustion" },
+          });
+        } catch (error: any) {
+          await db
+            .update(jobs)
+            .set({
+              status: "failed",
+              result: `Failed: job stuck in running state and exceeded retry limit; auto-recovery failed: ${error?.message ?? "invalid cron schedule"}`,
+              updatedAt: new Date(),
+            })
+            .where(eq(jobs.id, job.id));
+
+          failedExhaustedJobs.push({ id: job.id, name: job.name });
+          logger.error("recurring_job_recovery_failed", {
+            jobId: job.id,
+            jobName: job.name,
+            cronSchedule: job.cronSchedule,
+            timezone: job.timezone,
+            error: error?.message,
+          });
+
+          await sendJobFailureDm({
+            jobId: job.id,
+            requestedBy: job.requestedBy,
+            text: `Recurring job \`${job.name}\` exhausted retries but could not be auto-recovered. Last error: ${lastError}.`,
+            logContext: { event: "recurring_job_recovery_failed" },
+          });
+        }
+      } else {
+        await db
+          .update(jobs)
+          .set({
+            status: "failed",
+            result: "Failed: job stuck in running state and exceeded retry limit",
+            updatedAt: new Date(),
+          })
+          .where(eq(jobs.id, job.id));
+
+        failedExhaustedJobs.push({ id: job.id, name: job.name });
+
+        await sendJobFailureDm({
+          jobId: job.id,
+          requestedBy: job.requestedBy,
+          text: `Job ${job.name} exhausted retries. Last error: ${lastError}.`,
+          logContext: { event: "one_shot_job_exhausted_retries" },
+        });
+      }
+    }
 
     const allStaleIds = [
       ...staleRunning.map((j) => j.id),
@@ -253,7 +333,8 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
     }
     if (staleExhausted.length > 0) {
       logger.error(`Heartbeat: ${staleExhausted.length} stale jobs exceeded retry limit`, {
-        jobs: staleExhausted.map((j) => j.name),
+        recoveredRecurringJobs: recoveredRecurringJobs.map((j) => j.name),
+        failedJobs: failedExhaustedJobs.map((j) => j.name),
       });
     }
 

--- a/apps/api/src/cron/job-notifications.ts
+++ b/apps/api/src/cron/job-notifications.ts
@@ -1,0 +1,81 @@
+import { WebClient } from "@slack/web-api";
+import { logger } from "../lib/logger.js";
+import { safePostMessage } from "../lib/slack-messaging.js";
+import { resolveSlackDestination } from "../tools/slack.js";
+
+const botToken = process.env.SLACK_BOT_TOKEN || "";
+const slackClient = new WebClient(botToken);
+
+export function truncateJobFailureText(value: string | null | undefined, maxChars = 400): string {
+  const text = value?.trim() || "unknown";
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars - 3)}...`;
+}
+
+function firstAdminUserId(): string | null {
+  return (
+    (process.env.AURA_ADMIN_USER_IDS || "")
+      .split(",")
+      .map((id) => id.trim())
+      .find(Boolean) ?? null
+  );
+}
+
+export function resolveJobFailureDmTarget(
+  requestedBy: string | null | undefined,
+  { fallbackToAdmin = true }: { fallbackToAdmin?: boolean } = {},
+): string | null {
+  const requester = requestedBy?.trim();
+  if (requester && requester !== "aura") return requester;
+  if (!fallbackToAdmin) return null;
+
+  return process.env.FOUNDER_USER_ID?.trim() || firstAdminUserId();
+}
+
+export async function sendJobFailureDm({
+  jobId,
+  requestedBy,
+  text,
+  fallbackToAdmin = true,
+  logContext = {},
+}: {
+  jobId: string;
+  requestedBy: string | null | undefined;
+  text: string;
+  fallbackToAdmin?: boolean;
+  logContext?: Record<string, unknown>;
+}): Promise<boolean> {
+  const target = resolveJobFailureDmTarget(requestedBy, { fallbackToAdmin });
+
+  if (!target) {
+    logger.warn("Job failure DM skipped: no target", { jobId, ...logContext });
+    return false;
+  }
+
+  try {
+    const dmChannelId = await resolveSlackDestination(slackClient, target);
+    if (!dmChannelId) {
+      logger.warn("Job failure DM skipped: target did not resolve", {
+        jobId,
+        target,
+        ...logContext,
+      });
+      return false;
+    }
+
+    await safePostMessage(slackClient, {
+      channel: dmChannelId,
+      text,
+    });
+
+    return true;
+  } catch (error: any) {
+    logger.error("Job failure DM failed", {
+      jobId,
+      target,
+      error: error?.message,
+      ...logContext,
+    });
+    return false;
+  }
+}

--- a/content/docs/tools/jobs.mdx
+++ b/content/docs/tools/jobs.mdx
@@ -12,6 +12,10 @@ Aura can schedule work to run in the background. Jobs come in two types:
 
 The **heartbeat** runs every 30 minutes and evaluates all pending jobs. Scheduling granularity is approximately 30 minutes. Failed jobs retry 3x with 30-minute backoff, then escalate via DM.
 
+## Recurring job recovery
+
+If a recurring job is left in `running` past the stale threshold and has already exhausted retries, the heartbeat does not leave it in `failed` forever. It resets the job to `pending`, clears `retries`, computes the next cron tick in the job timezone, and DMs the requester with the last error and next attempt time. One-shot jobs that exhaust stale retries stay `failed` and also send a DM.
+
 ---
 
 ## `create_job`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Auto-recover stale exhausted recurring jobs by resetting them to pending and scheduling the next cron tick.
- Send shared Slack DM notifications when stale exhausted recurring jobs recover or one-shot jobs fail permanently.
- Add heartbeat coverage for recurring recovery, one-shot exhaustion notification, and healthy stale retry recovery.
- Document recurring job recovery behavior.

Closes #962

## Testing
- `pnpm --filter aura-api exec vitest run src/cron/heartbeat.test.ts`
- `pnpm typecheck`
- `pnpm --filter aura-api test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6428df8-433f-4037-967e-cf787fb9f1c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6428df8-433f-4037-967e-cf787fb9f1c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

