### PR TITLE
Fix long sandbox command Slack streaming UX

### DIFF
--- a/.cursor/skills/aura-self-modification/SKILL.md
+++ b/.cursor/skills/aura-self-modification/SKILL.md
@@ -54,6 +54,25 @@ run_command("rg 'pattern' /home/user/aura/src/")
 run_command("cat /home/user/aura/src/tools/slack.ts")
 ```
 
+## GitHub CLI merge safety
+
+Before any `gh pr merge` command, precheck mergeability so branch protection does
+not leave the command hanging until the sandbox timeout:
+
+```bash
+state="$(gh pr view "$PR_NUMBER" --json mergeStateStatus,reviewDecision)"
+merge_state="$(printf '%s' "$state" | jq -r '.mergeStateStatus')"
+review_decision="$(printf '%s' "$state" | jq -r '.reviewDecision')"
+if [ "$merge_state" = "BLOCKED" ]; then
+  echo "PR #$PR_NUMBER is BLOCKED (${review_decision:-review required}). Use --admin to bypass or wait for review." >&2
+  exit 1
+fi
+gh pr merge "$PR_NUMBER" --squash
+```
+
+For loops that merge or otherwise call GitHub repeatedly, start with `set -e`
+so the first blocked PR or timeout aborts the loop instead of cascading.
+
 ## Key files
 
 - `src/personality/system-prompt.ts` — personality, tools, self-awareness (editing = editing your own mind)

--- a/apps/api/src/db/seed-skills.ts
+++ b/apps/api/src/db/seed-skills.ts
@@ -39,7 +39,10 @@ const SEED_SKILLS = [
 4. For changes: create a branch, make edits, commit, push, open PR via gh CLI.
    Always create PRs on branches, never push to main.
    Tag Joan for review on anything non-trivial.
-   For prompt changes (system-prompt.ts): flag as "self-edit" and explain reasoning.`,
+   For prompt changes (system-prompt.ts): flag as "self-edit" and explain reasoning.
+   Before any gh pr merge, run: gh pr view "$PR_NUMBER" --json mergeStateStatus,reviewDecision.
+   If mergeStateStatus is BLOCKED, fail fast with: "PR #N is BLOCKED (review required). Use --admin to bypass or wait for review."
+   In shell loops with gh/network calls, use set -e so one failure aborts the loop.`,
   },
   {
     topic: "follow-up-protocol",

--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentMocks = vi.hoisted(() => ({
+  createInteractiveAgent: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+}));
+
+vi.mock("../lib/agents.js", () => ({
+  createInteractiveAgent: agentMocks.createInteractiveAgent,
+}));
+
+vi.mock("../lib/ai.js", () => ({
+  getMainModel: vi.fn(),
+  buildCachedSystemMessages: vi.fn(),
+}));
+
+vi.mock("../lib/tool.js", () => ({
+  getSlackMeta: (tool: any) => tool?.slack,
+}));
+
+vi.mock("../lib/settings.js", () => ({
+  getSettingJSON: vi.fn().mockResolvedValue("timeline"),
+}));
+
+vi.mock("../lib/slack-status.js", () => ({
+  trySetAssistantThreadStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/error-logger.js", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("../tools/scratchpad.js", () => ({
+  cleanupScratchpad: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../tools/table.js", () => ({
+  TABLE_BLOCK_KEY: "__table_block",
+}));
+
+vi.mock("./prepare-step.js", () => ({
+  InvocationSupersededError: class InvocationSupersededError extends Error {
+    invocationId = "test-invocation";
+  },
+}));
+
+import { generateResponse } from "./respond.js";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createSlackClient(streamers: Array<{ append: any; stop: any }>) {
+  return {
+    chatStream: vi.fn(() => {
+      const next = streamers.shift();
+      if (!next) throw new Error("No streamers left");
+      return next;
+    }),
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ok: true, ts: "fallback-ts", channel: "C123" }),
+    },
+  };
+}
+
+function mockAgentStream(fullStream: AsyncIterable<any>) {
+  agentMocks.createInteractiveAgent.mockResolvedValue({
+    agent: {
+      stream: vi.fn().mockResolvedValue({
+        fullStream,
+        usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+        steps: Promise.resolve([]),
+      }),
+    },
+    tools: {
+      run_command: {
+        slack: {
+          status: "Running a command in the sandbox...",
+        },
+      },
+    },
+    modelId: "test-model",
+    getStepModelIds: () => ["test-model"],
+  });
+}
+
+function baseOptions(slackClient: any) {
+  return {
+    stablePrefix: "",
+    conversationContext: "",
+    userMessage: "run a slow command",
+    slackClient,
+    channelId: "C123",
+    threadTs: "1710000000.000000",
+    teamId: "T123",
+    recipientUserId: "U123",
+  };
+}
+
+describe("generateResponse Slack stream handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("splits to a new stream with a tombstone when a tool call exceeds 75 seconds", async () => {
+    vi.useFakeTimers();
+    const finishTool = deferred<void>();
+    const firstStream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondStream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([firstStream, secondStream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "sleep 200", timeout_seconds: 200 },
+      };
+      await finishTool.promise;
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
+      };
+      yield { type: "text-delta", text: "Done." };
+    })());
+
+    const responsePromise = generateResponse(baseOptions(slackClient));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(firstStream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "task_update",
+        id: "call-1",
+        status: "in_progress",
+      })],
+    });
+
+    await vi.advanceTimersByTimeAsync(75_000);
+
+    expect(slackClient.chatStream).toHaveBeenCalledTimes(2);
+    expect(firstStream.append).toHaveBeenCalledWith({
+      chunks: expect.arrayContaining([
+        expect.objectContaining({
+          type: "task_update",
+          id: "call-1",
+          status: "complete",
+          output: "continuing in a new message...",
+        }),
+        expect.objectContaining({
+          type: "markdown_text",
+          text: expect.stringContaining("continuing in a new message"),
+        }),
+      ]),
+    });
+    expect(firstStream.stop).toHaveBeenCalled();
+
+    finishTool.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(responsePromise).resolves.toMatchObject({
+      raw: "Done.",
+      alreadyPosted: true,
+    });
+    expect(secondStream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "task_update",
+        id: "call-1",
+        status: "complete",
+      })],
+    });
+  });
+
+  it("stops a failed stream with a continuation tombstone before postMessage fallback", async () => {
+    const stream = {
+      append: vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(Object.assign(new Error("invalid_blocks"), {
+          data: { error: "invalid_blocks" },
+        })),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "true" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
+      };
+      yield { type: "text-delta", text: "Fallback text." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(stream.stop).toHaveBeenCalledWith({
+      chunks: expect.arrayContaining([
+        expect.objectContaining({
+          type: "task_update",
+          id: "call-1",
+          status: "complete",
+          output: "continuing in a new message...",
+        }),
+        expect.objectContaining({
+          type: "markdown_text",
+          text: expect.stringContaining("continuing in a new message"),
+        }),
+      ]),
+    });
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "C123",
+      thread_ts: "1710000000.000000",
+      text: expect.stringContaining("Fallback text."),
+    }));
+  });
+});

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -201,6 +201,9 @@ const STREAM_THRESHOLD_SENTENCE = 8_000;
 const STREAM_THRESHOLD_WHITESPACE = 9_000;
 const STREAM_HARD_LIMIT = 9_500;
 const MAX_CONTINUATIONS = 5;
+const LONG_TOOL_SPLIT_MS = 75_000;
+const STREAM_CONTINUATION_TOMBSTONE = "_(continuing in a new message...)_";
+const TOOL_CONTINUATION_OUTPUT = "continuing in a new message...";
 
 /**
  * Find the best split index in a text delta for stream continuation.
@@ -396,6 +399,7 @@ export async function generateResponse(
   // chat.startStream. When we detect this, we flip to buffer-only mode
   // and post the final result via chat.postMessage.
   let streamingFailed = skipStreaming;
+  let streamTombstoneSent = false;
 
   async function tryStreamAppend(
     payload: Omit<ChatAppendStreamArguments, "channel" | "ts">,
@@ -511,6 +515,9 @@ export async function generateResponse(
           context: { fallback: "postMessage" },
         });
       }
+      if (streamingFailed) {
+        await stopFrozenStreamWithTombstone();
+      }
     }
     return false;
   }
@@ -533,6 +540,8 @@ export async function generateResponse(
 
   // Slack stream keepalive — sends minimal payload to prevent ~30s idle timeout
   let streamKeepAlive: ReturnType<typeof setInterval> | null = null;
+  let longToolSplitTimer: ReturnType<typeof setTimeout> | null = null;
+  let longToolSplitInFlight = false;
 
   // ── Build agent ──────────────────────────────────────────────────────
   const { agent, tools, modelId, getStepModelIds } = await createInteractiveAgent({
@@ -587,6 +596,58 @@ export async function generateResponse(
   let continuationCount = 0;
   let tableBuffer: string[] = [];
   let lineCarry = "";
+
+  function clearLongToolSplitTimer() {
+    if (longToolSplitTimer) {
+      clearTimeout(longToolSplitTimer);
+      longToolSplitTimer = null;
+    }
+  }
+
+  function buildStreamTombstoneChunks(): SlackStreamChunk[] {
+    const chunks: SlackStreamChunk[] = [];
+    for (const [toolCallId, pending] of pendingToolInputs.entries()) {
+      const slackMeta = getSlackMeta(tools[pending.name]);
+      chunks.push(toTaskUpdateChunk({
+        id: toolCallId,
+        title: slackMeta?.status ?? "Working on it...",
+        status: "complete",
+        output: TOOL_CONTINUATION_OUTPUT,
+      }));
+    }
+    chunks.push(toChunkMarkdownText(`\n${STREAM_CONTINUATION_TOMBSTONE}\n`));
+    return chunks;
+  }
+
+  async function appendStreamTombstone(): Promise<void> {
+    if (!streamer || streamTombstoneSent) return;
+    const payload = asAppendPayload({ chunks: buildStreamTombstoneChunks() });
+    try {
+      currentStreamLength += estimateAppendSize(payload);
+      await streamer.append(payload);
+      streamTombstoneSent = true;
+    } catch (err: any) {
+      logger.warn("Failed to append stream continuation tombstone", {
+        channelId,
+        slackError: err?.data?.error,
+        error: err?.message,
+      });
+    }
+  }
+
+  async function stopFrozenStreamWithTombstone(): Promise<void> {
+    if (!streamer || streamTombstoneSent) return;
+    try {
+      await streamer.stop({ chunks: buildStreamTombstoneChunks() });
+      streamTombstoneSent = true;
+    } catch (err: any) {
+      logger.warn("Failed to stop frozen stream with continuation tombstone", {
+        channelId,
+        slackError: err?.data?.error,
+        error: err?.message,
+      });
+    }
+  }
 
   /**
    * Process a text chunk through the table line buffer.
@@ -659,7 +720,7 @@ export async function generateResponse(
     return output;
   }
 
-  async function splitToNewStream(): Promise<boolean> {
+  async function splitToNewStream(reason: "length" | "long_tool" = "length"): Promise<boolean> {
     if (streamingFailed || continuationCount >= MAX_CONTINUATIONS) {
       if (continuationCount >= MAX_CONTINUATIONS) {
         logger.warn("Max continuation messages reached", { continuationCount });
@@ -671,7 +732,12 @@ export async function generateResponse(
       currentStreamLength,
       totalAccumulated: accumulatedText.length,
       continuationCount: continuationCount + 1,
+      reason,
     });
+
+    if (reason === "long_tool") {
+      await appendStreamTombstone();
+    }
 
     try {
       await streamer.stop();
@@ -684,6 +750,7 @@ export async function generateResponse(
     try {
       streamer = slackClient.chatStream(streamParams as any);
       currentStreamLength = 0;
+      streamTombstoneSent = false;
       continuationCount++;
       return true;
     } catch (startErr: any) {
@@ -693,6 +760,34 @@ export async function generateResponse(
       );
       streamingFailed = true;
       return false;
+    }
+  }
+
+  function startLongToolSplitTimer() {
+    if (streamingFailed || longToolSplitTimer || pendingToolInputs.size === 0) return;
+    longToolSplitTimer = setTimeout(() => {
+      longToolSplitTimer = null;
+      void splitLongRunningToolStream();
+    }, LONG_TOOL_SPLIT_MS);
+  }
+
+  async function splitLongRunningToolStream(): Promise<void> {
+    if (longToolSplitInFlight || streamingFailed || pendingToolInputs.size === 0) return;
+    longToolSplitInFlight = true;
+    try {
+      logger.info("Long-running tool still active; splitting Slack stream", {
+        channelId,
+        pendingToolCount: pendingToolInputs.size,
+        thresholdMs: LONG_TOOL_SPLIT_MS,
+      });
+      if (!await splitToNewStream("long_tool") && streamingFailed) {
+        fallbackStartIdx = accumulatedText.length;
+      }
+    } finally {
+      longToolSplitInFlight = false;
+      if (!streamingFailed && pendingToolInputs.size > 0) {
+        startLongToolSplitTimer();
+      }
     }
   }
 
@@ -816,6 +911,7 @@ export async function generateResponse(
             name: chunk.toolName,
             input: truncateToBytes(JSON.stringify(inputArgs), 1500),
           });
+          startLongToolSplitTimer();
 
           // Keep resetting inactivity timer during long tool execution
           if (toolKeepAlive) clearInterval(toolKeepAlive);
@@ -890,6 +986,7 @@ export async function generateResponse(
 
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+          if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
 
           if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
@@ -934,6 +1031,7 @@ export async function generateResponse(
 
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+          if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
 
           if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
@@ -960,6 +1058,7 @@ export async function generateResponse(
     clearTimeout(inactivityTimer);
     if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
     if (streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+    clearLongToolSplitTimer();
 
     const llmMs = Date.now() - start;
     const usage = await result.usage;
@@ -1139,6 +1238,7 @@ export async function generateResponse(
     clearTimeout(inactivityTimer);
     if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
     if (streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+    clearLongToolSplitTimer();
 
     if (error instanceof InvocationSupersededError) {
       logger.info("Stream interrupted — invocation superseded", {

--- a/apps/api/src/tools/sandbox.test.ts
+++ b/apps/api/src/tools/sandbox.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sandboxMocks = vi.hoisted(() => ({
+  commandRun: vi.fn(),
+  getOrCreateSandbox: vi.fn(),
+  getSandboxEnvs: vi.fn(),
+  ensureUserHome: vi.fn(),
+}));
+
+vi.mock("../lib/sandbox.js", () => ({
+  getOrCreateSandbox: sandboxMocks.getOrCreateSandbox,
+  getSandboxEnvs: sandboxMocks.getSandboxEnvs,
+  ensureUserHome: sandboxMocks.ensureUserHome,
+  truncateOutput: (value: string) => value,
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/tool.js", () => ({
+  defineTool: (config: any) => config,
+}));
+
+import { createSandboxTools } from "./sandbox.js";
+
+describe("run_command timeout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sandboxMocks.commandRun.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    sandboxMocks.getOrCreateSandbox.mockResolvedValue({
+      commands: { run: sandboxMocks.commandRun },
+    });
+    sandboxMocks.getSandboxEnvs.mockResolvedValue({});
+    sandboxMocks.ensureUserHome.mockResolvedValue("/home/user");
+  });
+
+  it("defaults timeout_seconds to 90 seconds", async () => {
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command as any;
+    const input = tool.inputSchema.parse({ command: "true" });
+
+    expect(input.timeout_seconds).toBe(90);
+
+    await tool.execute(input);
+    expect(sandboxMocks.commandRun).toHaveBeenCalledWith("true", expect.objectContaining({
+      timeoutMs: 90_000,
+    }));
+  });
+
+  it("allows explicit timeouts above 90 seconds up to the 750 second ceiling", async () => {
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command as any;
+
+    const input = tool.inputSchema.parse({ command: "sleep 200", timeout_seconds: 200 });
+    expect(input.timeout_seconds).toBe(200);
+
+    await tool.execute(input);
+    expect(sandboxMocks.commandRun).toHaveBeenCalledWith("sleep 200", expect.objectContaining({
+      timeoutMs: 200_000,
+    }));
+    expect(() =>
+      tool.inputSchema.parse({ command: "sleep too long", timeout_seconds: 751 })
+    ).toThrow();
+  });
+});

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -19,7 +19,7 @@ export function createSandboxTools(context?: ScheduleContext) {
   return {
     run_command: defineTool({
       description:
-        "Execute a shell command in a sandboxed Linux VM. This is the universal primitive for computation: file ops, git, code execution (node, python), search (rg, grep), data processing (curl, jq), and self-modification via Claude Code (claude). Pre-installed: git, node, python, gh, gcloud, vercel CLI, ripgrep, curl, jq, claude. Install more with apt-get or pip. The sandbox persists between conversations — files and state are preserved across messages. Output is truncated; use head, tail, grep to filter. Break complex tasks into smaller commands. For complex workflows, check your skill notes first. Use higher timeouts (up to 750s) for long-running agent commands like Claude Code — the 750s ceiling leaves a 50s buffer before the Vercel function timeout at 800s.",
+        "Execute a shell command in a sandboxed Linux VM. This is the universal primitive for computation: file ops, git, code execution (node, python), search (rg, grep), data processing (curl, jq), and self-modification via Claude Code (claude). Pre-installed: git, node, python, gh, gcloud, vercel CLI, ripgrep, curl, jq, claude. Install more with apt-get or pip. The sandbox persists between conversations — files and state are preserved across messages. Output is truncated; use head, tail, grep to filter. Break complex tasks into smaller commands. Default timeout is 90s; explicitly opt in to longer timeouts only for headless/batch work or long-running agent commands. Slack chat.stream sessions cap around 3 minutes, so individual tool calls longer than 90s risk freezing the in-flight Slack stream before the final result arrives. If you run for/while loops with outbound network calls, start the script with set -e so one failure or timeout aborts the loop instead of compounding many slow failures. For complex workflows, check your skill notes first. Hard max is 750s for headless jobs and agent commands like Claude Code, leaving a 50s buffer before the Vercel function timeout at 800s.",
       requiredCredentials: ["e2b_api_key"],
       inputSchema: z.object({
         command: z
@@ -37,9 +37,9 @@ export function createSandboxTools(context?: ScheduleContext) {
           .number()
           .min(1)
           .max(750)
-          .default(120)
+          .default(90)
           .describe(
-            "Command timeout in seconds (default 120, max 750). Use higher timeouts for long-running agent commands like Claude Agent SDK or Codex CLI.",
+            "Command timeout in seconds (default 90, max 750). Explicitly opt in to values above 90s only for headless/batch work or long-running agent commands; Slack chat.stream caps around 3 minutes, so longer foreground calls can freeze the active Slack message.",
           ),
       }),
       execute: async ({ command, workdir, timeout_seconds }) => {

--- a/content/docs/tools/sandbox.mdx
+++ b/content/docs/tools/sandbox.mdx
@@ -18,7 +18,7 @@ Execute a shell command in the sandboxed Linux VM.
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `command` | string | **yes** | Shell command to run, e.g. `git clone https://github.com/org/repo.git` |
-| `timeout_seconds` | number | no | Timeout in seconds (default 120, max 750). Use higher values for long-running agent commands. |
+| `timeout_seconds` | number | no | Timeout in seconds (default 90, max 750). Explicitly opt in to values above 90s only for headless/batch work or long-running agent commands. |
 | `workdir` | string | no | Working directory, e.g. `/home/user/repo`. Defaults to `/home/user`. |
 
 **Returns:** exit code, stdout, stderr.
