### PR TITLE
Config special-effect settings registry

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "node --env-file=../../.env.local --import tsx --watch src/index.ts",
-    "build": "tsc",
+    "build": "pnpm --workspace-root gen:special-keys-docs && tsc",
     "vercel-build": "pnpm --filter @aura/db db:migrate",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,7 @@ import {
   openUpdateCredentialModal,
   openShareCredentialModal,
   openCredentialAccessModal,
+  SPECIAL_KEY_ACTION_PREFIX,
 } from "./slack/home.js";
 import {
   storeApiCredential,
@@ -36,6 +37,7 @@ import crypto from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { db } from "./db/client.js";
 import { notes, feedback } from "@aura/db/schema";
+import { getWorkspaceSpecialSettings } from "./config/registry.js";
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -390,6 +392,29 @@ app.post("/api/slack/interactions", async (c) => {
         })();
 
         waitUntil(savePromise);
+      }
+
+      if (action.action_id?.startsWith(SPECIAL_KEY_ACTION_PREFIX)) {
+        const key = action.action_id.slice(SPECIAL_KEY_ACTION_PREFIX.length);
+        const specialSetting = getWorkspaceSpecialSettings().find(
+          (entry) => entry.key === key,
+        );
+
+        if (specialSetting && typeof action.value === "string") {
+          const savePromise = (async () => {
+            try {
+              await setSetting(specialSetting.key, action.value, userId);
+              await publishHomeTab(slackClient, userId);
+            } catch (err) {
+              recordError("interactions.special_setting_save", err, {
+                userId,
+                settingKey: specialSetting.key,
+              });
+            }
+          })();
+
+          waitUntil(savePromise);
+        }
       }
 
       const credentialKey = CREDENTIAL_ACTIONS[action.action_id];

--- a/apps/api/src/config/registry.ts
+++ b/apps/api/src/config/registry.ts
@@ -1,0 +1,78 @@
+export type SpecialKey = {
+  key: string;
+  kind: "setting" | "env";
+  scope: "workspace" | "global";
+  effect: string;
+  example?: string;
+  default?: string | null;
+  docs_anchor?: string;
+};
+
+export const TOOLS_REPO_SETTING = {
+  key: "tools_repo",
+  kind: "setting",
+  scope: "workspace",
+  effect:
+    "Clones github.com/<value> to /home/user/aura-tools on every sandbox acquisition. Tools registered there become callable from recurring jobs via `python3 /home/user/aura-tools/runner.py <tool_name> <args>`.",
+  example: "realadvisor/aura-tools",
+  default: null,
+  docs_anchor: "tools_repo",
+} satisfies SpecialKey;
+
+export const DEFAULT_GITHUB_REPO_SETTING = {
+  key: "default_github_repo",
+  kind: "setting",
+  scope: "workspace",
+  effect:
+    "Sets the default GitHub repository used when dispatching Cursor Cloud Agents without an explicit repository.",
+  example: "AuraHQ-ai/aura",
+  default: "AuraHQ-ai/aura",
+  docs_anchor: "default_github_repo",
+} satisfies SpecialKey;
+
+export const MONGODB_ATLAS_URI_ENV = {
+  key: "MONGODB_ATLAS_URI",
+  kind: "env",
+  scope: "global",
+  effect:
+    "Advertises MongoDB Atlas as a sandbox scratch/staging storage layer in the agent prompt when the env var is available to the sandbox.",
+  example: "mongodb+srv://user:password@cluster.example.mongodb.net/aura",
+  default: null,
+  docs_anchor: "mongodb_atlas_uri",
+} satisfies SpecialKey;
+
+export const GOOGLE_SA_KEY_B64_ENV = {
+  key: "GOOGLE_SA_KEY_B64",
+  kind: "env",
+  scope: "global",
+  effect:
+    "Mounts the GCS bucket gs://aura-files at /mnt/aura-files inside the sandbox via gcsfuse when present.",
+  example: "base64-encoded-service-account-json",
+  default: null,
+  docs_anchor: "google_sa_key_b64",
+} satisfies SpecialKey;
+
+export const E2B_TEMPLATE_ID_ENV = {
+  key: "E2B_TEMPLATE_ID",
+  kind: "env",
+  scope: "global",
+  effect:
+    "Selects the E2B sandbox template. Changing it forces the next sandbox acquisition to discard a saved sandbox using an older template.",
+  example: "tmpl_abc123",
+  default: null,
+  docs_anchor: "e2b_template_id",
+} satisfies SpecialKey;
+
+export const SPECIAL_KEYS = [
+  TOOLS_REPO_SETTING,
+  DEFAULT_GITHUB_REPO_SETTING,
+  MONGODB_ATLAS_URI_ENV,
+  GOOGLE_SA_KEY_B64_ENV,
+  E2B_TEMPLATE_ID_ENV,
+] as const satisfies readonly SpecialKey[];
+
+export function getWorkspaceSpecialSettings(): SpecialKey[] {
+  return SPECIAL_KEYS.filter(
+    (entry) => entry.kind === "setting" && entry.scope === "workspace",
+  );
+}

