### PR TITLE
Suppress supersede stream error noise

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -627,7 +627,7 @@ describe("generateResponse Slack stream handling", () => {
     }));
   });
 
-  it("does not relaunch superseded empty completions", async () => {
+  it("does not error-log or relaunch superseded empty completions", async () => {
     const stream = {
       append: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
@@ -676,6 +676,15 @@ describe("generateResponse Slack stream handling", () => {
     expect(vi.mocked(logError).mock.calls.some(
       ([entry]) => entry.errorCode === "empty_completion_after_tools",
     )).toBe(false);
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "stream_on_error_callback",
+    )).toBe(false);
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      "Stream onError ignored — invocation superseded",
+      expect.objectContaining({
+        channelId: "C123",
+      }),
+    );
   });
 
   it("logs empty completions for tool-error-only continuation segments", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rebased onto latest `origin/main`
- preserved main's current supersede stream handling, which classifies superseded stream `onError` callbacks as info-level events instead of `error_events` noise
- strengthened the supersede regression test to assert no `stream_on_error_callback`, no `empty_completion_after_tools`, and no relaunch log is emitted

## Testing
- `pnpm --filter aura-api test -- src/pipeline/respond.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
- pre-push hook typechecks for `apps/api` and `apps/dashboard`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-110a90ff-e5fb-4c8a-9855-544b362666d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-110a90ff-e5fb-4c8a-9855-544b362666d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

