### PR TITLE
Add deferred tool manifest and reframe capabilities

### DIFF
--- a/apps/api/src/lib/agents.ts
+++ b/apps/api/src/lib/agents.ts
@@ -8,6 +8,8 @@ import {
   withCacheControl,
 } from "./ai.js";
 import { createSlackTools } from "../tools/slack.js";
+import { getDeferredToolManifest } from "../tools/deferred.js";
+import { appendDeferredToolsBlock } from "../personality/system-prompt.js";
 import {
   createInteractivePrepareStep,
   createHeadlessPrepareStep,
@@ -42,10 +44,14 @@ export async function createInteractiveAgent(
   const { modelId, model } = await getMainModel();
   const tools = await createSlackTools(options.slackClient, options.context, modelId, options.invocationId);
   const stepModelIds: string[] = [];
+  const dynamicContext = appendDeferredToolsBlock(
+    options.dynamicContext,
+    getDeferredToolManifest(tools),
+  );
   const systemMessages = buildCachedSystemMessages(
     options.stablePrefix,
     options.conversationContext,
-    options.dynamicContext,
+    dynamicContext,
   );
 
   const agent = new ToolLoopAgent({
@@ -56,7 +62,7 @@ export async function createInteractiveAgent(
     prepareStep: createInteractivePrepareStep({
       stablePrefix: options.stablePrefix,
       conversationContext: options.conversationContext,
-      dynamicContext: options.dynamicContext,
+      dynamicContext,
       modelId,
       defaultEffort: "medium",
       thinkingBudget: 8000,
@@ -87,14 +93,18 @@ export async function createHeadlessAgent(options: HeadlessAgentOptions) {
   const { modelId, model } = await getMainModel();
   const tools = await createSlackTools(options.slackClient, options.context, modelId, options.invocationId);
   const stepModelIds: string[] = [];
+  const systemPrompt = appendDeferredToolsBlock(
+    options.systemPrompt,
+    getDeferredToolManifest(tools),
+  ) ?? options.systemPrompt;
 
   const agent = new ToolLoopAgent({
     model,
     tools,
-    instructions: withCacheControl(options.systemPrompt),
+    instructions: withCacheControl(systemPrompt),
     stopWhen: stepCountIs(HEADLESS_STEP_LIMIT),
     prepareStep: createHeadlessPrepareStep({
-      stablePrefix: options.systemPrompt,
+      stablePrefix: systemPrompt,
       modelId,
       defaultEffort: "medium",
       thinkingBudget: 16000,
@@ -119,10 +129,15 @@ export interface SubagentAgentOptions {
 }
 
 export function createSubAgent(options: SubagentAgentOptions) {
+  const systemPrompt = appendDeferredToolsBlock(
+    options.systemPrompt,
+    getDeferredToolManifest(options.tools),
+  ) ?? options.systemPrompt;
+
   return new ToolLoopAgent({
     model: options.model,
     tools: options.tools,
-    instructions: options.systemPrompt,
+    instructions: systemPrompt,
     stopWhen: stepCountIs(options.maxSteps ?? 50),
   });
 }

--- a/apps/api/src/personality/system-prompt.test.ts
+++ b/apps/api/src/personality/system-prompt.test.ts
@@ -13,7 +13,7 @@ vi.mock("../lib/logger.js", () => ({
   },
 }));
 
-import { buildDynamicContext } from "./system-prompt.js";
+import { buildDynamicContext, formatDeferredTools } from "./system-prompt.js";
 
 function extractCapabilitiesBlock(prompt: string): string {
   const match = prompt.match(/<capabilities>[\s\S]*<\/capabilities>/);
@@ -21,15 +21,18 @@ function extractCapabilitiesBlock(prompt: string): string {
 }
 
 describe("buildDynamicContext capabilities", () => {
-  it("renders sorted sandbox credential names in the expected format", () => {
+  it("renders sorted sandbox credential names grouped by capability", () => {
     const prompt = buildDynamicContext({
       sandboxEnvNames: ["NOTION_API_KEY", "GITHUB_TOKEN"],
     });
 
     const expected = `<capabilities>
-You have these credentials/API keys available in your sandbox env (run_command, etc.). Names only — never paste or log values. Use them when relevant; don't claim you "don't have access" without checking first.
-- GITHUB_TOKEN
-- NOTION_API_KEY
+You have access to these systems from the sandbox environment. Credential names are identifiers only -- never paste or log values. Prefer typed Aura tools and safe CLIs before raw HTTP/API calls.
+
+Hard rule: Seeing a credential name is not a reason to use it -- it's a reason to check if a typed tool wraps it. Before \`curl\` with a secret, run \`tool_search_tool_bm25\` for the domain.
+
+- GitHub: \`GITHUB_TOKEN\` -- prefer the \`gh\` CLI in the sandbox; for issue/PR ops use it directly
+- Other available credentials: \`NOTION_API_KEY\` -- search typed tools for the relevant domain before raw API use
 </capabilities>`;
 
     expect(extractCapabilitiesBlock(prompt)).toBe(expected);
@@ -46,8 +49,30 @@ You have these credentials/API keys available in your sandbox env (run_command, 
     });
 
     const block = extractCapabilitiesBlock(prompt);
-    expect(block).toContain("- NOTION_API_KEY");
+    expect(block).toContain("`NOTION_API_KEY`");
     expect(block).not.toContain(secretValue);
+  });
+
+  it("contains the hard guardrail line inside the capabilities block", () => {
+    const prompt = buildDynamicContext({
+      sandboxEnvNames: ["SLACK_BOT_TOKEN"],
+    });
+
+    expect(extractCapabilitiesBlock(prompt)).toContain(
+      "Seeing a credential name is not a reason to use it -- it's a reason to check if a typed tool wraps it. Before `curl` with a secret, run `tool_search_tool_bm25` for the domain.",
+    );
+  });
+
+  it("annotates CURSOR_API_KEY with Cursor tool wrappers when present", () => {
+    const prompt = buildDynamicContext({
+      sandboxEnvNames: ["CURSOR_API_KEY"],
+      availableToolNames: ["dispatch_cursor_agent", "check_cursor_agent"],
+    });
+
+    const block = extractCapabilitiesBlock(prompt);
+    expect(block).toContain("`CURSOR_API_KEY`");
+    expect(block).toContain("`dispatch_cursor_agent`");
+    expect(block).toContain("`check_cursor_agent`");
   });
 
   it("omits the capabilities block when no credential names are available", () => {
@@ -55,6 +80,55 @@ You have these credentials/API keys available in your sandbox env (run_command, 
       "<capabilities>",
     );
     expect(buildDynamicContext({})).not.toContain("<capabilities>");
+  });
+});
+
+describe("deferred tools manifest", () => {
+  it("renders a deferred_tools block when deferred tools exist", () => {
+    const prompt = buildDynamicContext({
+      deferredTools: [
+        {
+          name: "dispatch_cursor_agent",
+          description: "dispatch async coding agent to Aura repo",
+        },
+        {
+          name: "check_cursor_agent",
+          description: "check status of dispatched agent",
+        },
+      ],
+    });
+
+    expect(prompt).toContain(`<deferred_tools>
+Available on demand (call tool_search_tool_bm25 to load schemas):
+- check_cursor_agent: check status of dispatched agent
+- dispatch_cursor_agent: dispatch async coding agent to Aura repo
+</deferred_tools>`);
+  });
+
+  it("excludes manifest entries that are already immediate tools", () => {
+    const manifest = formatDeferredTools(
+      [
+        {
+          name: "dispatch_cursor_agent",
+          description: "dispatch async coding agent to Aura repo",
+        },
+        {
+          name: "run_command",
+          description: "run shell commands in the sandbox",
+        },
+      ],
+      ["run_command"],
+    );
+
+    expect(manifest).toContain("- dispatch_cursor_agent:");
+    expect(manifest).not.toContain("run_command");
+  });
+
+  it("omits the deferred_tools block when there are no deferred tools", () => {
+    expect(buildDynamicContext({ deferredTools: [] })).not.toContain(
+      "<deferred_tools>",
+    );
+    expect(formatDeferredTools(undefined)).toBe("");
   });
 });
 

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -46,6 +46,11 @@ interface SystemPromptContext {
   entitySummaries?: EntitySummary[];
 }
 
+export interface DeferredToolSummary {
+  name: string;
+  description: string;
+}
+
 /**
  * Aura's base personality — the soul of the system.
  * Version-controlled. Changes are deliberate.
@@ -414,14 +419,148 @@ function formatStorage(envNames: string[]): string {
   return `<storage>\n${lines.join("\n")}\n</storage>`;
 }
 
-function formatCapabilities(envNames: string[]): string {
+const CAPABILITY_DOMAINS: Array<{
+  label: string;
+  envNames: string[];
+  guidance: string;
+  wrappers?: string[];
+}> = [
+  {
+    label: "Cursor Cloud Agents",
+    envNames: ["CURSOR_API_KEY"],
+    wrappers: [
+      "dispatch_cursor_agent",
+      "check_cursor_agent",
+      "followup_cursor_agent",
+      "list_cursor_agents",
+      "stop_cursor_agent",
+    ],
+    guidance: "dispatch and manage async coding agents with the typed Cursor tools",
+  },
+  {
+    label: "GitHub",
+    envNames: ["GITHUB_TOKEN"],
+    guidance: "prefer the `gh` CLI in the sandbox; for issue/PR ops use it directly",
+  },
+  {
+    label: "Slack",
+    envNames: ["SLACK_BOT_TOKEN", "SLACK_USER_TOKEN"],
+    wrappers: [
+      "search_messages",
+      "read_channel_history",
+      "send_channel_message",
+      "send_direct_message",
+      "read_thread_replies",
+    ],
+    guidance: "use the Slack tools, not Web API curl",
+  },
+  {
+    label: "Postgres",
+    envNames: ["DATABASE_URL"],
+    guidance: "use `psql $DATABASE_URL` in the sandbox for direct database inspection",
+  },
+  {
+    label: "BigQuery",
+    envNames: ["GOOGLE_BQ_CREDENTIALS"],
+    wrappers: [
+      "bq_list_datasets",
+      "bq_list_tables",
+      "bq_inspect_table",
+      "bq_execute_query",
+    ],
+    guidance: "use the BigQuery tools, especially `bq_execute_query`, not bq CLI curl",
+  },
+  {
+    label: "E2B Sandboxes",
+    envNames: ["E2B_API_KEY", "E2B_PAT"],
+    wrappers: ["run_command", "dispatch_headless", "run_subagent"],
+    guidance: "use the sandbox tools instead of calling E2B APIs directly",
+  },
+];
+
+function formatToolList(toolNames: string[]): string {
+  return toolNames.map((name) => `\`${name}\``).join(" / ");
+}
+
+function formatCapabilities(
+  envNames: string[],
+  availableToolNames?: string[],
+): string {
   const names = [...new Set(envNames)].sort();
   if (names.length === 0) return "";
 
+  const availableTools = availableToolNames
+    ? new Set(availableToolNames)
+    : null;
+  const covered = new Set<string>();
+  const lines: string[] = [
+    "You have access to these systems from the sandbox environment. Credential names are identifiers only -- never paste or log values. Prefer typed Aura tools and safe CLIs before raw HTTP/API calls.",
+    "",
+    "Hard rule: Seeing a credential name is not a reason to use it -- it's a reason to check if a typed tool wraps it. Before `curl` with a secret, run `tool_search_tool_bm25` for the domain.",
+    "",
+  ];
+
+  for (const domain of CAPABILITY_DOMAINS) {
+    const presentEnvNames = domain.envNames.filter((name) => names.includes(name));
+    if (presentEnvNames.length === 0) continue;
+    presentEnvNames.forEach((name) => covered.add(name));
+
+    const presentWrappers = domain.wrappers?.filter((name) =>
+      availableTools ? availableTools.has(name) : true,
+    ) ?? [];
+    const wrapperText = presentWrappers.length > 0
+      ? ` -> ${formatToolList(presentWrappers)}`
+      : "";
+    lines.push(
+      `- ${domain.label}: ${presentEnvNames.map((name) => `\`${name}\``).join(" / ")}${wrapperText} -- ${domain.guidance}`,
+    );
+  }
+
+  const uncategorized = names.filter((name) => !covered.has(name));
+  if (uncategorized.length > 0) {
+    lines.push(
+      `- Other available credentials: ${uncategorized.map((name) => `\`${name}\``).join(", ")} -- search typed tools for the relevant domain before raw API use`,
+    );
+  }
+
   return `<capabilities>
-You have these credentials/API keys available in your sandbox env (run_command, etc.). Names only — never paste or log values. Use them when relevant; don't claim you "don't have access" without checking first.
-${names.map((name) => `- ${name}`).join("\n")}
+${lines.join("\n")}
 </capabilities>`;
+}
+
+export function formatDeferredTools(
+  deferredTools: DeferredToolSummary[] | undefined,
+  immediateToolNames: string[] = [],
+): string {
+  if (!deferredTools?.length) return "";
+
+  const immediateTools = new Set(immediateToolNames);
+  const seen = new Set<string>();
+  const entries = deferredTools
+    .filter((tool) => {
+      if (immediateTools.has(tool.name) || seen.has(tool.name)) return false;
+      seen.add(tool.name);
+      return true;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (entries.length === 0) return "";
+
+  return `<deferred_tools>
+Available on demand (call tool_search_tool_bm25 to load schemas):
+${entries.map((tool) => `- ${tool.name}: ${tool.description}`).join("\n")}
+</deferred_tools>`;
+}
+
+export function appendDeferredToolsBlock(
+  prompt: string | undefined,
+  deferredTools: DeferredToolSummary[] | undefined,
+  immediateToolNames: string[] = [],
+): string | undefined {
+  const block = formatDeferredTools(deferredTools, immediateToolNames);
+  if (!block) return prompt;
+  if (prompt?.includes("<deferred_tools>")) return prompt;
+  return prompt ? `${prompt}\n\n${block}` : block;
 }
 
 export interface SystemPromptLayers {
@@ -606,6 +745,9 @@ export function buildDynamicContext(context: {
   threadTs?: string;
   usageStats?: string;
   sandboxEnvNames?: string[];
+  availableToolNames?: string[];
+  deferredTools?: DeferredToolSummary[];
+  immediateToolNames?: string[];
 }): string {
   let s = `<runtime>\n## Current context\n\n${getCurrentTimeContext(context.userTimezone)}`;
   if (context.modelId) s += `\nActive model: \`${context.modelId}\``;
@@ -613,7 +755,15 @@ export function buildDynamicContext(context: {
   if (context.threadTs) s += `\nCurrent thread_ts: ${context.threadTs}`;
   if (context.usageStats) s += `\n\n${context.usageStats}`;
   s += "\n</runtime>";
-  const capabilities = formatCapabilities(context.sandboxEnvNames ?? []);
+  const deferredTools = formatDeferredTools(
+    context.deferredTools,
+    context.immediateToolNames,
+  );
+  if (deferredTools) s += `\n\n${deferredTools}`;
+  const capabilities = formatCapabilities(
+    context.sandboxEnvNames ?? [],
+    context.availableToolNames,
+  );
   if (capabilities) s += `\n\n${capabilities}`;
   const storage = formatStorage(context.sandboxEnvNames ?? []);
   if (storage) s += `\n\n${storage}`;

--- a/apps/api/src/pipeline/generate.ts
+++ b/apps/api/src/pipeline/generate.ts
@@ -10,6 +10,8 @@ import {
 } from "ai";
 import { createInteractivePrepareStep } from "./prepare-step.js";
 import { buildCachedSystemMessages, getEscalationModel } from "../lib/ai.js";
+import { getDeferredToolManifest } from "../tools/deferred.js";
+import { appendDeferredToolsBlock } from "../personality/system-prompt.js";
 
 /**
  * Channel-agnostic agentic stream.
@@ -50,10 +52,14 @@ export interface AgenticStreamOptions {
 
 export function createAgenticStream(options: AgenticStreamOptions) {
   const stepModelIds: string[] = [];
+  const dynamicContext = appendDeferredToolsBlock(
+    options.dynamicContext,
+    getDeferredToolManifest(options.tools),
+  ) ?? options.dynamicContext;
   const prepareStep = createInteractivePrepareStep({
     stablePrefix: options.stablePrefix,
     conversationContext: options.conversationContext,
-    dynamicContext: options.dynamicContext,
+    dynamicContext,
     thinkingBudget: options.thinkingBudget ?? 8000,
     modelId: options.modelId,
     recordStepModelId: (stepNumber, stepModelId) => {
@@ -68,7 +74,7 @@ export function createAgenticStream(options: AgenticStreamOptions) {
   const system = buildCachedSystemMessages(
     options.stablePrefix,
     options.conversationContext,
-    options.dynamicContext,
+    dynamicContext,
   );
 
   return streamText({

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -432,7 +432,11 @@ dashboardChatApp.openapi(postChatRoute, async (c) => {
       modelIdOverride: modelId,
     });
 
-    const tools = await createCoreTools({ userId, channelId: "dashboard" });
+    const tools = await createCoreTools(
+      { userId, channelId: "dashboard" },
+      undefined,
+      modelId,
+    );
 
     const sanitizedMessages = sanitizeAssistantPartOrder(messages);
     const modelMessages = await convertToModelMessages(sanitizedMessages);

--- a/apps/api/src/tools/core.ts
+++ b/apps/api/src/tools/core.ts
@@ -19,9 +19,10 @@ import { createJobTools } from "./jobs.js";
 import { createSubagentTools } from "./subagents.js";
 import { createScratchpadTools } from "./scratchpad.js";
 import { createMemoryTools } from "./memories.js";
-import { filterToolsByCredentials } from "../lib/tool.js";
+import { filterToolsByCredentials, registerToolNames } from "../lib/tool.js";
 import { resolveUserCredentials } from "../lib/permissions.js";
 import { logger } from "../lib/logger.js";
+import { applyAnthropicToolDiscovery } from "./deferred.js";
 
 /**
  * Channel-agnostic tools available to every connector (Slack, Dashboard, etc.).
@@ -34,7 +35,11 @@ import { logger } from "../lib/logger.js";
  *
  * Filters tools based on the calling user's credential access.
  */
-export async function createCoreTools(context?: ScheduleContext, preResolvedCreds?: Set<string>) {
+export async function createCoreTools(
+  context?: ScheduleContext,
+  preResolvedCreds?: Set<string>,
+  modelId?: string,
+) {
   const allTools = {
     ...createDateTimeTools(),
     ...createNoteTools(context),
@@ -61,12 +66,16 @@ export async function createCoreTools(context?: ScheduleContext, preResolvedCred
 
   try {
     const userCreds = preResolvedCreds ?? await resolveUserCredentials(context?.userId);
-    return filterToolsByCredentials(allTools, userCreds);
+    const filteredTools = filterToolsByCredentials(allTools, userCreds);
+    await applyAnthropicToolDiscovery(filteredTools, modelId);
+    return registerToolNames(filteredTools);
   } catch (e: any) {
     logger.warn("createCoreTools: credential resolution failed, returning ungated tools only", {
       userId: context?.userId,
       error: e.message,
     });
-    return filterToolsByCredentials(allTools, new Set());
+    const filteredTools = filterToolsByCredentials(allTools, new Set());
+    await applyAnthropicToolDiscovery(filteredTools, modelId);
+    return registerToolNames(filteredTools);
   }
 }

--- a/apps/api/src/tools/deferred.ts
+++ b/apps/api/src/tools/deferred.ts
@@ -1,0 +1,164 @@
+export interface DeferredToolManifestEntry {
+  name: string;
+  description: string;
+}
+
+export const DEFERRED_TOOL_NAMES = new Set([
+  // BigQuery / Data
+  "bq_list_datasets",
+  "bq_list_tables",
+  "bq_inspect_table",
+  "bq_execute_query",
+  // Google Sheets
+  "read_google_sheet",
+  // Google Drive
+  "search_drive",
+  "read_drive_file",
+  "list_drive_folder",
+  "list_shared_drives",
+  // Calendar
+  "check_calendar",
+  "create_event",
+  "update_event",
+  "delete_event",
+  "find_available_slot",
+  // Canvas
+  "read_canvas",
+  "create_canvas",
+  "edit_canvas",
+  "delete_canvas",
+  "share_canvas",
+  "list_canvases",
+  // Slack Lists (list + get are eager -- used in every bug triage session)
+  "create_slack_list_item",
+  "update_slack_list_item",
+  "delete_slack_list_item",
+  // Email
+  "send_email",
+  "reply_to_email",
+  // Email triage (per-user Gmail)
+  "sync_emails",
+  "email_digest",
+  "update_email_thread",
+  "read_user_emails",
+  "read_user_email",
+  "generate_gmail_auth_url",
+  "create_gmail_draft",
+  "list_gmail_drafts",
+  "delete_gmail_draft",
+  // Dev / Code (run_command is eager -- used reflexively in most sessions)
+  "dispatch_headless",
+  "read_job_trace",
+  "dispatch_cursor_agent",
+  "check_cursor_agent",
+  "followup_cursor_agent",
+  "stop_cursor_agent",
+  "get_cursor_conversation",
+  "list_cursor_agents",
+  // Browser
+  "browse",
+  "download_slack_file",
+  // Voice / Calls
+  "list_voice_agents",
+  "place_call",
+  "send_sms",
+  "send_voice_note",
+  // Directory / Contacts
+  "lookup_workspace_user",
+  "list_workspace_users",
+  "lookup_contact",
+  // Checkpoint
+  "checkpoint_plan",
+  // Resources
+  "ingest_resource",
+  "search_resources",
+  "get_resource",
+  "list_resources",
+  // Subagent
+  "run_subagent",
+  // People
+  "get_person",
+  "update_person",
+]);
+
+function isAnthropicModel(modelId?: string): boolean {
+  return modelId?.startsWith("anthropic/") ?? false;
+}
+
+function toOneLineDescription(description: unknown): string {
+  if (typeof description !== "string") return "deferred tool";
+  const normalized = description.replace(/\s+/g, " ").trim();
+  if (!normalized) return "deferred tool";
+
+  const firstSentence = normalized.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim() ?? normalized;
+  const withoutTerminalPunctuation = firstSentence.replace(/[.!?]$/, "");
+  return withoutTerminalPunctuation.length > 180
+    ? `${withoutTerminalPunctuation.slice(0, 177)}...`
+    : withoutTerminalPunctuation;
+}
+
+function hasDeferredLoading(tool: unknown): boolean {
+  return Boolean(
+    tool &&
+      typeof tool === "object" &&
+      (tool as { providerOptions?: { anthropic?: { deferLoading?: boolean } } })
+        .providerOptions?.anthropic?.deferLoading === true,
+  );
+}
+
+/**
+ * Apply Anthropic's deferred schema loading to infrequently used tools and add
+ * the native BM25 search meta-tool that can load their schemas on demand.
+ */
+export async function applyAnthropicToolDiscovery<T extends Record<string, any>>(
+  tools: T,
+  modelId?: string,
+): Promise<T> {
+  if (!isAnthropicModel(modelId)) return tools;
+
+  const mutableTools = tools as Record<string, any>;
+  const { anthropic } = await import("@ai-sdk/anthropic");
+  // toolSearchBm25_20251119() returns an Anthropic-native tool object that
+  // bypasses defineTool(), so attach the Slack metadata manually.
+  const toolSearch = anthropic.tools.toolSearchBm25_20251119();
+  ((toolSearch as unknown) as Record<string, unknown>).slack = {
+    status: "Searching tools...",
+    detail: (i: { query: string }) => i.query,
+  };
+  mutableTools.toolSearch = toolSearch;
+
+  for (const name of DEFERRED_TOOL_NAMES) {
+    const existing = mutableTools[name];
+    if (!existing) continue;
+    const providerOptions =
+      existing && typeof existing === "object" && "providerOptions" in existing
+        ? (existing as { providerOptions?: Record<string, any> }).providerOptions ?? {}
+        : {};
+    mutableTools[name] = {
+      ...existing,
+      providerOptions: {
+        ...providerOptions,
+        anthropic: {
+          ...(providerOptions.anthropic ?? {}),
+          deferLoading: true,
+        },
+      },
+    };
+  }
+
+  return tools;
+}
+
+export function getDeferredToolManifest(
+  tools: Record<string, unknown>,
+): DeferredToolManifestEntry[] {
+  return Object.entries(tools)
+    .filter(([, tool]) => hasDeferredLoading(tool))
+    .map(([name, tool]) => ({
+      name,
+      description: toOneLineDescription(
+        (tool as { description?: unknown }).description,
+      ),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/api/src/tools/slack.ts
+++ b/apps/api/src/tools/slack.ts
@@ -11,6 +11,7 @@ import { createSubagentTools } from "./subagents.js";
 import { createVoiceTools } from "./voice.js";
 import { createEmailSyncTools } from "./email-sync.js";
 import { createScratchpadTools } from "./scratchpad.js";
+import { applyAnthropicToolDiscovery } from "./deferred.js";
 import type { ScheduleContext } from "@aura/db/schema";
 import { formatForSlack } from "../lib/format.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
@@ -589,7 +590,7 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
 
   const tools: Record<string, any> = {
     // ── Core Tools (channel-agnostic, shared with Dashboard etc.) ────────
-    ...(await createCoreTools(context, userCreds)),
+    ...(await createCoreTools(context, userCreds, modelId)),
 
     list_channels: defineTool({
       description:
@@ -3014,74 +3015,7 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
     if (!(k in filteredTools)) delete tools[k];
   }
 
-  // ── Anthropic Tool Discovery ──────────────────────────────────────
-  // When running on an Anthropic model, mark infrequently-used tools as
-  // deferred so their schemas aren't sent upfront, and register the
-  // tool search meta-tool so Claude can discover them on demand.
-  // Non-Anthropic providers don't support these features.
-  const isAnthropic = modelId?.startsWith("anthropic/") ?? false;
-
-  if (isAnthropic) {
-    const { anthropic } = await import("@ai-sdk/anthropic");
-    // TODO: toolSearchBm25_20251119() returns an Anthropic-native tool object that bypasses
-    // defineTool(), so it never gets the `slack` metadata we use for Slack action cards.
-    // Workaround: cast to any and attach the slack property manually so the pipeline
-    // renders a proper card (status + detail) instead of the fallback "Done" label.
-    // Long-term fix: Anthropic should expose a way to attach metadata to built-in tools,
-    // or we should wrap it in defineTool() once the SDK supports that pattern.
-    const _toolSearch = anthropic.tools.toolSearchBm25_20251119();
-    ((_toolSearch as unknown) as Record<string, unknown>).slack = {
-      status: "Searching tools...",
-      detail: (i: { query: string }) => i.query,
-    };
-    tools.toolSearch = _toolSearch;
-
-    const DEFERRED_TOOLS = new Set([
-      // BigQuery / Data
-      "bq_list_datasets", "bq_list_tables", "bq_inspect_table", "bq_execute_query",
-      // Google Sheets
-      "read_google_sheet",
-      // Google Drive
-      "search_drive", "read_drive_file", "list_drive_folder", "list_shared_drives",
-      // Calendar
-      "check_calendar", "create_event", "update_event", "delete_event", "find_available_slot",
-      // Canvas
-      "read_canvas", "create_canvas", "edit_canvas", "delete_canvas", "share_canvas", "list_canvases",
-      // Slack Lists (list + get are eager -- used in every bug triage session)
-      "create_slack_list_item", "update_slack_list_item", "delete_slack_list_item",
-      // Email
-      "send_email", "reply_to_email",
-      // Email triage (per-user Gmail)
-      "sync_emails", "email_digest", "update_email_thread",
-      "read_user_emails", "read_user_email",
-      "generate_gmail_auth_url", "create_gmail_draft", "list_gmail_drafts", "delete_gmail_draft",
-      // Dev / Code (run_command is eager -- used reflexively in most sessions)
-      "dispatch_headless", "read_job_trace",
-      "dispatch_cursor_agent", "check_cursor_agent", "followup_cursor_agent",
-      "stop_cursor_agent", "get_cursor_conversation", "list_cursor_agents",
-      // Browser
-      "browse", "download_slack_file",
-      // Voice / Calls
-      "list_voice_agents", "place_call", "send_sms", "send_voice_note",
-      // Directory / Contacts
-      "lookup_workspace_user", "list_workspace_users", "lookup_contact",
-      // Checkpoint
-      "checkpoint_plan",
-      // Resources
-      "ingest_resource", "search_resources", "get_resource", "list_resources",
-      // Subagent
-      "run_subagent",
-      // People
-      "get_person", "update_person",
-    ]);
-
-    const deferOpts = { anthropic: { deferLoading: true } };
-    for (const name of DEFERRED_TOOLS) {
-      if (name in tools) {
-        tools[name] = { ...tools[name], providerOptions: deferOpts };
-      }
-    }
-  }
+  await applyAnthropicToolDiscovery(tools, modelId);
 
   return registerToolNames(tools);
 }

--- a/apps/api/src/tools/subagents.ts
+++ b/apps/api/src/tools/subagents.ts
@@ -58,7 +58,7 @@ async function buildToolScope(
     case "slack": {
       if (!client) {
         const { createCoreTools } = await import("./core.js");
-        return await createCoreTools(context, userCreds);
+        return await createCoreTools(context, userCreds, modelId);
       }
       const { createSlackTools } = await import("./slack.js");
       return { ...(await createSlackTools(client, context, modelId)) };
@@ -75,7 +75,7 @@ async function buildToolScope(
     default: {
       if (!client) {
         const { createCoreTools } = await import("./core.js");
-        return await createCoreTools(context, userCreds);
+        return await createCoreTools(context, userCreds, modelId);
       }
       const { createSlackTools } = await import("./slack.js");
       return await createSlackTools(client, context, modelId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a `<deferred_tools>` prompt block listing deferred tool names and one-line descriptions so Aura can discover schemas with `tool_search_tool_bm25`.
- Centralizes Anthropic deferred-tool registration and applies it to Slack, dashboard/core, headless, and subagent paths without changing the deferral mechanism.
- Reframes `<capabilities>` around system access, typed-tool/CLI preference, and an inline hard guardrail against curling secrets.
- Annotates known credentials with preferred wrappers/CLIs, including Cursor, GitHub, Slack, BigQuery, Postgres, and E2B.

Fixes #968.

## Self-edit
This changes Aura's system prompt framing and tool-discovery instructions. The intent is to make deferred tools discoverable while keeping schemas deferred, and to steer secret-backed access toward typed wrappers first.

## Tests
- `pnpm --filter aura-api test -- src/personality/system-prompt.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d802fe48-be98-407b-a268-feceeed8b499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d802fe48-be98-407b-a268-feceeed8b499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

