### PR TITLE
Resurface stream-death root cause to error_events (#983)

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -57,6 +57,7 @@ vi.mock("./prepare-step.js", () => ({
 }));
 
 import { generateResponse } from "./respond.js";
+import { logError } from "../lib/error-logger.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -87,6 +88,7 @@ function mockAgentStream(fullStream: AsyncIterable<any>) {
       stream: vi.fn().mockResolvedValue({
         fullStream,
         usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+        finishReason: Promise.resolve("stop"),
         steps: Promise.resolve([]),
       }),
     },
@@ -246,6 +248,57 @@ describe("generateResponse Slack stream handling", () => {
       channel: "C123",
       thread_ts: "1710000000.000000",
       text: expect.stringContaining("Fallback text."),
+    }));
+  });
+
+  it("logs empty completions after tool errors without recording unexpected stream errors", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-error",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        error: new Error("sandbox died"),
+      };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    const logErrorMock = vi.mocked(logError);
+    const emptyCompletionLogs = logErrorMock.mock.calls.filter(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools",
+    );
+    const unexpectedStreamLogs = logErrorMock.mock.calls.filter(
+      ([entry]) => entry.errorName === "UnexpectedStreamError",
+    );
+
+    expect(emptyCompletionLogs).toHaveLength(1);
+    expect(emptyCompletionLogs[0]?.[0]).toMatchObject({
+      errorName: "EmptyCompletion",
+      errorCode: "empty_completion_after_tools",
+      channelId: "C123",
+      context: {
+        toolCallCount: 1,
+        toolErrorCount: 1,
+        finishReason: "stop",
+      },
+    });
+    expect(unexpectedStreamLogs).toHaveLength(0);
+    expect(stream.stop).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "markdown_text",
+        text: expect.stringContaining("no output generated"),
+      })],
+    });
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "C123",
+      thread_ts: "1710000000.000000",
+      text: "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_",
     }));
   });
 });

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -512,7 +512,12 @@ export async function generateResponse(
           errorMessage: err?.message || "unexpected error on stream append",
           errorCode: err?.data?.error || "unknown",
           channelId,
-          context: { fallback: "postMessage" },
+          context: {
+            fallback: "postMessage",
+            ...(err?.data?.error === "message_not_in_streaming_state" && {
+              isFallbackRecovery: true,
+            }),
+          },
         });
       }
       if (streamingFailed) {
@@ -566,6 +571,20 @@ export async function generateResponse(
 
   const streamCallOptions: Record<string, any> = {
     abortSignal: abortController.signal,
+    onError: ({ error }: { error: unknown }) => {
+      const streamError = error instanceof Error ? error : undefined;
+      const errorLike = error && typeof error === "object"
+        ? error as { name?: string; message?: string; stack?: string }
+        : undefined;
+      logError({
+        errorName: errorLike?.name || streamError?.name || "StreamMidFlightError",
+        errorMessage: errorLike?.message || streamError?.message || String(error),
+        errorCode: "stream_on_error_callback",
+        channelId,
+        context: { accumulatedTextLength: accumulatedText.length },
+        stackTrace: errorLike?.stack || streamError?.stack,
+      });
+    },
   };
 
   if (hasFiles) {
@@ -596,6 +615,8 @@ export async function generateResponse(
   let continuationCount = 0;
   let tableBuffer: string[] = [];
   let lineCarry = "";
+  let emptyCompletionDetected = false;
+  const emptyCompletionFallbackText = "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_";
 
   function clearLongToolSplitTimer() {
     if (longToolSplitTimer) {
@@ -1054,6 +1075,42 @@ export async function generateResponse(
       }
     }
 
+    if (accumulatedText.length === 0 && toolCallRecords.length > 0) {
+      let finishReason: unknown;
+      try {
+        finishReason = (result as any).finishReason
+          ? await (result as any).finishReason
+          : undefined;
+      } catch {
+        finishReason = undefined;
+      }
+
+      logError({
+        errorName: "EmptyCompletion",
+        errorMessage: "Stream completed without usable output after tool calls",
+        errorCode: "empty_completion_after_tools",
+        channelId,
+        context: {
+          toolCallCount: toolCallRecords.length,
+          toolErrorCount: toolCallRecords.filter((record) => record.is_error).length,
+          finishReason,
+        },
+      });
+
+      streamingFailed = true;
+      emptyCompletionDetected = true;
+
+      if (streamer) {
+        try {
+          await streamer.stop({
+            chunks: [toChunkMarkdownText("\n\n_...(no output generated — see Aura logs)_")],
+          });
+        } catch {
+          // Stream may already be unrecoverable.
+        }
+      }
+    }
+
     // ── Finalize ──────────────────────────────────────────────────────────
     clearTimeout(inactivityTimer);
     if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
@@ -1071,7 +1128,7 @@ export async function generateResponse(
 
     if (streamingFailed) {
       // Stop the current streamer to avoid leaving an orphaned stream on Slack
-      if (streamer) {
+      if (streamer && !emptyCompletionDetected) {
         try { await streamer.stop(); } catch { /* stream may already be broken */ }
       }
 
@@ -1107,7 +1164,9 @@ export async function generateResponse(
       });
 
       const toolMeta = buildToolMetadata(toolCallRecords);
-      const fallbackText = formattedUnsent || "_I processed your request but had nothing to say._";
+      const fallbackText = emptyCompletionDetected
+        ? emptyCompletionFallbackText
+        : formattedUnsent || "_I processed your request but had nothing to say._";
 
       try {
         const fallbackResult = await safePostMessage(slackClient, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes https://github.com/AuraHQ-ai/aura/issues/983.

Included fixes:

1. Empty-completion detection: after `fullStream` completes with tool calls but no accumulated text, log `empty_completion_after_tools` with tool counts, error counts, and finish reason.
2. AI SDK stream `onError` handler: logs `stream_on_error_callback` with accumulated text length and stack trace when available.
3. Fallback-recovery tagging: marks `UnexpectedStreamError` entries caused by `message_not_in_streaming_state` with `isFallbackRecovery: true`.
4. Visible empty-completion tombstone: attempts to finalize the Slack stream with `...(no output generated — see Aura logs)` before posting the user-visible retry prompt.
5. Smoke test: added coverage for a `tool-error`-only stream, asserting exactly one `empty_completion_after_tools` log and no `UnexpectedStreamError`.

## Verification

- `pnpm --filter aura-api test -- src/pipeline/respond.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0043162-3e8f-4771-acac-395f60fe687f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0043162-3e8f-4771-acac-395f60fe687f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

