### PR TITLE
Use structured output for DM thread titles

### DIFF
--- a/apps/api/src/pipeline/__tests__/dm-title.test.ts
+++ b/apps/api/src/pipeline/__tests__/dm-title.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatRecentDmThreadMessages,
+  sanitizeDmThreadTitle,
+  selectDmThreadTitle,
+} from "../dm-title.js";
+
+describe("DM thread title helpers", () => {
+  it("accepts high-confidence titles without language-specific matching", () => {
+    expect(
+      selectDmThreadTitle({
+        title: "Vercel deployment logs",
+        confidence: "high",
+      }),
+    ).toBe("Vercel deployment logs");
+
+    expect(
+      selectDmThreadTitle({
+        title: "Déploiement Vercel",
+        confidence: "high",
+      }),
+    ).toBe("Déploiement Vercel");
+
+    expect(
+      selectDmThreadTitle({
+        title: "リリース確認",
+        confidence: "high",
+      }),
+    ).toBe("リリース確認");
+  });
+
+  it("rejects low-confidence candidates regardless of their text", () => {
+    expect(
+      selectDmThreadTitle({
+        title: "Valid looking topic",
+        confidence: "low",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects null and structurally invalid titles", () => {
+    expect(selectDmThreadTitle({ title: null, confidence: "high" })).toBeNull();
+    expect(selectDmThreadTitle({ title: "!", confidence: "high" })).toBeNull();
+    expect(selectDmThreadTitle({ title: "a", confidence: "high" })).toBeNull();
+  });
+
+  it("normalizes wrappers, whitespace, and trailing punctuation structurally", () => {
+    expect(sanitizeDmThreadTitle('  "Pipeline\ninvestigation."  ')).toBe(
+      "Pipeline investigation",
+    );
+  });
+
+  it("formats elided conversation context from both ends of the thread", () => {
+    const formatted = formatRecentDmThreadMessages({
+      messagesElided: true,
+      recentMessages: [
+        { displayName: "A", text: "first" },
+        { displayName: "B", text: "second" },
+        { displayName: "A", text: "third" },
+      ],
+    });
+
+    expect(formatted).toContain("--- Start of conversation ---");
+    expect(formatted).toContain("A: first");
+    expect(formatted).toContain("--- ... ---");
+    expect(formatted).toContain("A: third");
+    expect(formatted).toContain("--- Latest ---");
+  });
+});

--- a/apps/api/src/pipeline/dm-title.ts
+++ b/apps/api/src/pipeline/dm-title.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+
+const MAX_TITLE_CHARS = 100;
+
+const dmThreadTitleSchema = z.object({
+  title: z
+    .string()
+    .max(MAX_TITLE_CHARS)
+    .nullable()
+    .describe("Concise conversation topic, or null when no reliable topic should be set."),
+  confidence: z
+    .enum(["high", "low"])
+    .describe("Use high only when the title names a concrete topic from the conversation."),
+});
+
+type DmThreadTitleResult = z.infer<typeof dmThreadTitleSchema>;
+
+const INITIAL_TITLE_SYSTEM = `Create a short Slack DM thread title from the conversation.
+
+Base the title on the user's underlying subject, not on the assistant's conversational behavior.
+Return confidence "high" only when the title names a concrete topic from the user-visible conversation.
+Return title null and confidence "low" when the available messages do not establish a concrete topic, or when the only salient content is refusal, uncertainty, capability limitation, apology, meta-commentary, or emotional state.
+
+Title requirements:
+- 3-8 words, or a similarly concise length for languages that do not use spaces.
+- A noun phrase or topic label, not a sentence.
+- No wrapping quotes and no trailing punctuation.`;
+
+const UPDATE_TITLE_SYSTEM = `Create or update a short Slack DM thread title from the conversation.
+
+Capture the concrete topic or topic arc of the conversation. Do not title the thread after the assistant's conversational behavior.
+Return confidence "high" only when the title names a concrete topic from the user-visible conversation.
+Return title null and confidence "low" when the available messages do not establish a concrete topic, or when the only salient content is refusal, uncertainty, capability limitation, apology, meta-commentary, or emotional state.
+
+Title requirements:
+- 5-10 words, or a similarly concise length for languages that do not use spaces.
+- If multiple concrete topics are important, join them with " / ".
+- No wrapping quotes and no trailing punctuation.`;
+
+/** Strip wrapper characters and normalize whitespace without inspecting language content. */
+export function sanitizeDmThreadTitle(raw: string): string {
+  return raw
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^['"`]+|['"`]+$/g, "")
+    .replace(/[.!?:;]+$/g, "")
+    .trim();
+}
+
+function isStructurallyValidTitle(title: string): boolean {
+  if (title.length < 2 || title.length > MAX_TITLE_CHARS) return false;
+  if (!/[\p{L}\p{N}]/u.test(title)) return false;
+  return true;
+}
+
+export function selectDmThreadTitle(result: DmThreadTitleResult): string | null {
+  if (result.confidence !== "high" || result.title === null) return null;
+
+  const title = sanitizeDmThreadTitle(result.title).slice(0, MAX_TITLE_CHARS);
+  return isStructurallyValidTitle(title) ? title : null;
+}
+
+async function generateStructuredTitle(params: {
+  system: string;
+  prompt: string;
+}): Promise<string | null> {
+  const [{ generateObject }, { getFastModel }] = await Promise.all([
+    import("ai"),
+    import("../lib/ai.js"),
+  ]);
+  const fastModel = await getFastModel();
+
+  const { object } = await generateObject({
+    model: fastModel,
+    schema: dmThreadTitleSchema,
+    system: params.system,
+    prompt: params.prompt,
+    temperature: 0,
+  });
+
+  return selectDmThreadTitle(object);
+}
+
+export async function generateInitialDmThreadTitle(params: {
+  userMessage: string;
+  assistantResponse: string;
+}): Promise<string | null> {
+  const { userMessage, assistantResponse } = params;
+  return generateStructuredTitle({
+    system: INITIAL_TITLE_SYSTEM,
+    prompt: `User message:
+${userMessage.slice(0, 600)}
+
+Assistant response, for context only:
+${assistantResponse.slice(0, 600)}`,
+  });
+}
+
+export function formatRecentDmThreadMessages(params: {
+  recentMessages: Array<{ displayName: string; text: string }>;
+  messagesElided: boolean;
+}): string {
+  const { recentMessages, messagesElided } = params;
+  if (!messagesElided) {
+    return recentMessages
+      .map((message) => `${message.displayName}: ${message.text.slice(0, 150)}`)
+      .join("\n");
+  }
+
+  const half = Math.ceil(recentMessages.length / 2);
+  return [
+    "--- Start of conversation ---",
+    ...recentMessages
+      .slice(0, half)
+      .map((message) => `${message.displayName}: ${message.text.slice(0, 150)}`),
+    "--- ... ---",
+    ...recentMessages
+      .slice(half)
+      .map((message) => `${message.displayName}: ${message.text.slice(0, 150)}`),
+    "--- Latest ---",
+  ].join("\n");
+}
+
+export async function generateUpdatedDmThreadTitle(params: {
+  recentMessages: Array<{ displayName: string; text: string }>;
+  messagesElided: boolean;
+  assistantResponse: string;
+}): Promise<string | null> {
+  const { recentMessages, messagesElided, assistantResponse } = params;
+  const messagesContext = formatRecentDmThreadMessages({
+    recentMessages,
+    messagesElided,
+  });
+
+  return generateStructuredTitle({
+    system: UPDATE_TITLE_SYSTEM,
+    prompt: `Conversation:
+${messagesContext}
+
+Latest assistant response, for context only:
+${assistantResponse.slice(0, 300)}`,
+  });
+}

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -36,6 +36,10 @@ import { logError } from "../lib/error-logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
 import { trySetAssistantThreadStatus } from "../lib/slack-status.js";
 import {
+  generateInitialDmThreadTitle,
+  generateUpdatedDmThreadTitle,
+} from "./dm-title.js";
+import {
   createConversationTrace,
   persistConversationInputs,
   persistConversationSteps,
@@ -999,11 +1003,6 @@ async function runBackgroundTasks(params: {
   }
 }
 
-/** Strip wrapping quotes and trailing punctuation that LLMs sometimes add despite instructions. */
-function sanitizeTitle(raw: string): string {
-  return raw.trim().replace(/^["'""]+|["'""]+$/g, "").replace(/[.!;:]+$/, "").trim();
-}
-
 /**
  * Generate and set the initial title for a DM thread.
  * Triggered after the first assistant response so both sides of the
@@ -1018,15 +1017,10 @@ async function setInitialDmThreadTitle(params: {
 }): Promise<void> {
   const { userMessage, assistantResponse, channelId, threadTs, client } = params;
   try {
-    const { getFastModel } = await import("../lib/ai.js");
-    const { generateText } = await import("ai");
-    const fastModel = await getFastModel();
-    const { text: raw } = await generateText({
-      model: fastModel,
-      maxOutputTokens: 40,
-      prompt: `What is this conversation about? Name the core topic in 3-8 words. No quotes, no punctuation at the end.\n\nUser: "${userMessage.slice(0, 300)}"\n\nAssistant: "${assistantResponse.slice(0, 500)}"`,
+    const title = await generateInitialDmThreadTitle({
+      userMessage,
+      assistantResponse,
     });
-    const title = sanitizeTitle(raw).slice(0, 100);
     if (!title) return;
     await client.assistant.threads.setTitle({
       channel_id: channelId,
@@ -1066,30 +1060,11 @@ async function maybeUpdateDmThreadTitle(params: {
   if (totalMessages < 5 || totalMessages % 5 > 1) return;
 
   try {
-    const { getFastModel } = await import("../lib/ai.js");
-    const { generateText } = await import("ai");
-    const fastModel = await getFastModel();
-
-    const half = Math.ceil(recentMessages.length / 2);
-    const messagesContext = messagesElided
-      ? [
-          "--- Start of conversation ---",
-          ...recentMessages.slice(0, half).map(m => `${m.displayName}: ${m.text.slice(0, 150)}`),
-          "--- ... ---",
-          ...recentMessages.slice(half).map(m => `${m.displayName}: ${m.text.slice(0, 150)}`),
-          "--- Latest ---",
-        ].join("\n")
-      : recentMessages
-          .map(m => `${m.displayName}: ${m.text.slice(0, 150)}`)
-          .join("\n");
-
-    const { text: raw } = await generateText({
-      model: fastModel,
-      maxOutputTokens: 40,
-      prompt: `What are the 1-3 core topics discussed in this Slack DM conversation? Express as a short title (5-10 words). If multiple distinct topics, separate them with " / ". Capture the essence of the whole conversation arc, not just the latest messages. No quotes, no punctuation at the end.\n\nConversation:\n${messagesContext}\n\nLatest assistant response: "${assistantResponse.slice(0, 300)}"`,
+    const newTitle = await generateUpdatedDmThreadTitle({
+      recentMessages,
+      messagesElided,
+      assistantResponse,
     });
-
-    const newTitle = sanitizeTitle(raw).slice(0, 100);
     if (newTitle) {
       await client.assistant.threads.setTitle({
         channel_id: channelId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaced free-text DM title generation with AI SDK structured output: `{ title: string | null, confidence: "high" | "low" }`.
- Only calls Slack `assistant.threads.setTitle` when the structured result is high confidence and passes language-agnostic structural validation.
- Moved title prompt/selection logic into `apps/api/src/pipeline/dm-title.ts` and added focused tests for confidence gating, multilingual titles, sanitization, and elided thread formatting.

## Notes

- No hardcoded natural-language refusal/opening strings or English-only regex filters were added.
- The assistant response is provided as context only; prompts instruct title generation to use the underlying conversation topic rather than assistant meta/refusal behavior.

## Verification

- `pnpm --filter aura-api exec vitest run src/pipeline/__tests__/dm-title.test.ts`
- `cd apps/api && npx tsc --noEmit`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-649097f7-17cb-4708-b480-38261ba800f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-649097f7-17cb-4708-b480-38261ba800f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

