### PR TITLE
Fix #988: catch continuation-empty-completion and AbortError stream deaths

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -29,7 +29,7 @@ import {
   hasPermission,
 } from "./lib/api-credentials.js";
 import { resolveConfirmation } from "./lib/confirmation.js";
-import { executionContext } from "./lib/tool.js";
+import { executionContext, type ExecutionContext } from "./lib/tool.js";
 import { setSetting, getConfig } from "./lib/settings.js";
 import { logger } from "./lib/logger.js";
 import { resolveSlackDestination } from "./tools/slack.js";
@@ -38,7 +38,7 @@ import { safePostMessage } from "./lib/slack-messaging.js";
 import crypto from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { db } from "./db/client.js";
-import { notes, feedback } from "@aura/db/schema";
+import { errorEvents, notes, feedback } from "@aura/db/schema";
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -53,6 +53,73 @@ if (!signingSecret || !botToken) {
 }
 
 const slackClient = new WebClient(botToken);
+
+// ── Process-level crash fallback ────────────────────────────────────────────
+
+let latestInFlightContext: ExecutionContext | null = null;
+const globalForProcessHooks = globalThis as typeof globalThis & {
+  __auraProcessErrorHooksRegistered?: boolean;
+};
+
+function stringifyUnhandledReason(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === "string") return reason;
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+function stackForUnhandledReason(reason: unknown): string | undefined {
+  if (reason instanceof Error) return reason.stack;
+  if (reason && typeof reason === "object" && "stack" in reason) {
+    return String((reason as { stack?: unknown }).stack);
+  }
+  return undefined;
+}
+
+function logProcessLevelError(
+  errorName: "UnhandledRejection" | "UncaughtException",
+  reason: unknown,
+): void {
+  try {
+    const ctx = executionContext.getStore() ?? latestInFlightContext ?? undefined;
+    const write = db.insert(errorEvents)
+      .values({
+        errorName,
+        errorMessage: stringifyUnhandledReason(reason) || errorName,
+        errorCode: "function_died_unhandled",
+        userId: ctx?.callingUserId ?? ctx?.triggeredBy,
+        channelId: ctx?.channelId,
+        context: {
+          triggerType: ctx?.triggerType,
+          threadTs: ctx?.threadTs,
+          workspaceId: ctx?.workspaceId,
+        },
+        stackTrace: stackForUnhandledReason(reason),
+      })
+      .catch(() => {});
+
+    const timeout = new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 1_500);
+      (timer as any).unref?.();
+    });
+    void Promise.race([write, timeout]).catch(() => {});
+  } catch {
+    // Process-level handlers must never throw.
+  }
+}
+
+if (!globalForProcessHooks.__auraProcessErrorHooksRegistered) {
+  globalForProcessHooks.__auraProcessErrorHooksRegistered = true;
+  process.on("unhandledRejection", (reason) => {
+    logProcessLevelError("UnhandledRejection", reason);
+  });
+  process.on("uncaughtException", (error) => {
+    logProcessLevelError("UncaughtException", error);
+  });
+}
 
 // ── Hono App ────────────────────────────────────────────────────────────────
 
