### PR TITLE
ops: route job failures to creators, escalate consecutive failures (fixes #977)

### DIFF
--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -487,7 +487,6 @@ export async function executeJob(
       await sendJobFailureDm({
         jobId,
         requestedBy: job.requestedBy,
-        fallbackToAdmin: false,
         text: `I tried 3 times but couldn't complete this job: "${job.description}"\n\nError: ${error.message}`,
         logContext: { executionId },
       });

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbMock = vi.hoisted(() => {
   type Operation = {
-    kind: "select" | "update" | "delete";
+    kind: "select" | "update" | "delete" | "insert";
     setArg?: Record<string, unknown>;
+    valuesArg?: Record<string, unknown>;
   };
 
   const state = {
@@ -12,6 +13,7 @@ const dbMock = vi.hoisted(() => {
     select: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    insert: vi.fn(),
   };
 
   function nextResult() {
@@ -28,6 +30,12 @@ const dbMock = vi.hoisted(() => {
         operation.setArg = setArg;
         return query;
       }),
+      values: vi.fn((valuesArg: Record<string, unknown>) => {
+        operation.valuesArg = valuesArg;
+        return query;
+      }),
+      onConflictDoUpdate: vi.fn(() => query),
+      onConflictDoNothing: vi.fn(() => query),
       returning: vi.fn(() => {
         state.operations.push(operation);
         return Promise.resolve(nextResult());
@@ -44,6 +52,7 @@ const dbMock = vi.hoisted(() => {
   state.select.mockImplementation(() => createQuery({ kind: "select" }));
   state.update.mockImplementation(() => createQuery({ kind: "update" }));
   state.delete.mockImplementation(() => createQuery({ kind: "delete" }));
+  state.insert.mockImplementation(() => createQuery({ kind: "insert" }));
 
   return state;
 });
@@ -56,6 +65,7 @@ vi.mock("../db/client.js", () => ({
     select: dbMock.select,
     update: dbMock.update,
     delete: dbMock.delete,
+    insert: dbMock.insert,
   },
 }));
 
@@ -73,13 +83,13 @@ vi.mock("./execute-job.js", () => ({
   executeJob: executeJobMock,
 }));
 
-vi.mock("./job-notifications.js", () => ({
-  sendJobFailureDm: sendJobFailureDmMock,
-  truncateJobFailureText: (value: string | null | undefined, maxChars = 400) => {
-    const text = value?.trim() || "unknown";
-    return text.length <= maxChars ? text : `${text.slice(0, maxChars - 3)}...`;
-  },
-}));
+vi.mock("./job-notifications.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./job-notifications.js")>();
+  return {
+    ...actual,
+    sendJobFailureDm: sendJobFailureDmMock,
+  };
+});
 
 function queueDbResults(...results: unknown[][]) {
   dbMock.results = [...results];
@@ -89,6 +99,12 @@ function updateSets() {
   return dbMock.operations
     .filter((operation) => operation.kind === "update")
     .map((operation) => operation.setArg ?? {});
+}
+
+function insertValues() {
+  return dbMock.operations
+    .filter((operation) => operation.kind === "insert")
+    .map((operation) => operation.valuesArg ?? {});
 }
 
 function baseJob(overrides: Record<string, unknown>) {
@@ -125,6 +141,8 @@ function baseJob(overrides: Record<string, unknown>) {
 
 describe("heartbeat stale running recovery", () => {
   const originalCronSecret = process.env.CRON_SECRET;
+  const originalFounderUserId = process.env.FOUNDER_USER_ID;
+  const originalAuraAdminUserIds = process.env.AURA_ADMIN_USER_IDS;
 
   beforeEach(() => {
     process.env.CRON_SECRET = "test-secret";
@@ -133,6 +151,7 @@ describe("heartbeat stale running recovery", () => {
     dbMock.results = [];
     dbMock.operations = [];
     vi.clearAllMocks();
+    sendJobFailureDmMock.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -141,6 +160,16 @@ describe("heartbeat stale running recovery", () => {
       delete process.env.CRON_SECRET;
     } else {
       process.env.CRON_SECRET = originalCronSecret;
+    }
+    if (originalFounderUserId === undefined) {
+      delete process.env.FOUNDER_USER_ID;
+    } else {
+      process.env.FOUNDER_USER_ID = originalFounderUserId;
+    }
+    if (originalAuraAdminUserIds === undefined) {
+      delete process.env.AURA_ADMIN_USER_IDS;
+    } else {
+      process.env.AURA_ADMIN_USER_IDS = originalAuraAdminUserIds;
     }
   });
 
@@ -254,5 +283,169 @@ describe("heartbeat stale running recovery", () => {
       ),
     ).toBe(false);
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to founder or admin env vars for system-owned jobs", async () => {
+    process.env.FOUNDER_USER_ID = "U_FOUNDER";
+    process.env.AURA_ADMIN_USER_IDS = "U_ADMIN";
+
+    const { resolveJobFailureDmTarget } = await import("./job-notifications.js");
+
+    expect(resolveJobFailureDmTarget("aura")).toBeNull();
+    expect(resolveJobFailureDmTarget(null)).toBeNull();
+    expect(resolveJobFailureDmTarget(" U_OWNER ")).toBe("U_OWNER");
+  });
+
+  it("escalates after 5 consecutive failed recurring job executions", async () => {
+    const recurringJob = baseJob({
+      status: "pending",
+      cronSchedule: "* * * * *",
+      name: "sync-meta-comments-daily",
+      lastResult: "previous failure",
+    });
+    const recentFailures = [0, 1, 2, 3, 4].map((index) => ({
+      id: `exec-${index}`,
+      status: "failed",
+      startedAt: new Date(`2026-05-20T08:5${4 - index}:00.000Z`),
+      error: index === 0 ? "Meta API timeout" : "previous error",
+    }));
+
+    executeJobMock.mockRejectedValueOnce(new Error("Meta API timeout"));
+    queueDbResults(
+      [recurringJob], // pending jobs
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // stale running jobs below max retries
+      [], // stale exhausted jobs
+      recentFailures, // recent job executions
+      [], // no existing marker
+      [], // marker insert
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
+    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        requestedBy: "U_REQUESTER",
+        text: expect.stringContaining(
+          "Your recurring job `sync-meta-comments-daily` has failed 5 consecutive runs.",
+        ),
+      }),
+    );
+    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("It's been broken since 2026-05-20T08:50:00.000Z."),
+      }),
+    );
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topic: "job-failure-streak:job-1",
+          category: "job_failure_streak_marker",
+          injectInContext: false,
+        }),
+      ]),
+    );
+  });
+
+  it("does not duplicate escalation on the 6th consecutive failure in the same streak", async () => {
+    const recurringJob = baseJob({
+      status: "pending",
+      cronSchedule: "* * * * *",
+      name: "sync-meta-comments-daily",
+    });
+    const recentFailures = [0, 1, 2, 3, 4].map((index) => ({
+      id: `exec-${index + 2}`,
+      status: "failed",
+      startedAt: new Date(`2026-05-20T08:5${5 - index}:00.000Z`),
+      error: "still failing",
+    }));
+
+    executeJobMock.mockRejectedValueOnce(new Error("still failing"));
+    queueDbResults(
+      [recurringJob],
+      [],
+      [],
+      [],
+      [],
+      recentFailures,
+      [{ id: "marker-1", updatedAt: new Date("2026-05-20T08:54:30.000Z") }],
+      [], // no successful executions since the marker
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+    expect(insertValues()).toEqual([]);
+  });
+
+  it("does not escalate immediately after a successful run resets the streak", async () => {
+    const recurringJob = baseJob({
+      status: "pending",
+      cronSchedule: "* * * * *",
+      name: "sync-meta-comments-daily",
+    });
+    const recentExecutions = [
+      {
+        id: "exec-latest",
+        status: "failed",
+        startedAt: new Date("2026-05-20T08:58:00.000Z"),
+        error: "new failure",
+      },
+      {
+        id: "exec-success",
+        status: "completed",
+        startedAt: new Date("2026-05-20T08:57:00.000Z"),
+        error: null,
+      },
+      {
+        id: "exec-old-1",
+        status: "failed",
+        startedAt: new Date("2026-05-20T08:56:00.000Z"),
+        error: "old failure",
+      },
+      {
+        id: "exec-old-2",
+        status: "failed",
+        startedAt: new Date("2026-05-20T08:55:00.000Z"),
+        error: "old failure",
+      },
+      {
+        id: "exec-old-3",
+        status: "failed",
+        startedAt: new Date("2026-05-20T08:54:00.000Z"),
+        error: "old failure",
+      },
+    ];
+
+    executeJobMock.mockRejectedValueOnce(new Error("new failure"));
+    queueDbResults(
+      [recurringJob],
+      [],
+      [],
+      [],
+      [],
+      recentExecutions,
+      [], // marker reset delete
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+    expect(insertValues()).toEqual([]);
   });
 });

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, lt, lte, gte, sql, isNull, or, inArray } from "drizzle-orm";
+import { eq, and, lt, lte, gte, gt, desc, sql, isNull, or, inArray } from "drizzle-orm";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
 import { jobs, notes, jobExecutions } from "@aura/db/schema";
@@ -14,6 +14,9 @@ const MAX_JOBS_PER_SWEEP = 10;
 
 /** Threshold for recovering jobs stuck in "running" (15 minutes) */
 const STALE_RUNNING_THRESHOLD_MS = 15 * 60 * 1000;
+
+/** Consecutive failed recurring executions before owner escalation */
+const CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD = 5;
 
 // ── Job Eligibility (recurring jobs) ─────────────────────────────────────────
 
@@ -69,6 +72,141 @@ function isRecurringJobDue(job: typeof jobs.$inferSelect): boolean {
   return true;
 }
 
+function consecutiveFailureMarkerTopic(jobId: string): string {
+  return `job-failure-streak:${jobId}`;
+}
+
+async function clearConsecutiveFailureMarker(job: typeof jobs.$inferSelect): Promise<void> {
+  await db
+    .delete(notes)
+    .where(
+      and(
+        eq(notes.workspaceId, job.workspaceId),
+        eq(notes.topic, consecutiveFailureMarkerTopic(job.id)),
+      ),
+    );
+}
+
+async function maybeEscalateConsecutiveRecurringFailures(
+  failedJobs: Array<typeof jobs.$inferSelect>,
+): Promise<number> {
+  let escalated = 0;
+
+  for (const job of failedJobs) {
+    const recentExecutions = await db
+      .select({
+        id: jobExecutions.id,
+        status: jobExecutions.status,
+        startedAt: jobExecutions.startedAt,
+        error: jobExecutions.error,
+      })
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id))
+      .orderBy(desc(jobExecutions.startedAt))
+      .limit(CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD);
+
+    if (
+      recentExecutions.length < CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD ||
+      recentExecutions.some((execution) => execution.status !== "failed")
+    ) {
+      if (recentExecutions.some((execution) => execution.status === "completed")) {
+        await clearConsecutiveFailureMarker(job);
+      }
+      continue;
+    }
+
+    const markerTopic = consecutiveFailureMarkerTopic(job.id);
+    const [existingMarker] = await db
+      .select({ id: notes.id, updatedAt: notes.updatedAt })
+      .from(notes)
+      .where(and(eq(notes.workspaceId, job.workspaceId), eq(notes.topic, markerTopic)))
+      .limit(1);
+
+    if (existingMarker) {
+      const successfulExecutionsSinceMarker = await db
+        .select({ id: jobExecutions.id })
+        .from(jobExecutions)
+        .where(
+          and(
+            eq(jobExecutions.jobId, job.id),
+            eq(jobExecutions.status, "completed"),
+            gt(jobExecutions.startedAt, existingMarker.updatedAt),
+          ),
+        )
+        .limit(1);
+
+      if (successfulExecutionsSinceMarker.length === 0) {
+        logger.info("recurring_job_failure_streak_dm_deduped", {
+          jobId: job.id,
+          jobName: job.name,
+          threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
+        });
+        continue;
+      }
+
+      await clearConsecutiveFailureMarker(job);
+    }
+
+    const streakStart = recentExecutions[recentExecutions.length - 1];
+    const latestFailure = recentExecutions[0];
+    const lastError = truncateJobFailureText(latestFailure.error ?? job.lastResult);
+
+    const sent = await sendJobFailureDm({
+      jobId: job.id,
+      requestedBy: job.requestedBy,
+      text: `Your recurring job \`${job.name}\` has failed ${CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD} consecutive runs. Last error: ${lastError}. It's been broken since ${streakStart.startedAt.toISOString()}. Disable it with \`cancel_job\` if it's no longer needed, or fix it.`,
+      logContext: {
+        event: "recurring_job_consecutive_failures",
+        threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
+        streakStartedAt: streakStart.startedAt.toISOString(),
+      },
+    });
+
+    if (!sent) continue;
+
+    const now = new Date();
+    await db
+      .insert(notes)
+      .values({
+        workspaceId: job.workspaceId,
+        topic: markerTopic,
+        content: JSON.stringify({
+          jobId: job.id,
+          threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
+          latestFailureStartedAt: latestFailure.startedAt.toISOString(),
+          streakStartedAt: streakStart.startedAt.toISOString(),
+        }),
+        category: "job_failure_streak_marker",
+        injectInContext: false,
+        ownerId: job.requestedBy,
+        visibility: "private",
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [notes.workspaceId, notes.topic],
+        set: {
+          content: JSON.stringify({
+            jobId: job.id,
+            threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
+            latestFailureStartedAt: latestFailure.startedAt.toISOString(),
+            streakStartedAt: streakStart.startedAt.toISOString(),
+          }),
+          updatedAt: now,
+        },
+      });
+
+    escalated++;
+    logger.warn("recurring_job_consecutive_failures_escalated", {
+      jobId: job.id,
+      jobName: job.name,
+      threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
+      streakStartedAt: streakStart.startedAt.toISOString(),
+    });
+  }
+
+  return escalated;
+}
+
 // ── Heartbeat Cron App ───────────────────────────────────────────────────────
 
 export const heartbeatApp = new Hono();