@@ -128,8 +128,12 @@ The sandbox is currently a single shared instance across all users and threads. 
 | Task | Recommended timeout |
 |------|-------------------|
 | Quick commands (`ls`, `grep`, `git log`) | 10–30s |
-| Code execution, file processing | 60–120s |
+| Code execution, file processing | 60–90s |
 | `claude` agent tasks (multi-file changes) | 400–750s |
 | Long web crawls or batch processing | 300–600s |
+
+Slack `chat.stream` sessions cap at around 3 minutes. Individual foreground tool calls longer than 90s can leave the in-flight Slack message frozen on a tool widget before the response continues elsewhere, so prefer smaller commands and only set higher `timeout_seconds` when the work is headless or intentionally long-running.
+
+When running `for` or `while` loops that make outbound network calls, start the script with `set -e` so one failed or timed-out command aborts the loop instead of compounding many slow failures.
 
 The Vercel function timeout is 800s. Leave a 50s buffer for overhead — use 750s maximum.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lower `run_command` default timeout to 90s while preserving the 750s explicit ceiling.
- Add proactive Slack stream splitting for tool calls still running after 75s, with tombstone updates so old tool widgets resolve cleanly.
- Add tombstone stop handling for fatal `chatStream` fallback paths before posting the remaining response via `postMessage`.
- Document loop safety (`set -e`) and GitHub PR merge prechecks to fail fast on blocked reviews.

## Tests
- `pnpm --filter aura-api exec vitest run src/tools/sandbox.test.ts src/pipeline/respond.test.ts`
- `pnpm --filter aura-api exec tsc --noEmit && pnpm typecheck`
- `pnpm --filter aura-api test`
- `npx tsc --noEmit` (from `apps/api`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbc633ae-dc5c-4378-894d-0bbe48f5716d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbc633ae-dc5c-4378-894d-0bbe48f5716d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