@@ -257,15 +324,17 @@ app.post("/api/slack/events", async (c) => {
     // On Vercel, we must acknowledge within 3 seconds, so we process
     // in the background using waitUntil where available.
     const userId = event.user || "unknown";
+    const eventExecutionContext: ExecutionContext = {
+      triggeredBy: userId,
+      triggerType: "user_message",
+      callingUserId: event.user || undefined,
+      channelId: event.channel || undefined,
+      threadTs: event.thread_ts || event.ts || undefined,
+      workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
+    };
+    latestInFlightContext = eventExecutionContext;
     const pipelinePromise = executionContext.run(
-      {
-        triggeredBy: userId,
-        triggerType: "user_message",
-        callingUserId: event.user || undefined,
-        channelId: event.channel || undefined,
-        threadTs: event.thread_ts || event.ts || undefined,
-        workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
-      },
+      eventExecutionContext,
       async () =>
         runPipeline({
           event,
@@ -278,6 +347,10 @@ app.post("/api/slack/events", async (c) => {
         eventType: event.type,
         channel: event.channel,
       });
+    }).finally(() => {
+      if (latestInFlightContext === eventExecutionContext) {
+        latestInFlightContext = null;
+      }
     });
 
     // Keep the function alive after the response is sent so the

--- a/apps/api/src/lib/error-logger.test.ts
+++ b/apps/api/src/lib/error-logger.test.ts
@@ -1,8 +1,35 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
 
-const { sanitizeErrorText } = await import("./error-logger.js");
+const dbMock = vi.hoisted(() => {
+  const values = vi.fn((row: any) => Promise.resolve(row));
+  const insert = vi.fn(() => ({ values }));
+  return { insert, values };
+});
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    insert: dbMock.insert,
+  },
+}));
+
+vi.mock("./slack-messaging.js", () => ({
+  safePostMessage: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+const {
+  flushLoggerDrops,
+  resetErrorLoggerStateForTest,
+  sanitizeErrorText,
+  logError,
+} = await import("./error-logger.js");
 
 function numericArray(length: number): string {
   return `[${Array.from({ length }, (_, i) => ((i + 1) / 1000).toFixed(4)).join(",")}]`;
@@ -50,5 +77,57 @@ describe("sanitizeErrorText", () => {
   it("returns an empty string for nullish input", () => {
     expect(sanitizeErrorText(null)).toBe("");
     expect(sanitizeErrorText(undefined)).toBe("");
+  });
+});
+
+describe("logError rate-limit drop visibility", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T15:00:00.000Z"));
+    dbMock.insert.mockClear();
+    dbMock.values.mockClear();
+    resetErrorLoggerStateForTest();
+  });
+
+  afterEach(() => {
+    resetErrorLoggerStateForTest();
+    vi.useRealTimers();
+  });
+
+  it("flushes per-code rate-limit drops to error_events", async () => {
+    for (let i = 0; i < 6; i++) {
+      logError({
+        errorName: "NoisyError",
+        errorMessage: `noisy ${i}`,
+        errorCode: "noisy_error",
+      });
+    }
+
+    expect(dbMock.values).toHaveBeenCalledTimes(5);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushLoggerDrops();
+
+    const loggerDropRows = dbMock.values.mock.calls
+      .map(([row]) => row)
+      .filter((row) => row.errorCode === "error_logger_drops");
+
+    expect(loggerDropRows).toHaveLength(1);
+    expect(loggerDropRows[0]).toMatchObject({
+      errorName: "LoggerDrops",
+      errorCode: "error_logger_drops",
+      context: {
+        totalDropped: 1,
+        drops: {
+          noisy_error: {
+            count: 1,
+            reasons: {
+              per_code: 1,
+              global: 0,
+            },
+          },
+        },
+      },
+    });
   });
 });

--- a/apps/api/src/lib/error-logger.ts
+++ b/apps/api/src/lib/error-logger.ts
@@ -23,14 +23,21 @@ interface RateWindow {
   windowStart: number;
 }
 
+type RateLimitReason = "per_code" | "global";
+
 const RATE_LIMIT_PER_CODE = 5;
 const RATE_WINDOW_MS = 60_000;
 const GLOBAL_LIMIT = 20;
 const SLACK_COOLDOWN_MS = 5 * 60_000;
+const LOGGER_DROPS_FLUSH_MS = 60_000;
+const LOGGER_DROPS_ERROR_CODE = "error_logger_drops";
 
 const perCodeWindows = new Map<string, RateWindow>();
 let globalWindow: RateWindow = { count: 0, windowStart: Date.now() };
 let globalCircuitOpen = false;
+const droppedByCode = new Map<string, { count: number; reasons: Record<RateLimitReason, number> }>();
+let dropsFlushTimer: ReturnType<typeof setInterval> | null = null;
+let flushingDrops = false;
 
 const slackWindows = new Map<
   string,
@@ -72,7 +79,7 @@ export function sanitizeErrorText(
   return out;
 }
 
-function isRateLimited(errorCode: string): boolean {
+function getRateLimit(errorCode: string): { limited: false } | { limited: true; reason: RateLimitReason } {
   const now = Date.now();
 
   // Global circuit breaker
@@ -80,7 +87,7 @@ function isRateLimited(errorCode: string): boolean {
     globalWindow = { count: 0, windowStart: now };
     globalCircuitOpen = false;
   }
-  if (globalCircuitOpen) return true;
+  if (globalCircuitOpen) return { limited: true, reason: "global" };
   if (globalWindow.count >= GLOBAL_LIMIT) {
     if (!globalCircuitOpen) {
       globalCircuitOpen = true;
@@ -88,16 +95,19 @@ function isRateLimited(errorCode: string): boolean {
         "[error-logger] Global circuit breaker tripped — suppressing DB writes",
       );
     }
-    return true;
+    return { limited: true, reason: "global" };
   }
 
   // Per-code rate limit
   const window = perCodeWindows.get(errorCode);
   if (!window || now - window.windowStart > RATE_WINDOW_MS) {
     perCodeWindows.set(errorCode, { count: 0, windowStart: now });
-    return false;
+    return { limited: false };
   }
-  return window.count >= RATE_LIMIT_PER_CODE;
+  if (window.count >= RATE_LIMIT_PER_CODE) {
+    return { limited: true, reason: "per_code" };
+  }
+  return { limited: false };
 }
 
 function recordWrite(errorCode: string): void {
@@ -110,6 +120,91 @@ function recordWrite(errorCode: string): void {
     window.count++;
   } else {
     perCodeWindows.set(errorCode, { count: 1, windowStart: now });
+  }
+}
+
+function ensureDropsFlushTimer(): void {
+  if (dropsFlushTimer) return;
+
+  dropsFlushTimer = setInterval(() => {
+    flushLoggerDrops().catch(() => {});
+  }, LOGGER_DROPS_FLUSH_MS);
+  (dropsFlushTimer as any).unref?.();
+}
+
+function recordDrop(errorCode: string, reason: RateLimitReason): void {
+  if (flushingDrops) return;
+
+  const existing = droppedByCode.get(errorCode) ?? {
+    count: 0,
+    reasons: { per_code: 0, global: 0 },
+  };
+  existing.count++;
+  existing.reasons[reason]++;
+  droppedByCode.set(errorCode, existing);
+  ensureDropsFlushTimer();
+}
+
+export async function flushLoggerDrops(): Promise<void> {
+  if (flushingDrops || droppedByCode.size === 0) return;
+
+  flushingDrops = true;
+  const drops = Object.fromEntries(
+    Array.from(droppedByCode.entries()).map(([errorCode, value]) => [
+      errorCode,
+      {
+        count: value.count,
+        reasons: { ...value.reasons },
+      },
+    ]),
+  );
+  droppedByCode.clear();
+
+  const totalDropped = Object.values(drops).reduce(
+    (sum, value) => sum + value.count,
+    0,
+  );
+
+  try {
+    await db.insert(errorEvents)
+      .values({
+        errorName: "LoggerDrops",
+        errorMessage: `Error logger dropped ${totalDropped} event${totalDropped === 1 ? "" : "s"} due to rate limiting`,
+        errorCode: LOGGER_DROPS_ERROR_CODE,
+        context: {
+          drops,
+          totalDropped,
+          flushIntervalMs: LOGGER_DROPS_FLUSH_MS,
+        },
+      });
+  } catch (err) {
+    for (const [errorCode, value] of Object.entries(drops)) {
+      const existing = droppedByCode.get(errorCode) ?? {
+        count: 0,
+        reasons: { per_code: 0, global: 0 },
+      };
+      existing.count += value.count;
+      existing.reasons.per_code += value.reasons.per_code;
+      existing.reasons.global += value.reasons.global;
+      droppedByCode.set(errorCode, existing);
+    }
+    logger.warn("Failed to flush error logger drop counters", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    flushingDrops = false;
+  }
+}
+
+export function resetErrorLoggerStateForTest(): void {
+  perCodeWindows.clear();
+  globalWindow = { count: 0, windowStart: Date.now() };
+  globalCircuitOpen = false;
+  droppedByCode.clear();
+  flushingDrops = false;
+  if (dropsFlushTimer) {
+    clearInterval(dropsFlushTimer);
+    dropsFlushTimer = null;
   }
 }
 
@@ -202,8 +297,9 @@ async function postToSlack(params: LogErrorParams): Promise<void> {
  */
 export function logError(params: LogErrorParams): void {
   const code = params.errorCode || params.errorName;
+  const rateLimit = getRateLimit(code);
 
-  if (!isRateLimited(code)) {
+  if (!rateLimit.limited) {
     recordWrite(code);
 
     db.insert(errorEvents)
@@ -218,6 +314,8 @@ export function logError(params: LogErrorParams): void {
         stackTrace: sanitizeErrorText(params.stackTrace),
       })
       .catch(() => {});
+  } else {
+    recordDrop(code, rateLimit.reason);
   }
 
   if (!globalCircuitOpen) {

--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -301,4 +301,144 @@ describe("generateResponse Slack stream handling", () => {
       text: "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_",
     }));
   });
+
+  it("logs empty completions for tool-error-only continuation segments", async () => {
+    vi.useFakeTimers();
+    const finishTool = deferred<void>();
+    const firstStream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondStream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([firstStream, secondStream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Starting the job.\n" };
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "sleep 200", timeout_seconds: 200 },
+      };
+      await finishTool.promise;
+      yield {
+        type: "tool-error",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        error: new Error("sandbox died"),
+      };
+    })());
+
+    const responsePromise = generateResponse(baseOptions(slackClient));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(75_000);
+    expect(slackClient.chatStream).toHaveBeenCalledTimes(2);
+
+    finishTool.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(responsePromise).resolves.toMatchObject({
+      raw: "Starting the job.\n",
+      alreadyPosted: true,
+    });
+
+    const logErrorMock = vi.mocked(logError);
+    const continuationLogs = logErrorMock.mock.calls.filter(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools_continuation",
+    );
+    const aggregateLogs = logErrorMock.mock.calls.filter(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools",
+    );
+
+    expect(continuationLogs).toHaveLength(1);
+    expect(continuationLogs[0]?.[0]).toMatchObject({
+      errorName: "EmptyCompletion",
+      errorCode: "empty_completion_after_tools_continuation",
+      channelId: "C123",
+      context: {
+        toolCallCount: 1,
+        toolErrorCount: 1,
+        segmentIndex: 1,
+        continuationReason: "long_tool",
+        segmentEnd: "final",
+        finishReason: "stop",
+      },
+    });
+    expect(aggregateLogs).toHaveLength(0);
+    expect(secondStream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "markdown_text",
+        text: expect.stringContaining("no output generated in continuation"),
+      })],
+    });
+  });
+
+  it("logs and tombstones watchdog AbortError streams", async () => {
+    vi.useFakeTimers();
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+      code: "ABORT_ERR",
+    });
+
+    agentMocks.createInteractiveAgent.mockResolvedValue({
+      agent: {
+        stream: vi.fn().mockImplementation(async (options: { abortSignal: AbortSignal }) => ({
+          fullStream: (async function* () {
+            await new Promise<void>((_resolve, reject) => {
+              if (options.abortSignal.aborted) {
+                reject(abortError);
+                return;
+              }
+              options.abortSignal.addEventListener("abort", () => reject(abortError), { once: true });
+            });
+          })(),
+          usage: Promise.resolve({ inputTokens: 1, outputTokens: 0 }),
+          finishReason: Promise.resolve("abort"),
+          steps: Promise.resolve([]),
+        })),
+      },
+      tools: {},
+      modelId: "test-model",
+      getStepModelIds: () => ["test-model"],
+    });
+
+    const responsePromise = generateResponse(baseOptions(slackClient));
+    const responseExpectation = expect(responsePromise).rejects.toMatchObject({
+      name: "AbortError",
+      code: "ABORT_ERR",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(180_000);
+
+    await responseExpectation;
+
+    const abortLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "stream_aborted_by_watchdog",
+    );
+    expect(abortLogs).toHaveLength(1);
+    expect(abortLogs[0]?.[0]).toMatchObject({
+      errorName: "StreamAborted",
+      errorCode: "stream_aborted_by_watchdog",
+      channelId: "C123",
+      context: {
+        reason: "inactivity",
+        accumulatedTextLength: 0,
+        toolCallCount: 0,
+        segmentIndex: 0,
+      },
+    });
+    expect(stream.stop).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "markdown_text",
+        text: expect.stringContaining("[stream aborted: inactivity]"),
+      })],
+    });
+  });
 });

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -528,14 +528,19 @@ export async function generateResponse(
   }
 
   // ── Inactivity timeout ───────────────────────────────────────────────
