### PR TITLE
fix(cursor-agent): correct followup endpoint path (404 fix)

### DIFF
--- a/apps/api/src/lib/cursor-agent.ts
+++ b/apps/api/src/lib/cursor-agent.ts
@@ -112,7 +112,7 @@ export async function followupCursorAgent(
   agentId: string,
   prompt: string,
 ): Promise<CursorAgentResponse> {
-  const res = await fetch(`${CURSOR_API_BASE}/agents/${agentId}/follow-up`, {
+  const res = await fetch(`${CURSOR_API_BASE}/agents/${agentId}/followup`, {
     method: "POST",
     headers: await headers(),
     body: JSON.stringify({ prompt: { text: prompt } }),
@@ -120,7 +120,7 @@ export async function followupCursorAgent(
   if (!res.ok) {
     const text = await res.text();
     throw new Error(
-      `Cursor API POST /agents/${agentId}/follow-up failed (${res.status}): ${text}`,
+      `Cursor API POST /agents/${agentId}/followup failed (${res.status}): ${text}`,
     );
   }
   return (await res.json()) as CursorAgentResponse;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct Cursor follow-up API path from `/agents/{id}/follow-up` to `/agents/{id}/followup`.
- Update the matching error message string.

Closes #981.

## Quick audit
- Checked the Cursor pass-through docs for the other endpoints used in `apps/api/src/lib/cursor-agent.ts`: `/agents`, `/agents/{id}`, `/agents/{id}/conversation`, and `/agents/{id}/stop` match the documented paths.

## Tests
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5cb783-075d-4060-b59e-eb684d4169ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5cb783-075d-4060-b59e-eb684d4169ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

