### PR TITLE
fix(sandbox): warn when run_command_detached env vars missing (#985)

### DIFF
--- a/apps/api/src/tools/sandbox.test.ts
+++ b/apps/api/src/tools/sandbox.test.ts
@@ -13,6 +13,13 @@ const sandboxMocks = vi.hoisted(() => ({
   ensureUserHome: vi.fn(),
 }));
 
+const loggerMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
 const dbMocks = vi.hoisted(() => ({
   insertValues: vi.fn(),
   insertOnConflictDoUpdate: vi.fn(),
@@ -29,12 +36,7 @@ vi.mock("../lib/sandbox.js", () => ({
 }));
 
 vi.mock("../lib/logger.js", () => ({
-  logger: {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
+  logger: loggerMocks,
 }));
 
 vi.mock("../lib/tool.js", () => ({
@@ -234,6 +236,37 @@ describe("sandbox command tools", () => {
       requestedBy: "U123",
       workspaceId: "default",
     }));
+  });
+
+  it("warns once when detached command webhook env vars are missing", async () => {
+    vi.resetModules();
+    delete process.env.AURA_PUBLIC_URL;
+    delete process.env.SANDBOX_WEBHOOK_SECRET;
+    const { createSandboxTools: createFreshSandboxTools } = await import("./sandbox.js");
+    const tool = createFreshSandboxTools({ userId: "U123" } as any).run_command_detached as any;
+
+    await tool.execute(tool.inputSchema.parse({ command: "sleep 300" }));
+    await tool.execute(tool.inputSchema.parse({ command: "sleep 301" }));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      "run_command_detached: webhook callback disabled, env vars missing",
+      {
+        missing: ["AURA_PUBLIC_URL", "SANDBOX_WEBHOOK_SECRET"],
+        effect:
+          "detached commands will run, but completion webhooks will silently no-op; results only available via check_command polling",
+      },
+    );
+  });
+
+  it("does not warn when detached command webhook env vars are present", async () => {
+    vi.resetModules();
+    const { createSandboxTools: createFreshSandboxTools } = await import("./sandbox.js");
+    const tool = createFreshSandboxTools({ userId: "U123" } as any).run_command_detached as any;
+
+    await tool.execute(tool.inputSchema.parse({ command: "sleep 300" }));
+
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
   });
 
   it("checks detached command status with default tail lines", async () => {

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -18,6 +18,8 @@ const DEFAULT_PUBLIC_URL = "https://aura-alpha-five.vercel.app";
 type Sandbox = Awaited<ReturnType<typeof getOrCreateSandbox>>;
 type CommandEnv = Record<string, string>;
 
+let warnedAboutWebhookEnv = false;
+
 interface DetachedCommandStart {
   id: string;
   pid: number;
@@ -50,6 +52,25 @@ function getPublicUrl(): string {
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`.replace(/\/+$/, "");
   }
   return DEFAULT_PUBLIC_URL;
+}
+
+function warnIfWebhookEnvMissing() {
+  if (warnedAboutWebhookEnv) return;
+
+  const missing: string[] = [];
+  if (!process.env.AURA_PUBLIC_URL) missing.push("AURA_PUBLIC_URL");
+  if (!process.env.SANDBOX_WEBHOOK_SECRET) missing.push("SANDBOX_WEBHOOK_SECRET");
+  if (missing.length === 0) return;
+
+  warnedAboutWebhookEnv = true;
+  logger.warn(
+    "run_command_detached: webhook callback disabled, env vars missing",
+    {
+      missing,
+      effect:
+        "detached commands will run, but completion webhooks will silently no-op; results only available via check_command polling",
+    },
+  );
 }
 
 function getWorkspaceId(context?: ScheduleContext): string {
@@ -645,6 +666,7 @@ export function createSandboxTools(context?: ScheduleContext) {
             command: command.substring(0, 100),
             workdir,
           });
+          warnIfWebhookEnvMissing();
 
           const detached = await startDetachedCommand({
             sandbox,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a one-shot `logger.warn` when `run_command_detached` is dispatched without webhook callback env vars.
- Include the missing env var list and explicit degraded-mode effect in the warning payload.
- Cover both missing-env and env-present paths in sandbox tool tests.

Closes #985

## Verification
- `npx tsc --noEmit` from `apps/api`
- `pnpm --filter aura-api test`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3eded9c1-22b8-4951-aa2d-92a06dddfd1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3eded9c1-22b8-4951-aa2d-92a06dddfd1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