+  type StreamAbortReason = "inactivity" | "long_tool" | "superseded" | "unknown";
+  type ContinuationReason = "length" | "long_tool";
+
   const abortController = new AbortController();
   let inactivityTimer: ReturnType<typeof setTimeout> = undefined as any;
+  let lastAbortReason: StreamAbortReason = "unknown";
 
   const resetTimer = () => {
     clearTimeout(inactivityTimer);
     inactivityTimer = setTimeout(() => {
       logger.warn("LLM inactivity timeout (180s), aborting");
-      abortController.abort();
+      lastAbortReason = "inactivity";
+      abortController.abort("inactivity");
     }, 180_000);
   };
   resetTimer();
@@ -613,10 +618,53 @@ export async function generateResponse(
   const toolCallRecords: ToolCallRecord[] = [];
   const pendingToolInputs = new Map<string, { name: string; input: string }>();
   let continuationCount = 0;
+  let currentSegmentIndex = 0;
+  let currentSegmentTextLength = 0;
+  let currentSegmentToolRecordStart = 0;
+  let currentSegmentContinuationReason: ContinuationReason | "root" = "root";
+  const loggedEmptyContinuationSegments = new Set<number>();
   let tableBuffer: string[] = [];
   let lineCarry = "";
   let emptyCompletionDetected = false;
   const emptyCompletionFallbackText = "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_";
+
+  async function logEmptyContinuationSegmentIfNeeded(params: {
+    segmentEnd: "split" | "final";
+    finishReason?: unknown;
+  }): Promise<void> {
+    if (currentSegmentIndex === 0) return;
+    if (loggedEmptyContinuationSegments.has(currentSegmentIndex)) return;
+    if (currentSegmentTextLength > 0) return;
+
+    const segmentToolRecords = toolCallRecords.slice(currentSegmentToolRecordStart);
+    if (segmentToolRecords.length === 0) return;
+
+    loggedEmptyContinuationSegments.add(currentSegmentIndex);
+    logError({
+      errorName: "EmptyCompletion",
+      errorMessage: "Continuation stream completed without usable output after tool calls",
+      errorCode: "empty_completion_after_tools_continuation",
+      channelId,
+      context: {
+        toolCallCount: segmentToolRecords.length,
+        toolErrorCount: segmentToolRecords.filter((record) => record.is_error).length,
+        segmentIndex: currentSegmentIndex,
+        continuationReason: currentSegmentContinuationReason,
+        segmentEnd: params.segmentEnd,
+        finishReason: params.finishReason,
+      },
+    });
+
+    if (params.segmentEnd === "final" && streamer && !streamingFailed) {
+      try {
+        const tombstone = "\n\n_...(no output generated in continuation — see Aura logs)_";
+        currentStreamLength += tombstone.length;
+        await streamer.append(asAppendPayload({ markdown_text: tombstone }));
+      } catch {
+        // Stream may already be unrecoverable; the error row above is the durable signal.
+      }
+    }
+  }
 
   function clearLongToolSplitTimer() {
     if (longToolSplitTimer) {
@@ -741,7 +789,7 @@ export async function generateResponse(
     return output;
   }
 
-  async function splitToNewStream(reason: "length" | "long_tool" = "length"): Promise<boolean> {
+  async function splitToNewStream(reason: ContinuationReason = "length"): Promise<boolean> {
     if (streamingFailed || continuationCount >= MAX_CONTINUATIONS) {
       if (continuationCount >= MAX_CONTINUATIONS) {
         logger.warn("Max continuation messages reached", { continuationCount });
@@ -754,6 +802,10 @@ export async function generateResponse(
       totalAccumulated: accumulatedText.length,
       continuationCount: continuationCount + 1,
       reason,
+    });
+
+    await logEmptyContinuationSegmentIfNeeded({
+      segmentEnd: "split",
     });
 
     if (reason === "long_tool") {
@@ -773,6 +825,10 @@ export async function generateResponse(
       currentStreamLength = 0;
       streamTombstoneSent = false;
       continuationCount++;
+      currentSegmentIndex = continuationCount;
+      currentSegmentTextLength = 0;
+      currentSegmentToolRecordStart = toolCallRecords.length;
+      currentSegmentContinuationReason = reason;
       return true;
     } catch (startErr: any) {
       logger.warn(
@@ -829,6 +885,7 @@ export async function generateResponse(
       switch (chunk.type) {
         case "text-delta": {
           accumulatedText += chunk.text;
+          currentSegmentTextLength += chunk.text.length;
           let remaining = processChunkForTables(chunk.text);
           if (!remaining) break;
 
@@ -1074,6 +1131,20 @@ export async function generateResponse(
         fallbackStartIdx = streamedRawIdx;
       }
     }
+
+    let continuationFinishReason: unknown;
+    try {
+      continuationFinishReason = (result as any).finishReason
+        ? await (result as any).finishReason
+        : undefined;
+    } catch {
+      continuationFinishReason = undefined;
+    }
+
+    await logEmptyContinuationSegmentIfNeeded({
+      segmentEnd: "final",
+      finishReason: continuationFinishReason,
+    });
 
     if (accumulatedText.length === 0 && toolCallRecords.length > 0) {
       let finishReason: unknown;
@@ -1469,6 +1540,54 @@ export async function generateResponse(
           stackTrace: retryError instanceof Error ? retryError.stack : undefined,
         });
       }
+    }
+
+    const isAbortError = error?.name === "AbortError" || error?.code === "ABORT_ERR";
+    if (isAbortError) {
+      const reason = lastAbortReason || "unknown";
+      const tombstone = `_[stream aborted: ${reason}]_`;
+
+      logError({
+        errorName: "StreamAborted",
+        errorMessage: error?.message || `Stream aborted: ${reason}`,
+        errorCode: "stream_aborted_by_watchdog",
+        channelId,
+        context: {
+          reason,
+          accumulatedTextLength: accumulatedText.length,
+          toolCallCount: toolCallRecords.length,
+          segmentIndex: currentSegmentIndex,
+        },
+        stackTrace: error?.stack,
+      });
+
+      if (streamer && !streamingFailed) {
+        try {
+          await streamer.stop({ chunks: [toChunkMarkdownText(`\n\n${tombstone}`)] });
+        } catch {
+          try {
+            await safePostMessage(slackClient, {
+              channel: channelId,
+              text: tombstone,
+              thread_ts: threadTs,
+            });
+          } catch {
+            // Best effort only; preserve the original abort error.
+          }
+        }
+      } else {
+        try {
+          await safePostMessage(slackClient, {
+            channel: channelId,
+            text: tombstone,
+            thread_ts: threadTs,
+          });
+        } catch {
+          // Best effort only; preserve the original abort error.
+        }
+      }
+
+      throw error;
     }
 
     logError({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #988.

- Add per-continuation-segment EmptyCompletion logging for spawned Slack streams that finish with tool activity but no new text.
- Add explicit AbortError handling for watchdog-aborted streams, including a visible stream tombstone and `StreamAborted / stream_aborted_by_watchdog` error event context.
- Add rate-limit drop accounting and periodic `LoggerDrops / error_logger_drops` flushing in the error logger.
- Add process-level best-effort `function_died_unhandled` logging for unhandled rejections and uncaught exceptions with in-flight Slack context when available.

## Verification

- `pnpm --filter aura-api test src/pipeline/respond.test.ts src/lib/error-logger.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
- `pnpm --filter aura-api test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91462bde-b8fa-4dd5-a602-93a40a244d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91462bde-b8fa-4dd5-a602-93a40a244d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