--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -4,6 +4,12 @@ import { decryptCredential } from "./credentials.js";
 import { db } from "../db/client.js";
 import { credentials, credentialGrants } from "@aura/db/schema";
 import { logger } from "./logger.js";
+import {
+  E2B_TEMPLATE_ID_ENV,
+  GOOGLE_SA_KEY_B64_ENV,
+  TOOLS_REPO_SETTING,
+  type SpecialKey,
+} from "../config/registry.js";
 
 const sandboxNoteKey = (userId?: string) =>
   userId ? `e2b_sandbox_id:${userId}` : "e2b_sandbox_id";
@@ -15,6 +21,7 @@ const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour -- autoPause handles inacti
  *  Keyed by userId so concurrent invocations for different users don't share state. */
 let cachedSandbox: any | null = null;
 let cachedSandboxUserId: string | undefined;
+const toolsRepoReady = new Set<string>();
 
 interface SandboxCredentialRow {
   id: string;
@@ -42,6 +49,7 @@ export function clearCachedSandbox(): void {
     cachedSandboxUserId = undefined;
   }
   userHomeReady.clear();
+  toolsRepoReady.clear();
 }
 
 /**
@@ -56,6 +64,24 @@ async function loadE2B() {
 
 function resolveSandboxEnvName(row: SandboxCredentialRow): string {
   return row.sandboxEnvName || row.name.toUpperCase();
+}
+
+function logBootstrap(
+  entry: SpecialKey,
+  valueLabel: string | null,
+  effectSummary: string,
+): void {
+  if (valueLabel) {
+    logger.info(
+      `[bootstrap] ${entry.key}=${valueLabel} -> ${effectSummary}`,
+      { key: entry.key, value: valueLabel, effect: effectSummary },
+    );
+  } else {
+    logger.info(
+      `[bootstrap] ${entry.key} unset, skipping`,
+      { key: entry.key, effect: effectSummary },
+    );
+  }
 }
 
 async function resolveSandboxCredentialRows(
@@ -220,6 +246,85 @@ export async function getSandboxEnvNames(userId?: string): Promise<string[]> {
   return [...new Set(rows.map(resolveSandboxEnvName))].sort();
 }
 
+async function ensureToolsRepo(
+  sandbox: any,
+  envs: Record<string, string>,
+): Promise<void> {
+  const repo = (await getSetting(TOOLS_REPO_SETTING.key))?.trim();
+  const checkoutPath = "/home/user/aura-tools";
+  const effectSummary = `cloning to ${checkoutPath}`;
+
+  if (!repo) {
+    logBootstrap(TOOLS_REPO_SETTING, null, effectSummary);
+    return;
+  }
+
+  logBootstrap(TOOLS_REPO_SETTING, repo, effectSummary);
+
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    logger.warn(`Invalid ${TOOLS_REPO_SETTING.key} setting; expected owner/repo`, { repo });
+    return;
+  }
+
+  const sandboxId = sandbox.sandboxId || "unknown";
+  const cacheKey = `${sandboxId}:${repo}`;
+  if (toolsRepoReady.has(cacheKey)) return;
+
+  const cloneUrl = envs.GITHUB_TOKEN
+    ? `https://x-access-token:${envs.GITHUB_TOKEN}@github.com/${repo}.git`
+    : `https://github.com/${repo}.git`;
+  const command = [
+    "set -e",
+    `target="${checkoutPath}"`,
+    'if [ -d "$target/.git" ]; then',
+    '  origin="$(git -C "$target" remote get-url origin || true)"',
+    '  case "$origin" in',
+    '    *"github.com/$TOOLS_REPO.git") git -C "$target" pull --quiet --ff-only ;;',
+    '    *) rm -rf "$target"; git clone --depth=1 "$TOOLS_REPO_CLONE_URL" "$target" ;;',
+    "  esac",
+    "else",
+    '  rm -rf "$target"',
+    '  git clone --depth=1 "$TOOLS_REPO_CLONE_URL" "$target"',
+    "fi",
+  ].join("\n");
+
+  try {
+    const result = await sandbox.commands.run(command, {
+      timeoutMs: 60_000,
+      envs: {
+        ...envs,
+        TOOLS_REPO: repo,
+        TOOLS_REPO_CLONE_URL: cloneUrl,
+      },
+    });
+
+    if (result.exitCode !== 0) {
+      logger.warn("Failed to bootstrap tools repo in sandbox", {
+        repo,
+        exitCode: result.exitCode,
+        stderr: envs.GITHUB_TOKEN
+          ? result.stderr?.replace(envs.GITHUB_TOKEN, "[REDACTED]")
+          : result.stderr,
+      });
+      return;
+    }
+
+    toolsRepoReady.add(cacheKey);
+    logger.info("Tools repo ready in sandbox", {
+      repo,
+      checkoutPath,
+      sandboxId,
+    });
+  } catch (error: any) {
+    logger.warn("Failed to bootstrap tools repo in sandbox", {
+      repo,
+      error: envs.GITHUB_TOKEN
+        ? error.message?.replace(envs.GITHUB_TOKEN, "[REDACTED]")
+        : error.message,
+    });
+  }
+}
+
 /**
  * Mount the GCS bucket `gs://aura-files` at `/mnt/aura-files`.
  * Installs gcsfuse if needed and uses the base64-encoded SA key from envs.
@@ -230,50 +335,53 @@ async function setupSandboxFilesystem(
   envs: Record<string, string>,
 ): Promise<void> {
   try {
-    const mountCheck = await sandbox.commands.run(
-      "mountpoint -q /mnt/aura-files && echo mounted || echo not",
-      { timeoutMs: 5_000, envs },
-    );
-    if (mountCheck.stdout?.trim() === "mounted") return;
-
-    if (!envs.GOOGLE_SA_KEY_B64) {
-      logger.info("Skipping GCS mount — GOOGLE_SA_KEY_B64 not available");
-      return;
-    }
-
-    const gcsfuseCheck = await sandbox.commands.run("which gcsfuse", {
-      timeoutMs: 5_000,
-    });
-    if (gcsfuseCheck.exitCode !== 0) {
-      const distro = "bookworm";
-      const installResult = await sandbox.commands.run(
-        `echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt gcsfuse-${distro} main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc > /dev/null && sudo apt-get update -qq && sudo apt-get install -y -qq gcsfuse && { grep -q user_allow_other /etc/fuse.conf 2>/dev/null || echo user_allow_other | sudo tee -a /etc/fuse.conf > /dev/null; }`,
-        { timeoutMs: 60_000, envs },
+    const mountEffect = "mounting gs://aura-files at /mnt/aura-files";
+    if (!envs[GOOGLE_SA_KEY_B64_ENV.key]) {
+      logBootstrap(GOOGLE_SA_KEY_B64_ENV, null, mountEffect);
+    } else {
+      logBootstrap(GOOGLE_SA_KEY_B64_ENV, "set", mountEffect);
+      const mountCheck = await sandbox.commands.run(
+        "mountpoint -q /mnt/aura-files && echo mounted || echo not",
+        { timeoutMs: 5_000, envs },
       );
-      if (installResult.exitCode !== 0) {
-        logger.warn("gcsfuse install failed", {
-          exitCode: installResult.exitCode,
-          stderr: installResult.stderr,
+
+      if (mountCheck.stdout?.trim() !== "mounted") {
+        const gcsfuseCheck = await sandbox.commands.run("which gcsfuse", {
+          timeoutMs: 5_000,
         });
-        return;
+        if (gcsfuseCheck.exitCode !== 0) {
+          const distro = "bookworm";
+          const installResult = await sandbox.commands.run(
+            `echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] https://packages.cloud.google.com/apt gcsfuse-${distro} main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc > /dev/null && sudo apt-get update -qq && sudo apt-get install -y -qq gcsfuse && { grep -q user_allow_other /etc/fuse.conf 2>/dev/null || echo user_allow_other | sudo tee -a /etc/fuse.conf > /dev/null; }`,
+            { timeoutMs: 60_000, envs },
+          );
+          if (installResult.exitCode !== 0) {
+            logger.warn("gcsfuse install failed", {
+              exitCode: installResult.exitCode,
+              stderr: installResult.stderr,
+            });
+          }
+        }
+
+        const mountResult = await sandbox.commands.run(
+          `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$${GOOGLE_SA_KEY_B64_ENV.key}" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && sudo gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
+          { timeoutMs: 30_000, envs },
+        );
+        if (mountResult.exitCode !== 0) {
+          logger.warn("gcsfuse mount failed", {
+            exitCode: mountResult.exitCode,
+            stderr: mountResult.stderr,
+          });
+        } else {
+          logger.info("GCS bucket mounted at /mnt/aura-files");
+        }
       }
     }
-
-    const mountResult = await sandbox.commands.run(
-      `touch /tmp/gcs-sa-key.json && chmod 600 /tmp/gcs-sa-key.json && echo "$GOOGLE_SA_KEY_B64" | base64 -d > /tmp/gcs-sa-key.json && sudo mkdir -p /mnt/aura-files && sudo chown 1000:1000 /mnt/aura-files && sudo gcsfuse --key-file=/tmp/gcs-sa-key.json --implicit-dirs --uid=1000 --gid=1000 -o allow_other aura-files /mnt/aura-files; EXIT=$?; rm -f /tmp/gcs-sa-key.json; exit $EXIT`,
-      { timeoutMs: 30_000, envs },
-    );
-    if (mountResult.exitCode !== 0) {
-      logger.warn("gcsfuse mount failed", {
-        exitCode: mountResult.exitCode,
-        stderr: mountResult.stderr,
-      });
-      return;
-    }
-    logger.info("GCS bucket mounted at /mnt/aura-files");
   } catch (error: any) {
     logger.warn("Failed to mount GCS bucket", { error: error.message });
   }
+
+  await ensureToolsRepo(sandbox, envs);
 }
 
 /**
@@ -378,7 +486,13 @@ export async function getOrCreateSandbox(userId?: string): Promise<any> {
   const templateKey = sandboxTemplateKey(userId);
   let savedId = await getSetting(noteKey);
   const savedTemplateId = await getSetting(templateKey);
-  const currentTemplateId = envs.E2B_TEMPLATE_ID || process.env.E2B_TEMPLATE_ID || undefined;
+  const currentTemplateId =
+    envs[E2B_TEMPLATE_ID_ENV.key] || process.env[E2B_TEMPLATE_ID_ENV.key] || undefined;
+  logBootstrap(
+    E2B_TEMPLATE_ID_ENV,
+    currentTemplateId ?? null,
+    "selecting E2B sandbox template",
+  );
 
   // If the template was upgraded, kill the old sandbox so we create a fresh one
   if (savedId && currentTemplateId && savedTemplateId !== currentTemplateId) {
@@ -428,7 +542,8 @@ export async function getOrCreateSandbox(userId?: string): Promise<any> {
   }
 
   // Create a new sandbox
-  const templateId = envs.E2B_TEMPLATE_ID || process.env.E2B_TEMPLATE_ID || undefined;
+  const templateId =
+    envs[E2B_TEMPLATE_ID_ENV.key] || process.env[E2B_TEMPLATE_ID_ENV.key] || undefined;
   logger.info("Creating new E2B sandbox", { templateId: templateId || "default" });
 
   // autoPause: E2B pauses the sandbox after DEFAULT_TIMEOUT_MS of inactivity

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -6,6 +6,7 @@ import { getCurrentTimeContext, relativeTime } from "../lib/temporal.js";
 import { logger } from "../lib/logger.js";
 import type { ConversationThread } from "../memory/retrieve.js";
 import type { ChannelType } from "../pipeline/context.js";
+import { MONGODB_ATLAS_URI_ENV } from "../config/registry.js";
 
 export interface PersonProfile {
   slackUserId: string;
@@ -397,7 +398,7 @@ function formatStorage(envNames: string[]): string {
   const has = (name: string) => envNames.includes(name);
   const lines: string[] = [];
 
-  if (has("MONGODB_ATLAS_URI")) {
+  if (has(MONGODB_ATLAS_URI_ENV.key)) {
     lines.push(
       "**MongoDB Atlas** is wired up as your scratch/staging storage layer. Use it whenever a job needs to persist or retrieve arbitrary structured data across sessions -- especially when you'd otherwise reinvent storage in the sandbox.",
       "",
@@ -407,7 +408,7 @@ function formatStorage(envNames: string[]): string {
       "- Per-task collections that don't deserve a Postgres schema and outlive a single sandbox session.",
       "",
       "Rules:",
-      "- The URI is in `MONGODB_ATLAS_URI` (sandbox env). The `mongodb` node driver and `mongosh` are pre-baked into the sandbox template.",
+      `- The URI is in \`${MONGODB_ATLAS_URI_ENV.key}\` (sandbox env). The \`mongodb\` node driver and \`mongosh\` are pre-baked into the sandbox template.`,
       "- Schemaless by design -- create collections on demand, no migrations, no DDL approvals needed. Name them `<domain>_<purpose>` (e.g. `fb_comments`, `notion_dump_2026_05_20`).",
       "- This is NOT a replacement for Postgres. Postgres (`DATABASE_URL`) is mission-critical, schema-managed core state (memories, messages, entities, jobs, notes) -- you do not write DDL or mutate it without Joan's approval. Mongo is your scratch space; Postgres is the system's spine.",
       "- Prefer Mongo over SQLite-in-sandbox or GCS FUSE for anything that needs to survive sandbox resets or be queried later. SQLite can vanish on e2b pause/resume; GCS FUSE is slow and not query-shaped.",

--- a/apps/api/src/slack/home.ts
+++ b/apps/api/src/slack/home.ts
@@ -12,6 +12,7 @@ import {
   getModelCatalogResponse,
   type ModelOption,
 } from "../lib/model-catalog.js";
+import { getWorkspaceSpecialSettings } from "../config/registry.js";
 
 // ── Credential Definitions ───────────────────────────────────────────────────
 
@@ -67,6 +68,85 @@ function buildDropdown(
       initial_option: initialOption,
     },
   };
+}
+
+const SPECIAL_KEY_ACTION_PREFIX = "special_setting_";
+
+function truncatePlainText(text: string, maxLength: number): string {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 3)}...`;
+}
+
+function buildSpecialSettingsBlocks(
+  currentSettings: Record<string, string>,
+  editable: boolean,
+): any[] {
+  const specialSettings = getWorkspaceSpecialSettings();
+  if (specialSettings.length === 0) return [];
+
+  const blocks: any[] = [
+    { type: "divider" },
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Sandbox & integrations" },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: editable
+            ? "Workspace-scoped settings with runtime side effects. Press Enter in a field to save it."
+            : "Workspace-scoped settings with runtime side effects.",
+        },
+      ],
+    },
+  ];
+
+  for (const entry of specialSettings) {
+    const currentValue = currentSettings[entry.key] || "";
+    if (editable) {
+      blocks.push(
+        {
+          type: "input",
+          block_id: `special_key_${entry.key}`,
+          optional: true,
+          dispatch_action: true,
+          label: {
+            type: "plain_text",
+            text: entry.key,
+          },
+          hint: {
+            type: "plain_text",
+            text: truncatePlainText(entry.effect, 2000),
+          },
+          element: {
+            type: "plain_text_input",
+            action_id: `${SPECIAL_KEY_ACTION_PREFIX}${entry.key}`,
+            initial_value: currentValue || undefined,
+            placeholder: {
+              type: "plain_text",
+              text: truncatePlainText(entry.example || entry.key, 150),
+            },
+            dispatch_action_config: {
+              trigger_actions_on: ["on_enter_pressed"],
+            },
+          },
+        },
+      );
+    } else {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*\`${entry.key}\`*\n${entry.effect}\nCurrent: ${
+            currentValue ? `\`${currentValue}\`` : "_not set_"
+          }`,
+        },
+      });
+    }
+  }
+
+  return blocks;
 }
 
 async function buildCredentialBlocks(): Promise<any[]> {
@@ -705,6 +785,8 @@ export async function publishHomeTab(
           },
         },
       );
+
+      blocks.push(...buildSpecialSettingsBlocks(currentSettings, true));
     } else {
       // Read-only view
       const mainLabel = labelByValue.get(mainValue) || mainValue;
@@ -720,6 +802,8 @@ export async function publishHomeTab(
           },
         },
       );
+
+      blocks.push(...buildSpecialSettingsBlocks(currentSettings, false));
     }
 
     const userCredBlocks = await buildUserCredentialBlocks(userId);
@@ -767,4 +851,5 @@ export const ACTION_TO_SETTING: Record<string, string> = {
   select_slack_task_display_mode: "slack_task_display_mode",
 };
 
+export { SPECIAL_KEY_ACTION_PREFIX };
 export { hasRole } from "../lib/permissions.js";

--- a/apps/api/src/tools/cursor-agent.ts
+++ b/apps/api/src/tools/cursor-agent.ts
@@ -6,6 +6,7 @@ import { notes } from "@aura/db/schema";
 import type { ScheduleContext } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
 import { getConfig } from "../lib/settings.js";
+import { DEFAULT_GITHUB_REPO_SETTING } from "../config/registry.js";
 
 /**
  * Create Cursor Cloud Agent tools for the AI SDK.
@@ -58,7 +59,10 @@ export function createCursorAgentTools(context?: ScheduleContext) {
             "../lib/cursor-agent.js"
           );
 
-          const defaultRepo = await getConfig("default_github_repo", "AuraHQ-ai/aura");
+          const defaultRepo = await getConfig(
+            DEFAULT_GITHUB_REPO_SETTING.key,
+            DEFAULT_GITHUB_REPO_SETTING.default ?? "AuraHQ-ai/aura",
+          );
           const repo = repository || defaultRepo;
           const repoUrl = `https://github.com/${repo}`;
 

--- a/content/docs/configuration/special-keys.mdx
+++ b/content/docs/configuration/special-keys.mdx
@@ -1,0 +1,68 @@
+---
+title: "Special configuration keys"
+description: "Settings and environment variables with runtime side effects in Aura."
+---
+
+# Special configuration keys
+
+This page is generated from `apps/api/src/config/registry.ts`. Update the registry, then run `pnpm gen:special-keys-docs` to refresh it.
+
+These keys do more than store static configuration: they change runtime behavior, bootstrap sandbox resources, or alter agent capabilities.
+
+| Key | Kind | Scope | Effect | Example | Default |
+| --- | --- | --- | --- | --- | --- |
+| [`tools_repo`](#tools_repo) | setting | workspace | Clones github.com/&lt;value&gt; to /home/user/aura-tools on every sandbox acquisition. Tools registered there become callable from recurring jobs via `python3 /home/user/aura-tools/runner.py &lt;tool_name&gt; &lt;args&gt;`. | `realadvisor/aura-tools` | _none_ |
+| [`default_github_repo`](#default_github_repo) | setting | workspace | Sets the default GitHub repository used when dispatching Cursor Cloud Agents without an explicit repository. | `AuraHQ-ai/aura` | `AuraHQ-ai/aura` |
+| [`MONGODB_ATLAS_URI`](#mongodb_atlas_uri) | env | global | Advertises MongoDB Atlas as a sandbox scratch/staging storage layer in the agent prompt when the env var is available to the sandbox. | `mongodb+srv://user:password@cluster.example.mongodb.net/aura` | _none_ |
+| [`GOOGLE_SA_KEY_B64`](#google_sa_key_b64) | env | global | Mounts the GCS bucket gs://aura-files at /mnt/aura-files inside the sandbox via gcsfuse when present. | `base64-encoded-service-account-json` | _none_ |
+| [`E2B_TEMPLATE_ID`](#e2b_template_id) | env | global | Selects the E2B sandbox template. Changing it forces the next sandbox acquisition to discard a saved sandbox using an older template. | `tmpl_abc123` | _none_ |
+
+## tools_repo
+
+<a id="tools_repo" />
+
+- **Kind:** setting
+- **Scope:** workspace
+- **Effect:** Clones github.com/&lt;value&gt; to /home/user/aura-tools on every sandbox acquisition. Tools registered there become callable from recurring jobs via `python3 /home/user/aura-tools/runner.py &lt;tool_name&gt; &lt;args&gt;`.
+- **Example:** `realadvisor/aura-tools`
+- **Default:** _none_
+
+## default_github_repo
+
+<a id="default_github_repo" />
+
+- **Kind:** setting
+- **Scope:** workspace
+- **Effect:** Sets the default GitHub repository used when dispatching Cursor Cloud Agents without an explicit repository.
+- **Example:** `AuraHQ-ai/aura`
+- **Default:** `AuraHQ-ai/aura`
+
+## MONGODB_ATLAS_URI
+
+<a id="mongodb_atlas_uri" />
+
+- **Kind:** env
+- **Scope:** global
+- **Effect:** Advertises MongoDB Atlas as a sandbox scratch/staging storage layer in the agent prompt when the env var is available to the sandbox.
+- **Example:** `mongodb+srv://user:password@cluster.example.mongodb.net/aura`
+- **Default:** _none_
+
+## GOOGLE_SA_KEY_B64
+
+<a id="google_sa_key_b64" />
+
+- **Kind:** env
+- **Scope:** global
+- **Effect:** Mounts the GCS bucket gs://aura-files at /mnt/aura-files inside the sandbox via gcsfuse when present.
+- **Example:** `base64-encoded-service-account-json`
+- **Default:** _none_
+
+## E2B_TEMPLATE_ID
+
+<a id="e2b_template_id" />
+
+- **Kind:** env
+- **Scope:** global
+- **Effect:** Selects the E2B sandbox template. Changing it forces the next sandbox acquisition to discard a saved sandbox using an older template.
+- **Example:** `tmpl_abc123`
+- **Default:** _none_

--- a/content/docs/docs.json
+++ b/content/docs/docs.json
@@ -51,6 +51,12 @@
             ]
           },
           {
+            "group": "Configuration",
+            "pages": [
+              "configuration/special-keys"
+            ]
+          },
+          {
             "group": "Core Systems",
             "pages": [
               "memory-system",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "prepare": "husky",
+    "gen:special-keys-docs": "pnpm --filter aura-api exec tsx ../../scripts/gen-special-keys-docs.ts",
+    "build": "pnpm gen:special-keys-docs && pnpm --filter @aura/db build && pnpm --filter aura-api build && pnpm --filter aura-dashboard build && pnpm --filter aurahq-web build",
     "dev": "pnpm --filter @aura/db build && pnpm --filter aura-api --filter aura-dashboard --parallel dev",
     "typecheck": "pnpm --filter aura-api typecheck && pnpm --filter aura-dashboard typecheck",
     "db:generate": "./scripts/env.sh pnpm --filter @aura/db db:generate",

--- a/scripts/gen-special-keys-docs.ts
+++ b/scripts/gen-special-keys-docs.ts
@@ -1,0 +1,98 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SPECIAL_KEYS, type SpecialKey } from "../apps/api/src/config/registry.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const outputPath = path.join(
+  repoRoot,
+  "content/docs/configuration/special-keys.mdx",
+);
+
+function escapeTableCell(value: string): string {
+  return value
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\|/g, "\\|")
+    .replace(/\n/g, "<br />");
+}
+
+function escapeMdxText(value: string): string {
+  return value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function formatValue(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "_none_";
+  return `\`${escapeTableCell(value)}\``;
+}
+
+function formatKey(entry: SpecialKey): string {
+  const anchor = entry.docs_anchor ?? entry.key.toLowerCase();
+  return `[\`${entry.key}\`](#${anchor})`;
+}
+
+function renderTable(entries: readonly SpecialKey[]): string {
+  const rows = entries.map((entry) =>
+    [
+      formatKey(entry),
+      entry.kind,
+      entry.scope,
+      escapeTableCell(entry.effect),
+      formatValue(entry.example),
+      formatValue(entry.default),
+    ].join(" | "),
+  );
+
+  return [
+    "| Key | Kind | Scope | Effect | Example | Default |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...rows.map((row) => `| ${row} |`),
+  ].join("\n");
+}
+
+function renderDetails(entries: readonly SpecialKey[]): string {
+  return entries
+    .map((entry) => {
+      const anchor = entry.docs_anchor ?? entry.key.toLowerCase();
+      return [
+        `## ${entry.key}`,
+        "",
+        `<a id="${anchor}" />`,
+        "",
+        `- **Kind:** ${entry.kind}`,
+        `- **Scope:** ${entry.scope}`,
+        `- **Effect:** ${escapeMdxText(entry.effect)}`,
+        `- **Example:** ${formatValue(entry.example)}`,
+        `- **Default:** ${formatValue(entry.default)}`,
+      ].join("\n");
+    })
+    .join("\n\n");
+}
+
+const content = `---
+title: "Special configuration keys"
+description: "Settings and environment variables with runtime side effects in Aura."
+---
+
+# Special configuration keys
+
+This page is generated from \`apps/api/src/config/registry.ts\`. Update the registry, then run \`pnpm gen:special-keys-docs\` to refresh it.
+
+These keys do more than store static configuration: they change runtime behavior, bootstrap sandbox resources, or alter agent capabilities.
+
+${renderTable(SPECIAL_KEYS)}
+
+${renderDetails(SPECIAL_KEYS)}
+`;
+
+async function main(): Promise<void> {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, content);
+  console.log(`Generated ${path.relative(repoRoot, outputPath)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `apps/api/src/config/registry.ts` as the source of truth for special-effect settings/env vars, seeded with `tools_repo` and audited entries for `default_github_repo`, `MONGODB_ATLAS_URI`, `GOOGLE_SA_KEY_B64`, and `E2B_TEMPLATE_ID`.
- Generates `content/docs/configuration/special-keys.mdx` from the registry and links it under Configuration docs.
- Renders workspace-scoped special settings in Slack App Home under Sandbox & integrations, with labeled inputs, helper text, examples, and save-on-enter behavior.
- Boots `tools_repo` into `/home/user/aura-tools` from the registry key and emits structured `[bootstrap] ...` lines for registry-driven sandbox setup.

Refs #972

## Verification
- `pnpm typecheck`
- `npx tsc --noEmit` from `apps/api`
- `pnpm --filter aura-api test -- src/lib/sandbox.test.ts src/personality/system-prompt.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b251f58d-4ad4-4c76-a808-be7e9c384443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b251f58d-4ad4-4c76-a808-be7e9c384443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

