### PR TITLE
ops: daily recurring-job health monitor with consecutive-failure surveillance (fixes #963)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ MODEL_EMBEDDING=openai/text-embedding-3-small
 # ── App config ───────────────────────────────────────────────────────────────
 AURA_BOT_USER_ID=U_AURA_BOT_ID
 AURA_ADMIN_USER_IDS=U_YOUR_USER_ID
+FOUNDER_USER_ID=U_FOUNDER_USER_ID
 LOG_LEVEL=info
 PORT=3001
 CRON_SECRET=your-cron-secret

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "content:index": "tsx scripts/index-content.ts",
     "content:index:no-embeddings": "tsx scripts/index-content.ts --skip-embeddings",
-    "backfill:canonical-model-ids": "tsx scripts/backfill-canonical-model-ids.ts"
+    "backfill:canonical-model-ids": "tsx scripts/backfill-canonical-model-ids.ts",
+    "jobs:seed-health": "tsx src/scripts/seed-recurring-health.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.46",

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -29,6 +29,8 @@ export const MAX_RETRIES = 3;
 
 /** Retry delay in ms (30 minutes — matches heartbeat cron interval) */
 const RETRY_DELAY_MS = 30 * 60 * 1000;
+const RECURRING_JOB_HEALTH_MONITOR_SCRIPT =
+  "internal:recurring-job-health-monitor";
 
 // ── Job-specific additive instructions ───────────────────────────────────────
 
@@ -66,6 +68,70 @@ async function loadPlanNote(topic: string): Promise<string | null> {
     .where(eq(notes.topic, topic))
     .limit(1);
   return rows[0]?.content ?? null;
+}
+
+async function runInternalJobScript(
+  script: string,
+  job: typeof jobs.$inferSelect,
+): Promise<string | null> {
+  if (script.trim() !== RECURRING_JOB_HEALTH_MONITOR_SCRIPT) {
+    return null;
+  }
+
+  const { runRecurringJobHealthMonitor } = await import("../jobs/health.js");
+  return runRecurringJobHealthMonitor({
+    founderUserId: job.requestedBy,
+    slackClient,
+  });
+}
+
+async function completeScriptOnlyJob(
+  job: typeof jobs.$inferSelect,
+  executionId: string,
+  resultText: string,
+  isRecurring: boolean,
+): Promise<void> {
+  if (job.channelId && job.threadTs) {
+    await safePostMessage(slackClient, {
+      channel: job.channelId,
+      thread_ts: job.threadTs,
+      text: resultText,
+    });
+  } else if (job.channelId) {
+    await safePostMessage(slackClient, {
+      channel: job.channelId,
+      text: resultText,
+    });
+  }
+
+  const now = new Date();
+  const todayStr = now.toISOString().slice(0, 10);
+  const isNewDay = job.lastExecutionDate !== todayStr;
+
+  await db
+    .update(jobs)
+    .set({
+      status: isRecurring ? "pending" : "completed",
+      ...(isRecurring ? { executeAt: null } : {}),
+      result: resultText.slice(0, 2000),
+      lastResult: resultText.slice(0, 2000),
+      lastExecutedAt: now,
+      executionCount: sql`${jobs.executionCount} + 1`,
+      todayExecutions: isNewDay ? 1 : sql`${jobs.todayExecutions} + 1`,
+      lastExecutionDate: todayStr,
+      retries: 0,
+      updatedAt: now,
+    })
+    .where(eq(jobs.id, job.id));
+
+  await db
+    .update(jobExecutions)
+    .set({
+      status: "completed",
+      finishedAt: now,
+      summary: resultText.slice(0, 500),
+    })
+    .where(eq(jobExecutions.id, executionId));
 }
 
 // ── Job Execution ────────────────────────────────────────────────────────────
@@ -184,79 +250,61 @@ export async function executeJob(
     let scriptOutput: string | null = null;
 
     if (job.script) {
-      try {
-        const { getOrCreateSandbox, truncateOutput, getSandboxEnvs } = await import("../lib/sandbox.js");
-        const sandbox = await getOrCreateSandbox();
-        const envs = await getSandboxEnvs(job.requestedBy);
+      const internalScriptOutput = await runInternalJobScript(job.script, job);
 
-        const scriptResult = await sandbox.commands.run(job.script, {
-          timeoutMs: 120_000,
-          cwd: "/home/user",
-          envs,
-        });
+      if (internalScriptOutput !== null) {
+        scriptOutput = internalScriptOutput;
 
-        if (scriptResult.exitCode === 0) {
-          scriptOutput = truncateOutput(scriptResult.stdout, 50_000);
+        if (!job.playbook) {
+          const resultText = scriptOutput || "(script produced no output)";
+          await completeScriptOnlyJob(job, executionId, resultText, isRecurring);
 
-          if (!job.playbook) {
-            const resultText = scriptOutput || "(script produced no output)";
-
-            if (job.channelId && job.threadTs) {
-              await safePostMessage(slackClient, {
-                channel: job.channelId,
-                thread_ts: job.threadTs,
-                text: resultText,
-              });
-            } else if (job.channelId) {
-              await safePostMessage(slackClient, {
-                channel: job.channelId,
-                text: resultText,
-              });
-            }
-
-            const now = new Date();
-            const todayStr = now.toISOString().slice(0, 10);
-            const isNewDay = job.lastExecutionDate !== todayStr;
-
-            await db.update(jobs).set({
-              status: isRecurring ? "pending" : "completed",
-              ...(isRecurring ? { executeAt: null } : {}),
-              result: resultText.slice(0, 2000),
-              lastResult: resultText.slice(0, 2000),
-              lastExecutedAt: now,
-              executionCount: sql`${jobs.executionCount} + 1`,
-              todayExecutions: isNewDay ? 1 : sql`${jobs.todayExecutions} + 1`,
-              lastExecutionDate: todayStr,
-              retries: 0,
-              updatedAt: now,
-            }).where(eq(jobs.id, jobId));
-
-            await db.update(jobExecutions).set({
-              status: "completed",
-              finishedAt: now,
-              summary: resultText.slice(0, 500),
-            }).where(eq(jobExecutions.id, executionId));
-
-            logger.info("executeJob: script-only job completed", { jobId, jobName: job.name });
-            return true;
-          }
-        } else {
-          logger.warn("executeJob: script failed, falling through to LLM", {
+          logger.info("executeJob: internal script-only job completed", {
             jobId,
             jobName: job.name,
-            exitCode: scriptResult.exitCode,
-            stderr: scriptResult.stderr?.slice(0, 500),
+          });
+          return true;
+        }
+      } else {
+        try {
+          const { getOrCreateSandbox, truncateOutput, getSandboxEnvs } = await import("../lib/sandbox.js");
+          const sandbox = await getOrCreateSandbox();
+          const envs = await getSandboxEnvs(job.requestedBy);
+
+          const scriptResult = await sandbox.commands.run(job.script, {
+            timeoutMs: 120_000,
+            cwd: "/home/user",
+            envs,
+          });
+
+          if (scriptResult.exitCode === 0) {
+            scriptOutput = truncateOutput(scriptResult.stdout, 50_000);
+
+            if (!job.playbook) {
+              const resultText = scriptOutput || "(script produced no output)";
+              await completeScriptOnlyJob(job, executionId, resultText, isRecurring);
+
+              logger.info("executeJob: script-only job completed", { jobId, jobName: job.name });
+              return true;
+            }
+          } else {
+            logger.warn("executeJob: script failed, falling through to LLM", {
+              jobId,
+              jobName: job.name,
+              exitCode: scriptResult.exitCode,
+              stderr: scriptResult.stderr?.slice(0, 500),
+            });
+          }
+        } catch (scriptErr: any) {
+          if (scriptOutput) {
+            throw scriptErr;
+          }
+          logger.warn("executeJob: script execution error, falling through to LLM", {
+            jobId,
+            jobName: job.name,
+            error: scriptErr.message,
           });
         }
-      } catch (scriptErr: any) {
-        if (scriptOutput) {
-          throw scriptErr;
-        }
-        logger.warn("executeJob: script execution error, falling through to LLM", {
-          jobId,
-          jobName: job.name,
-          error: scriptErr.message,
-        });
       }
     }
 

--- a/apps/api/src/jobs/health.test.ts
+++ b/apps/api/src/jobs/health.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../lib/slack-messaging.js", () => ({
+  safePostMessage: vi.fn(),
+}));
+
+vi.mock("../tools/slack.js", () => ({
+  resolveSlackDestination: vi.fn(),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+interface SeedJob {
+  id: string;
+  name: string;
+  cron_schedule: string | null;
+  status: string;
+  enabled: number;
+  requested_by: string;
+}
+
+interface SeedExecution {
+  job_id: string;
+  status: "completed" | "failed" | "running";
+  started_at: Date;
+  finished_at: Date | null;
+}
+
+function daysAgo(now: Date, days: number): Date {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function buildSqlRows(
+  jobs: SeedJob[],
+  executions: SeedExecution[],
+  now: Date,
+) {
+  return jobs
+    .filter((job) => job.enabled === 1 && job.cron_schedule)
+    .map((job) => {
+      const jobExecutions = executions.filter((execution) => execution.job_id === job.id);
+      const completed = jobExecutions.filter(
+        (execution) => execution.status === "completed" && execution.finished_at,
+      );
+      const lastSuccessfulRun =
+        completed.length === 0
+          ? null
+          : completed.reduce<Date | null>((latest, execution) => {
+              if (!execution.finished_at) return latest;
+              if (!latest || execution.finished_at > latest) return execution.finished_at;
+              return latest;
+            }, null);
+      const consecutiveFailures = jobExecutions.filter(
+        (execution) =>
+          execution.status === "failed" &&
+          execution.started_at > (lastSuccessfulRun ?? new Date("1970-01-01T00:00:00Z")),
+      ).length;
+
+      return {
+        id: job.id,
+        name: job.name,
+        cron_schedule: job.cron_schedule,
+        status: job.status,
+        enabled: job.enabled,
+        requested_by: job.requested_by,
+        last_successful_run: lastSuccessfulRun,
+        consecutive_failures: consecutiveFailures,
+        days_since_last_success: lastSuccessfulRun
+          ? (now.getTime() - lastSuccessfulRun.getTime()) / (24 * 60 * 60 * 1000)
+          : null,
+      };
+    });
+}
+
+describe("getRecurringJobHealth", () => {
+  const now = new Date("2026-05-20T09:00:00Z");
+  const founder = "U0678NQJ2";
+
+  beforeEach(() => {
+    dbMock.execute.mockReset();
+  });
+
+  it("flags slow-rot failures and leaves healthy/no-execution recurring jobs unflagged", async () => {
+    const seedJobs: SeedJob[] = [
+      {
+        id: "healthy",
+        name: "healthy-daily",
+        cron_schedule: "0 8 * * *",
+        status: "pending",
+        enabled: 1,
+        requested_by: founder,
+      },
+      {
+        id: "eleven-day-failing",
+        name: "sync-meta-comments-daily",
+        cron_schedule: "0 8 * * *",
+        status: "failed",
+        enabled: 1,
+        requested_by: founder,
+      },
+      {
+        id: "three-consec",
+        name: "three-consec-failure-job",
+        cron_schedule: "0 7 * * *",
+        status: "pending",
+        enabled: 1,
+        requested_by: founder,
+      },
+      {
+        id: "no-execution",
+        name: "new-recurring-job",
+        cron_schedule: "0 10 * * *",
+        status: "pending",
+        enabled: 1,
+        requested_by: founder,
+      },
+    ];
+    const seedExecutions: SeedExecution[] = [
+      {
+        job_id: "healthy",
+        status: "completed",
+        started_at: daysAgo(now, 0.2),
+        finished_at: daysAgo(now, 0.2),
+      },
+      {
+        job_id: "eleven-day-failing",
+        status: "completed",
+        started_at: daysAgo(now, 12),
+        finished_at: daysAgo(now, 12),
+      },
+      ...Array.from({ length: 11 }, (_, index) => ({
+        job_id: "eleven-day-failing",
+        status: "failed" as const,
+        started_at: daysAgo(now, 11 - index),
+        finished_at: daysAgo(now, 11 - index),
+      })),
+      {
+        job_id: "three-consec",
+        status: "completed",
+        started_at: daysAgo(now, 1),
+        finished_at: daysAgo(now, 1),
+      },
+      ...Array.from({ length: 3 }, (_, index) => ({
+        job_id: "three-consec",
+        status: "failed" as const,
+        started_at: daysAgo(now, 0.75 - index * 0.1),
+        finished_at: daysAgo(now, 0.75 - index * 0.1),
+      })),
+    ];
+
+    dbMock.execute.mockResolvedValue({
+      rows: buildSqlRows(seedJobs, seedExecutions, now),
+    });
+
+    const { getRecurringJobHealth } = await import("./health.js");
+    const rows = await getRecurringJobHealth();
+    const byName = Object.fromEntries(rows.map((row) => [row.name, row]));
+
+    expect(byName["healthy-daily"].isFlagged).toBe(false);
+    expect(byName["new-recurring-job"].isFlagged).toBe(false);
+
+    expect(byName["sync-meta-comments-daily"].isFlagged).toBe(true);
+    expect(byName["sync-meta-comments-daily"].consecutiveFailures).toBe(11);
+    expect(byName["sync-meta-comments-daily"].flagReasons).toEqual(
+      expect.arrayContaining([
+        "11 consecutive failures",
+        "12 days since last success",
+        "enabled job status is failed",
+      ]),
+    );
+
+    expect(byName["three-consec-failure-job"].isFlagged).toBe(true);
+    expect(byName["three-consec-failure-job"].consecutiveFailures).toBe(3);
+    expect(byName["three-consec-failure-job"].flagReasons).toContain(
+      "3 consecutive failures",
+    );
+  });
+});

--- a/apps/api/src/jobs/health.ts
+++ b/apps/api/src/jobs/health.ts
@@ -1,0 +1,315 @@
+import { sql } from "drizzle-orm";
+import type { WebClient } from "@slack/web-api";
+import { db } from "../db/client.js";
+import { settings } from "@aura/db/schema";
+import { safePostMessage } from "../lib/slack-messaging.js";
+import { resolveSlackDestination } from "../tools/slack.js";
+import { logger } from "../lib/logger.js";
+
+export const DEFAULT_FOUNDER_USER_ID = "U0678NQJ2";
+export const RECURRING_JOB_HEALTH_MONITOR_SCRIPT =
+  "internal:recurring-job-health-monitor";
+
+const HEALTH_TIMEZONE = "Europe/Zurich";
+const DAILY_DM_SETTING_PREFIX = "recurring_job_health:last_dm";
+
+export interface JobHealthRow {
+  id: string;
+  name: string;
+  cronSchedule: string;
+  status: string;
+  enabled: boolean;
+  requestedBy: string;
+  lastSuccessfulRun: Date | null;
+  consecutiveFailures: number;
+  daysSinceLastSuccess: number | null;
+  isFlagged: boolean;
+  flagReasons: string[];
+}
+
+interface RawJobHealthRow {
+  id: string;
+  name: string;
+  cron_schedule: string | null;
+  status: string;
+  enabled: boolean | number | string;
+  requested_by: string;
+  last_successful_run: Date | string | null;
+  consecutive_failures: number | string | null;
+  days_since_last_success: number | string | null;
+}
+
+function extractRows(result: unknown): RawJobHealthRow[] {
+  return ((result as any).rows ?? result) as RawJobHealthRow[];
+}
+
+function parseDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parseNumber(value: number | string | null | undefined): number | null {
+  if (value == null) return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseEnabled(value: boolean | number | string): boolean {
+  return value === true || value === 1 || value === "1" || value === "true";
+}
+
+function flagReasonsFor(row: {
+  status: string;
+  enabled: boolean;
+  consecutiveFailures: number;
+  daysSinceLastSuccess: number | null;
+}): string[] {
+  const reasons: string[] = [];
+
+  if (row.consecutiveFailures >= 3) {
+    reasons.push(`${row.consecutiveFailures} consecutive failures`);
+  }
+  if (row.daysSinceLastSuccess != null && row.daysSinceLastSuccess >= 2) {
+    reasons.push(`${formatDays(row.daysSinceLastSuccess)} days since last success`);
+  }
+  if (row.status === "failed" && row.enabled) {
+    reasons.push("enabled job status is failed");
+  }
+
+  return reasons;
+}
+
+export function normalizeJobHealthRows(rows: RawJobHealthRow[]): JobHealthRow[] {
+  return rows.map((row) => {
+    const enabled = parseEnabled(row.enabled);
+    const consecutiveFailures = parseNumber(row.consecutive_failures) ?? 0;
+    const daysSinceLastSuccess = parseNumber(row.days_since_last_success);
+    const lastSuccessfulRun = parseDate(row.last_successful_run);
+    const normalized = {
+      id: row.id,
+      name: row.name,
+      cronSchedule: row.cron_schedule ?? "",
+      status: row.status,
+      enabled,
+      requestedBy: row.requested_by,
+      lastSuccessfulRun,
+      consecutiveFailures,
+      daysSinceLastSuccess,
+    };
+    const flagReasons = flagReasonsFor(normalized);
+
+    return {
+      ...normalized,
+      isFlagged: flagReasons.length > 0,
+      flagReasons,
+    };
+  });
+}
+
+export async function getRecurringJobHealth(): Promise<JobHealthRow[]> {
+  const result = await db.execute(sql`
+    WITH last_success AS (
+      SELECT job_id, MAX(finished_at) AS last_successful_run
+      FROM job_executions
+      WHERE status = 'completed'
+      GROUP BY job_id
+    ),
+    consec_fails AS (
+      SELECT je.job_id,
+             COUNT(*) FILTER (
+               WHERE je.status = 'failed'
+                 AND je.started_at > COALESCE(ls.last_successful_run, '1970-01-01'::timestamptz)
+             ) AS consecutive_failures
+      FROM job_executions je
+      LEFT JOIN last_success ls ON ls.job_id = je.job_id
+      GROUP BY je.job_id
+    )
+    SELECT j.id,
+           j.name,
+           j.cron_schedule,
+           j.status,
+           j.enabled,
+           j.requested_by,
+           ls.last_successful_run,
+           COALESCE(cf.consecutive_failures, 0) AS consecutive_failures,
+           EXTRACT(EPOCH FROM (NOW() - ls.last_successful_run)) / 86400 AS days_since_last_success
+    FROM jobs j
+    LEFT JOIN last_success ls ON ls.job_id = j.id
+    LEFT JOIN consec_fails cf ON cf.job_id = j.id
+    WHERE j.enabled = 1
+      AND j.cron_schedule IS NOT NULL
+      AND j.cron_schedule != ''
+    ORDER BY
+      CASE WHEN j.status = 'failed' THEN 0 ELSE 1 END,
+      COALESCE(cf.consecutive_failures, 0) DESC,
+      ls.last_successful_run ASC NULLS FIRST,
+      j.name ASC
+  `);
+
+  return normalizeJobHealthRows(extractRows(result));
+}
+
+function localDateKey(date: Date, timezone = HEALTH_TIMEZONE): string {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
+
+function formatDateTime(date: Date | null): string {
+  if (!date) return "never";
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: HEALTH_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day} ${byType.hour}:${byType.minute}`;
+}
+
+function formatDays(days: number): string {
+  return days >= 10 ? days.toFixed(0) : days.toFixed(1);
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 3)}...`;
+}
+
+function formatSlackTable(rows: JobHealthRow[]): string {
+  const headers = ["Job", "Last Success", "Fails", "Days", "Status", "Cron"];
+  const body = rows.map((row) => [
+    truncate(row.name, 34),
+    formatDateTime(row.lastSuccessfulRun),
+    String(row.consecutiveFailures),
+    row.daysSinceLastSuccess == null ? "n/a" : formatDays(row.daysSinceLastSuccess),
+    row.status,
+    truncate(row.cronSchedule, 18),
+  ]);
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...body.map((row) => row[index].length)),
+  );
+  const formatRow = (row: string[]) =>
+    row.map((cell, index) => cell.padEnd(widths[index])).join(" | ");
+
+  return [
+    formatRow(headers),
+    widths.map((width) => "-".repeat(width)).join("-|-"),
+    ...body.map(formatRow),
+  ].join("\n");
+}
+
+export function formatRecurringJobHealthMessage(
+  rows: JobHealthRow[],
+  now = new Date(),
+): string {
+  const flagged = rows.filter((row) => row.isFlagged);
+  const date = localDateKey(now);
+  const reasonLines = flagged.map(
+    (row) => `- *${row.name}*: ${row.flagReasons.join("; ")}`,
+  );
+
+  return [
+    `*Recurring job health alert* (${date})`,
+    "",
+    `${flagged.length} of ${rows.length} enabled recurring jobs need attention.`,
+    "",
+    "```",
+    formatSlackTable(flagged),
+    "```",
+    "",
+    "*Why these were flagged*",
+    ...reasonLines,
+  ].join("\n");
+}
+
+function notificationSettingKey(founderUserId: string, dateKey: string): string {
+  return `${DAILY_DM_SETTING_PREFIX}:${founderUserId}:${dateKey}`;
+}
+
+async function claimDailyFounderNotification(
+  founderUserId: string,
+  dateKey: string,
+  flaggedRows: JobHealthRow[],
+): Promise<boolean> {
+  const key = notificationSettingKey(founderUserId, dateKey);
+  const value = JSON.stringify({
+    notifiedAt: new Date().toISOString(),
+    flaggedJobIds: flaggedRows.map((row) => row.id),
+  });
+
+  const inserted = await db
+    .insert(settings)
+    .values({
+      key,
+      value,
+      updatedBy: RECURRING_JOB_HEALTH_MONITOR_SCRIPT,
+      updatedAt: new Date(),
+    })
+    .onConflictDoNothing()
+    .returning({ key: settings.key });
+
+  return inserted.length > 0;
+}
+
+export async function runRecurringJobHealthMonitor(options?: {
+  founderUserId?: string;
+  slackClient?: WebClient;
+  now?: Date;
+}): Promise<string> {
+  const founderUserId =
+    options?.founderUserId || process.env.FOUNDER_USER_ID || DEFAULT_FOUNDER_USER_ID;
+  const now = options?.now ?? new Date();
+  const rows = await getRecurringJobHealth();
+  const flaggedRows = rows.filter((row) => row.isFlagged);
+
+  if (flaggedRows.length === 0) {
+    return `Recurring job health: all ${rows.length} enabled recurring jobs are healthy.`;
+  }
+
+  const dateKey = localDateKey(now);
+  const claimed = await claimDailyFounderNotification(founderUserId, dateKey, flaggedRows);
+  if (!claimed) {
+    return `Recurring job health: ${flaggedRows.length} job(s) need attention; skipped duplicate DM for ${founderUserId} on ${dateKey}.`;
+  }
+
+  let client = options?.slackClient;
+  if (!client) {
+    const { WebClient } = await import("@slack/web-api");
+    client = new WebClient(process.env.SLACK_BOT_TOKEN || "");
+  }
+  const dmChannelId = await resolveSlackDestination(client, founderUserId);
+
+  if (!dmChannelId) {
+    throw new Error(`Could not open Slack DM for founder ${founderUserId}`);
+  }
+
+  const message = formatRecurringJobHealthMessage(rows, now);
+  const postResult = await safePostMessage(client, {
+    channel: dmChannelId,
+    text: message,
+    unfurl_links: false,
+    unfurl_media: false,
+  });
+
+  if (!postResult.ok) {
+    throw new Error(`Slack rejected recurring job health DM for ${founderUserId}`);
+  }
+
+  logger.warn("Recurring job health monitor sent alert", {
+    founderUserId,
+    flaggedJobs: flaggedRows.map((row) => row.name),
+  });
+
+  return `Recurring job health: sent ${flaggedRows.length} flagged job(s) to ${founderUserId}.`;
+}

--- a/apps/api/src/jobs/seeds/index.ts
+++ b/apps/api/src/jobs/seeds/index.ts
@@ -1,0 +1,6 @@
+export {
+  RECURRING_JOB_HEALTH_MONITOR_DESCRIPTION,
+  RECURRING_JOB_HEALTH_MONITOR_NAME,
+  getRecurringJobHealthMonitorSeed,
+  seedRecurringJobHealthMonitor,
+} from "./recurring-job-health.js";

--- a/apps/api/src/jobs/seeds/recurring-job-health.ts
+++ b/apps/api/src/jobs/seeds/recurring-job-health.ts
@@ -1,0 +1,64 @@
+import { jobs } from "@aura/db/schema";
+import { db } from "../../db/client.js";
+import {
+  DEFAULT_FOUNDER_USER_ID,
+  RECURRING_JOB_HEALTH_MONITOR_SCRIPT,
+} from "../health.js";
+
+export const RECURRING_JOB_HEALTH_MONITOR_NAME =
+  "recurring-job-health-monitor";
+
+export const RECURRING_JOB_HEALTH_MONITOR_DESCRIPTION =
+  "Daily survey of recurring job health. DMs founder if any recurring job has consecutive failures >= 3 OR days since last success >= 2 OR status=failed with enabled=true.";
+
+export function getRecurringJobHealthMonitorSeed() {
+  return {
+    name: RECURRING_JOB_HEALTH_MONITOR_NAME,
+    description: RECURRING_JOB_HEALTH_MONITOR_DESCRIPTION,
+    playbook: null,
+    script: RECURRING_JOB_HEALTH_MONITOR_SCRIPT,
+    cronSchedule: "0 9 * * *",
+    frequencyConfig: null,
+    channelId: null,
+    threadTs: null,
+    executeAt: null,
+    requestedBy: process.env.FOUNDER_USER_ID || DEFAULT_FOUNDER_USER_ID,
+    priority: "normal",
+    status: "pending",
+    timezone: "Europe/Zurich",
+    result: null,
+    retries: 0,
+    enabled: 1,
+    requiredCredentialIds: [],
+    updatedAt: new Date(),
+  } satisfies typeof jobs.$inferInsert;
+}
+
+export async function seedRecurringJobHealthMonitor(): Promise<void> {
+  const seed = getRecurringJobHealthMonitorSeed();
+
+  await db
+    .insert(jobs)
+    .values(seed)
+    .onConflictDoUpdate({
+      target: [jobs.workspaceId, jobs.name],
+      set: {
+        description: seed.description,
+        playbook: seed.playbook,
+        script: seed.script,
+        cronSchedule: seed.cronSchedule,
+        frequencyConfig: seed.frequencyConfig,
+        channelId: seed.channelId,
+        threadTs: seed.threadTs,
+        executeAt: seed.executeAt,
+        requestedBy: seed.requestedBy,
+        priority: seed.priority,
+        status: seed.status,
+        timezone: seed.timezone,
+        retries: seed.retries,
+        enabled: seed.enabled,
+        requiredCredentialIds: seed.requiredCredentialIds,
+        updatedAt: seed.updatedAt,
+      },
+    });
+}

--- a/apps/api/src/scripts/seed-recurring-health.ts
+++ b/apps/api/src/scripts/seed-recurring-health.ts
@@ -1,0 +1,28 @@
+import { config } from "dotenv";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const isProd = process.argv.includes("--prod");
+const envFile = isProd ? ".env.production" : ".env.local";
+
+config({ path: resolve(repoRoot, envFile) });
+if (isProd) console.log("Using .env.production (--prod)");
+
+const {
+  RECURRING_JOB_HEALTH_MONITOR_NAME,
+  getRecurringJobHealthMonitorSeed,
+  seedRecurringJobHealthMonitor,
+} = await import("../jobs/seeds/index.js");
+
+try {
+  const seed = getRecurringJobHealthMonitorSeed();
+  await seedRecurringJobHealthMonitor();
+  console.log(
+    `Seeded recurring job "${RECURRING_JOB_HEALTH_MONITOR_NAME}" (${seed.cronSchedule} ${seed.timezone}) for ${seed.requestedBy}.`,
+  );
+} catch (error) {
+  console.error("Failed to seed recurring job health monitor:", error);
+  process.exit(1);
+}

--- a/content/docs/concepts/jobs.mdx
+++ b/content/docs/concepts/jobs.mdx
@@ -1,0 +1,31 @@
+---
+title: "Jobs"
+description: "How Aura schedules recurring work and monitors job health."
+---
+
+# Jobs
+
+Aura stores one-shot tasks, recurring work, and continuations in the `jobs` table.
+The heartbeat cron wakes up regularly, finds due enabled jobs, and sends them
+through the normal job executor.
+
+## Health monitor
+
+Aura includes a seeded recurring job named `recurring-job-health-monitor`.
+It runs daily at 09:00 Europe/Zurich (`0 9 * * *`) and surveys every enabled
+recurring job (`enabled = true` and `cron_schedule IS NOT NULL`).
+
+The monitor flags a job when any of these are true:
+
+- it has at least 3 consecutive failed executions since its last success
+- its last successful execution was at least 2 days ago
+- the job is still enabled but its current status is `failed`
+
+When at least one job is flagged, the monitor sends Joan a single Slack DM with
+a table containing the job name, last successful run, consecutive failure count,
+current status, and cron schedule. The DM is idempotent: each founder can receive
+at most one recurring-job health alert per calendar day.
+
+This monitor is implemented as a discoverable script-only job rather than as
+inline heartbeat logic, so it appears in `list_jobs`, can be disabled or tuned
+like any other recurring job, and avoids LLM cost for the daily survey.

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -26,6 +26,7 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `SLACK_USER_TOKEN` | Slack user token (`xoxp-...`) for message search |
 | `GITHUB_TOKEN` | GitHub PAT for reading source code and opening PRs |
 | `AURA_ADMIN_USER_IDS` | Comma-separated Slack user IDs with admin access. Fallback for users without a DB role — see [Permissions](/permissions) |
+| `FOUNDER_USER_ID` | Slack user ID that should receive founder-facing operational alerts such as recurring job health DMs |
 | `E2B_API_KEY` | E2B API key for sandbox access |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings and audio transcription |
 | `AURA_BOT_USER_ID` | Aura's own Slack bot user ID |

--- a/content/docs/docs.json
+++ b/content/docs/docs.json
@@ -54,6 +54,7 @@
             "group": "Core Systems",
             "pages": [
               "memory-system",
+              "concepts/jobs",
               "self-improvement",
               "permissions"
             ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `getRecurringJobHealth()` and a script-only recurring health monitor that DMs the founder when enabled recurring jobs exceed failure thresholds.
- Adds a seed definition plus `pnpm --filter aura-api jobs:seed-health` for one-time bootstrap.
- Documents the health monitor and founder alert env var.

Closes #963

## Bootstrap SQL
If the operator script is not used, seed the job with:

```sql
INSERT INTO jobs (name, description, script, cron_schedule, channel_id, thread_ts, execute_at, requested_by, priority, status, timezone, retries, enabled, required_credential_ids, updated_at)
VALUES (
  'recurring-job-health-monitor',
  'Daily survey of recurring job health. DMs founder if any recurring job has consecutive failures >= 3 OR days since last success >= 2 OR status=failed with enabled=true.',
  'internal:recurring-job-health-monitor',
  '0 9 * * *',
  NULL,
  NULL,
  NULL,
  COALESCE(current_setting('app.founder_user_id', true), 'U0678NQJ2'),
  'normal',
  'pending',
  'Europe/Zurich',
  0,
  1,
  '[]'::jsonb,
  NOW()
)
ON CONFLICT (workspace_id, name) DO UPDATE SET
  description = EXCLUDED.description,
  script = EXCLUDED.script,
  cron_schedule = EXCLUDED.cron_schedule,
  channel_id = EXCLUDED.channel_id,
  thread_ts = EXCLUDED.thread_ts,
  execute_at = EXCLUDED.execute_at,
  requested_by = EXCLUDED.requested_by,
  priority = EXCLUDED.priority,
  status = EXCLUDED.status,
  timezone = EXCLUDED.timezone,
  retries = EXCLUDED.retries,
  enabled = EXCLUDED.enabled,
  required_credential_ids = EXCLUDED.required_credential_ids,
  updated_at = NOW();
```

## Testing
- `pnpm --filter aura-api test -- src/jobs/health.test.ts`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4426f0b-3925-431d-8e7f-0d77f5a0372e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4426f0b-3925-431d-8e7f-0d77f5a0372e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