@@ -90,6 +228,8 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
   let plansExpired = 0;
   let plansAbandoned = 0;
   let staleRunningRecovered = 0;
+  let consecutiveFailureEscalations = 0;
+  const recurringJobsWithFreshFailures = new Map<string, typeof jobs.$inferSelect>();
 
   try {
     const now = new Date();
@@ -150,6 +290,9 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
             jobName: job.name,
             error: error.message,
           });
+          if (job.cronSchedule != null) {
+            recurringJobsWithFreshFailures.set(job.id, job);
+          }
           failed++;
         }
       }
@@ -338,6 +481,10 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       });
     }
 
+    consecutiveFailureEscalations = await maybeEscalateConsecutiveRecurringFailures(
+      [...recurringJobsWithFreshFailures.values()],
+    );
+
     // ── Done ─────────────────────────────────────────────────────────────
 
     const duration = Date.now() - sweepStart;
@@ -347,9 +494,19 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       plansExpired,
       plansAbandoned,
       staleRunningRecovered,
+      consecutiveFailureEscalations,
     });
 
-    return c.json({ ok: true, executed, failed, plansExpired, plansAbandoned, staleRunningRecovered, duration });
+    return c.json({
+      ok: true,
+      executed,
+      failed,
+      plansExpired,
+      plansAbandoned,
+      staleRunningRecovered,
+      consecutiveFailureEscalations,
+      duration,
+    });
   } catch (error: any) {
     logger.error("Heartbeat failed", { error: error.message });
     return c.json({ error: "Heartbeat failed" }, 500);

--- a/apps/api/src/cron/job-notifications.ts
+++ b/apps/api/src/cron/job-notifications.ts
@@ -12,43 +12,35 @@ export function truncateJobFailureText(value: string | null | undefined, maxChar
   return `${text.slice(0, maxChars - 3)}...`;
 }
 
-function firstAdminUserId(): string | null {
-  return (
-    (process.env.AURA_ADMIN_USER_IDS || "")
-      .split(",")
-      .map((id) => id.trim())
-      .find(Boolean) ?? null
-  );
-}
-
 export function resolveJobFailureDmTarget(
   requestedBy: string | null | undefined,
-  { fallbackToAdmin = true }: { fallbackToAdmin?: boolean } = {},
 ): string | null {
   const requester = requestedBy?.trim();
   if (requester && requester !== "aura") return requester;
-  if (!fallbackToAdmin) return null;
-
-  return process.env.FOUNDER_USER_ID?.trim() || firstAdminUserId();
+  return null;
 }
 
 export async function sendJobFailureDm({
   jobId,
   requestedBy,
   text,
-  fallbackToAdmin = true,
   logContext = {},
 }: {
   jobId: string;
   requestedBy: string | null | undefined;
   text: string;
-  fallbackToAdmin?: boolean;
   logContext?: Record<string, unknown>;
 }): Promise<boolean> {
-  const target = resolveJobFailureDmTarget(requestedBy, { fallbackToAdmin });
+  const target = resolveJobFailureDmTarget(requestedBy);
 
   if (!target) {
-    logger.warn("Job failure DM skipped: no target", { jobId, ...logContext });
+    const requester = requestedBy?.trim();
+    logger.warn(
+      requester === "aura"
+        ? "job_failure_dm_skipped_system_owned"
+        : "job_failure_dm_skipped_no_target",
+      { jobId, requestedBy, ...logContext },
+    );
     return false;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove founder/admin fallback routing from job failure DMs; failures now go to `requested_by` or are skipped for system-owned/missing owners.
- Add inline heartbeat detection for recurring cron jobs with 5 consecutive failed `job_executions`.
- Send one owner escalation DM per failure streak and reset the marker once a completed execution breaks the streak.

## Dedupe choice
Used a `notes`-backed marker (`job_failure_streak:<jobId>`) instead of adding a `jobs.last_streak_dm_at` column. This keeps the fix schema-light, avoids a migration for operational notification state, and lets heartbeat delete/reset the marker when a successful execution appears in the recent streak window.

## Tests
- `pnpm --filter aura-api test -- src/cron/heartbeat.test.ts`
- `pnpm typecheck`
- `npx tsc --noEmit` from `apps/api`

Fixes #977
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad3d0ef1-3ba3-4008-985a-0633a5167471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad3d0ef1-3ba3-4008-985a-0633a5167471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

