### PR TITLE
cron: classify script hard-failures and stop silent fall-through (fixes #961)

### DIFF
--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => {
+  const state = {
+    updateReturningResults: [] as unknown[][],
+    insertReturningResults: [] as unknown[][],
+    selectResults: [] as unknown[][],
+    updateCalls: [] as Array<{ table: unknown; setValues?: Record<string, unknown> }>,
+    insertCalls: [] as Array<{ table: unknown; values?: Record<string, unknown> }>,
+    update: vi.fn(),
+    insert: vi.fn(),
+    select: vi.fn(),
+  };
+
+  function createQuery(
+    call: { table: unknown; setValues?: Record<string, unknown>; values?: Record<string, unknown> },
+    results: unknown[][],
+  ) {
+    const query: any = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        call.setValues = values;
+        return query;
+      }),
+      values: vi.fn((values: Record<string, unknown>) => {
+        call.values = values;
+        return query;
+      }),
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      returning: vi.fn(() => Promise.resolve(results.shift() ?? [])),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(results.shift() ?? []).then(onFulfilled, onRejected),
+    };
+    return query;
+  }
+
+  state.update.mockImplementation((table: unknown) => {
+    const call = { table };
+    state.updateCalls.push(call);
+    return createQuery(call, state.updateReturningResults);
+  });
+
+  state.insert.mockImplementation((table: unknown) => {
+    const call = { table };
+    state.insertCalls.push(call);
+    return createQuery(call, state.insertReturningResults);
+  });
+
+  state.select.mockImplementation(() => {
+    const call = { table: undefined };
+    return createQuery(call, state.selectResults);
+  });
+
+  return state;
+});
+
+const commandRunMock = vi.hoisted(() => vi.fn());
+const getOrCreateSandboxMock = vi.hoisted(() => vi.fn());
+const getSandboxEnvsMock = vi.hoisted(() => vi.fn());
+const truncateOutputMock = vi.hoisted(() => vi.fn((output: string, maxChars = 4000) => output.slice(0, maxChars)));
+const createHeadlessAgentMock = vi.hoisted(() => vi.fn());
+const agentGenerateMock = vi.hoisted(() => vi.fn());
+const persistConversationInputsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    update: dbMock.update,
+    insert: dbMock.insert,
+    select: dbMock.select,
+  },
+}));
+
+vi.mock("../lib/sandbox.js", () => ({
+  getOrCreateSandbox: getOrCreateSandboxMock,
+  getSandboxEnvs: getSandboxEnvsMock,
+  truncateOutput: truncateOutputMock,
+}));
+
+vi.mock("../lib/agents.js", () => ({
+  createHeadlessAgent: createHeadlessAgentMock,
+}));
+
+vi.mock("../lib/tool.js", () => ({
+  executionContext: {
+    run: vi.fn((_context, callback) => callback()),
+  },
+}));
+
+vi.mock("../personality/system-prompt.js", () => ({
+  buildStablePrefix: vi.fn().mockResolvedValue("stable-prefix"),
+}));
+
+vi.mock("../lib/temporal.js", () => ({
+  getCurrentTimeContext: vi.fn(() => "time-context"),
+}));
+
+vi.mock("./persist-conversation.js", () => ({
+  createConversationTrace: vi.fn().mockResolvedValue("conversation-1"),
+  persistConversationInputs: persistConversationInputsMock,
+  persistConversationSteps: vi.fn().mockResolvedValue(undefined),
+  persistConversationError: vi.fn().mockResolvedValue(undefined),
+  updateConversationTraceUsage: vi.fn().mockResolvedValue(undefined),
+  buildConversationSteps: vi.fn(() => []),
+}));
+
+vi.mock("../lib/cost-calculator.js", () => ({
+  buildStepUsages: vi.fn(() => []),
+}));
+
+vi.mock("../tools/scratchpad.js", () => ({
+  getScratchpadContents: vi.fn(() => undefined),
+  cleanupScratchpad: vi.fn(),
+}));
+
+vi.mock("../tools/slack.js", () => ({
+  resolveSlackDestination: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../lib/slack-messaging.js", () => ({
+  safePostMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { errorEvents } from "@aura/db/schema";
+import { executeJob, MAX_RETRIES } from "./execute-job.js";
+
+function baseJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "job-1",
+    workspaceId: "default",
+    name: "sync-meta-comments-daily",
+    description: "Sync Meta comments",
+    playbook: "Summarize script output",
+    script: "python sync-meta-comments.py",
+    cronSchedule: null,
+    frequencyConfig: null,
+    channelId: "C123",
+    threadTs: null,
+    executeAt: new Date(),
+    requestedBy: "aura",
+    priority: "normal",
+    status: "pending",
+    timezone: "UTC",
+    result: null,
+    retries: 0,
+    lastExecutedAt: null,
+    lastResult: null,
+    executionCount: 0,
+    todayExecutions: 0,
+    lastExecutionDate: null,
+    enabled: 1,
+    requiredCredentialIds: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as any;
+}
+
+function resetDbQueues() {
+  dbMock.updateReturningResults = [[{ id: "job-1" }]];
+  dbMock.insertReturningResults = [[{ id: "execution-1" }]];
+  dbMock.selectResults = [];
+  dbMock.updateCalls = [];
+  dbMock.insertCalls = [];
+}
+
+function failedJobUpdate() {
+  return dbMock.updateCalls.find((call) => call.setValues?.status === "failed" && "retries" in call.setValues);
+}
+
+describe("executeJob script failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbQueues();
+    getOrCreateSandboxMock.mockResolvedValue({ commands: { run: commandRunMock } });
+    getSandboxEnvsMock.mockResolvedValue({});
+    persistConversationInputsMock.mockResolvedValue(2);
+    agentGenerateMock.mockResolvedValue({
+      text: "LLM completed",
+      steps: [],
+      totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    });
+    createHeadlessAgentMock.mockResolvedValue({
+      agent: { generate: agentGenerateMock },
+      modelId: "test-model",
+      getStepModelIds: () => [],
+    });
+  });
+
+  it("marks exit code 127 as failed, increments retries, and does not invoke the LLM", async () => {
+    commandRunMock.mockResolvedValue({
+      exitCode: 127,
+      stdout: "",
+      stderr: "python: command not found",
+    });
+
+    await expect(executeJob(baseJob({ retries: MAX_RETRIES - 1 }))).rejects.toMatchObject({
+      name: "ScriptHardFailure",
+      exitCode: 127,
+    });
+
+    expect(createHeadlessAgentMock).not.toHaveBeenCalled();
+    expect(agentGenerateMock).not.toHaveBeenCalled();
+    expect(failedJobUpdate()?.setValues).toMatchObject({
+      status: "failed",
+      retries: MAX_RETRIES,
+    });
+    expect(
+      dbMock.insertCalls.some(
+        (call) =>
+          call.table === errorEvents &&
+          call.values?.errorName === "ScriptHardFailure" &&
+          call.values?.errorCode === "SCRIPT_EXIT_127",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls through to the LLM with partial stdout and stderr for soft failures", async () => {
+    commandRunMock.mockResolvedValue({
+      exitCode: 1,
+      stdout: '{"partial":true}',
+      stderr: "API returned partial data before failing",
+    });
+
+    await expect(executeJob(baseJob())).resolves.toBe(true);
+
+    expect(createHeadlessAgentMock).toHaveBeenCalledOnce();
+    expect(agentGenerateMock).toHaveBeenCalledOnce();
+    const prompt = agentGenerateMock.mock.calls[0][0].prompt;
+    expect(prompt).toContain('{"partial":true}');
+    expect(prompt).toContain("## Script stderr");
+    expect(prompt).toContain("API returned partial data before failing");
+  });
+
+  it("treats thrown script errors with no stdout as hard failures", async () => {
+    commandRunMock.mockRejectedValue(new Error("Command timed out"));
+
+    await expect(executeJob(baseJob({ retries: MAX_RETRIES - 1 }))).rejects.toMatchObject({
+      name: "ScriptHardFailure",
+      exitCode: 1,
+    });
+
+    expect(createHeadlessAgentMock).not.toHaveBeenCalled();
+    expect(agentGenerateMock).not.toHaveBeenCalled();
+    expect(failedJobUpdate()?.setValues).toMatchObject({
+      status: "failed",
+      retries: MAX_RETRIES,
+    });
+  });
+});

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -1,7 +1,7 @@
 import { WebClient } from "@slack/web-api";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/client.js";
-import { jobs, notes, jobExecutions } from "@aura/db/schema";
+import { jobs, notes, jobExecutions, errorEvents } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import { createHeadlessAgent } from "../lib/agents.js";
@@ -49,6 +49,66 @@ You are resuming a multi-step task. Your accumulated progress and context are be
 - Post results in the thread you're continuing (routing is automatic).
 - Be concise and focused. Don't re-explain what was already done -- just continue the work.
 - If the continuation depth limit is reached, explain your current status and ask if you should keep going.`;
+
+export class ScriptHardFailure extends Error {
+  readonly exitCode: number;
+  readonly stderr: string;
+
+  constructor(exitCode: number, stderr: string) {
+    super(`Script hard failure (exit ${exitCode}): ${stderr || "(no stderr)"}`);
+    this.name = "ScriptHardFailure";
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+function isHardScriptFailure(exitCode: number, stdout: string, stderr: string): boolean {
+  if (exitCode === 127) return true; // command not found
+  if (exitCode === 126) return true; // not executable
+  if (/No such file or directory/i.test(stderr)) return true;
+  if (/command not found/i.test(stderr)) return true;
+  if (/ModuleNotFoundError|ImportError/i.test(stderr)) return true;
+  if (exitCode !== 0 && (!stdout || stdout.trim().length === 0)) return true;
+  return false;
+}
+
+function truncateScriptStderr(stderr: string): string {
+  return stderr.slice(0, 2000);
+}
+
+async function recordScriptHardFailure(params: {
+  jobId: string;
+  jobName: string;
+  requestedBy: string;
+  channelId: string | null;
+  exitCode: number;
+  stderr: string;
+}) {
+  try {
+    await db.insert(errorEvents).values({
+      timestamp: new Date(),
+      errorName: "ScriptHardFailure",
+      errorMessage: params.stderr || "(no stderr)",
+      errorCode: `SCRIPT_EXIT_${params.exitCode}`,
+      userId: params.requestedBy,
+      channelId: params.channelId,
+      context: {
+        jobId: params.jobId,
+        jobName: params.jobName,
+        exitCode: params.exitCode,
+        stderr: params.stderr,
+      },
+    });
+  } catch (error: any) {
+    logger.error("executeJob: failed to record script hard failure", {
+      jobId: params.jobId,
+      jobName: params.jobName,
+      exitCode: params.exitCode,
+      stderr: params.stderr,
+      error: error.message,
+    });
+  }
+}
 
 // ── Continuation Detection ───────────────────────────────────────────────────
 
@@ -182,6 +242,7 @@ export async function executeJob(
 
     // ── Script execution layer ──────────────────────────────────────────────
     let scriptOutput: string | null = null;
+    let scriptStderr: string | null = null;
 
     if (job.script) {
       try {
@@ -241,30 +302,77 @@ export async function executeJob(
             return true;
           }
         } else {
-          logger.warn("executeJob: script failed, falling through to LLM", {
+          const stdout = scriptResult.stdout || "";
+          const stderr = scriptResult.stderr || "";
+          scriptOutput = truncateOutput(stdout, 50_000);
+          scriptStderr = truncateScriptStderr(stderr);
+
+          if (isHardScriptFailure(scriptResult.exitCode, stdout, stderr)) {
+            await recordScriptHardFailure({
+              jobId,
+              jobName: job.name,
+              requestedBy: job.requestedBy,
+              channelId: job.channelId,
+              exitCode: scriptResult.exitCode,
+              stderr: scriptStderr,
+            });
+            throw new ScriptHardFailure(scriptResult.exitCode, scriptStderr);
+          }
+
+          logger.warn("executeJob: script soft-failed, falling through to LLM", {
             jobId,
             jobName: job.name,
             exitCode: scriptResult.exitCode,
-            stderr: scriptResult.stderr?.slice(0, 500),
+            stderr: scriptStderr.slice(0, 500),
           });
         }
       } catch (scriptErr: any) {
-        if (scriptOutput) {
+        if (scriptErr instanceof ScriptHardFailure) {
           throw scriptErr;
         }
-        logger.warn("executeJob: script execution error, falling through to LLM", {
-          jobId,
-          jobName: job.name,
-          error: scriptErr.message,
-        });
+
+        const exitCode = typeof scriptErr.exitCode === "number" ? scriptErr.exitCode : 1;
+        const stdout = typeof scriptErr.stdout === "string" ? scriptErr.stdout : (scriptOutput ?? "");
+        const stderr =
+          typeof scriptErr.stderr === "string"
+            ? scriptErr.stderr
+            : scriptErr.message || "Script execution failed";
+
+        if (isHardScriptFailure(exitCode, stdout, stderr)) {
+          const truncatedStderr = truncateScriptStderr(stderr);
+          await recordScriptHardFailure({
+            jobId,
+            jobName: job.name,
+            requestedBy: job.requestedBy,
+            channelId: job.channelId,
+            exitCode,
+            stderr: truncatedStderr,
+          });
+          throw new ScriptHardFailure(exitCode, truncatedStderr);
+        }
+
+        if (scriptOutput || (stdout && stdout.trim().length > 0)) {
+          scriptOutput = scriptOutput ?? stdout.slice(0, 50_000);
+          scriptStderr = truncateScriptStderr(stderr);
+          logger.warn("executeJob: script execution soft error, falling through to LLM", {
+            jobId,
+            jobName: job.name,
+            exitCode,
+            error: scriptErr.message,
+            stderr: scriptStderr.slice(0, 500),
+          });
+        }
       }
     }
 
     if (scriptOutput) {
-      prompt = `## Pre-computed data (from script)\n\n\`\`\`json\n${scriptOutput}\n\`\`\`\n\n---\n\n${prompt}`;
+      const stderrSection = scriptStderr
+        ? `\n\n## Script stderr\n\n\`\`\`\n${scriptStderr}\n\`\`\``
+        : "";
+      prompt = `## Pre-computed data (from script)\n\n\`\`\`json\n${scriptOutput}\n\`\`\`${stderrSection}\n\n---\n\n${prompt}`;
     }
 
-  const { agent, modelId, getStepModelIds } = await createHeadlessAgent({
+    const { agent, modelId, getStepModelIds } = await createHeadlessAgent({
       slackClient,
       context: {
         userId: job.requestedBy,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Classify script hard failures before falling through to the LLM.
- Record hard script failures in `error_events` with job context and stderr.
- Preserve soft failure fall-through while including truncated stderr in the LLM prompt.
- Add focused cron executor tests for hard exits, soft partial output, and thrown script errors.

## Tests
- `pnpm --filter aura-api test -- src/cron/execute-job.test.ts`
- `pnpm typecheck`

Closes #961
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0c16a6d-4769-4fcc-87df-6dcbe41e73fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0c16a6d-4769-4fcc-87df-6dcbe41e73fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

