### PR TITLE
Avoid error_events noise for recovered Slack stream state fallback

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -58,6 +58,7 @@ vi.mock("./prepare-step.js", () => ({
 
 import { generateResponse } from "./respond.js";
 import { logError } from "../lib/error-logger.js";
+import { logger } from "../lib/logger.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -248,6 +249,44 @@ describe("generateResponse Slack stream handling", () => {
       channel: "C123",
       thread_ts: "1710000000.000000",
       text: expect.stringContaining("Fallback text."),
+    }));
+  });
+
+  it("does not log message_not_in_streaming_state when postMessage fallback succeeds", async () => {
+    const stream = {
+      append: vi.fn().mockRejectedValueOnce(Object.assign(new Error("message_not_in_streaming_state"), {
+        data: { error: "message_not_in_streaming_state" },
+      })),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Recovered fallback text." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(logError).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "chatStream append left streaming state, falling back to postMessage",
+      expect.objectContaining({
+        channelId: "C123",
+        slackError: "message_not_in_streaming_state",
+      }),
+    );
+    expect(stream.stop).toHaveBeenCalledWith({
+      chunks: expect.arrayContaining([
+        expect.objectContaining({
+          type: "markdown_text",
+          text: expect.stringContaining("continuing in a new message"),
+        }),
+      ]),
+    });
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "C123",
+      thread_ts: "1710000000.000000",
+      text: expect.stringContaining("Recovered fallback text."),
     }));
   });
 

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -400,6 +400,7 @@ export async function generateResponse(
   // and post the final result via chat.postMessage.
   let streamingFailed = skipStreaming;
   let streamTombstoneSent = false;
+  let pendingMessageNotInStreamingStateError: Parameters<typeof logError>[0] | null = null;
 
   async function tryStreamAppend(
     payload: Omit<ChatAppendStreamArguments, "channel" | "ts">,
@@ -502,12 +503,7 @@ export async function generateResponse(
       } else {
         // Unknown streaming error — don't kill the response, fall back gracefully
         streamingFailed = true;
-        logger.error("chatStream append got unexpected error, falling back to postMessage", {
-          channelId,
-          slackError: err?.data?.error,
-          message: err?.message,
-        });
-        logError({
+        const errorLog = {
           errorName: "UnexpectedStreamError",
           errorMessage: err?.message || "unexpected error on stream append",
           errorCode: err?.data?.error || "unknown",
@@ -518,7 +514,23 @@ export async function generateResponse(
               isFallbackRecovery: true,
             }),
           },
-        });
+        };
+
+        if (err?.data?.error === "message_not_in_streaming_state") {
+          pendingMessageNotInStreamingStateError = errorLog;
+          logger.warn("chatStream append left streaming state, falling back to postMessage", {
+            channelId,
+            slackError: err?.data?.error,
+            message: err?.message,
+          });
+        } else {
+          logger.error("chatStream append got unexpected error, falling back to postMessage", {
+            channelId,
+            slackError: err?.data?.error,
+            message: err?.message,
+          });
+          logError(errorLog);
+        }
       }
       if (streamingFailed) {
         await stopFrozenStreamWithTombstone();
@@ -1249,6 +1261,9 @@ export async function generateResponse(
         });
 
         if (!fallbackResult.ok) {
+          if (pendingMessageNotInStreamingStateError) {
+            logError(pendingMessageNotInStreamingStateError);
+          }
           logger.warn("LLM response lost — channel does not support posting", {
             channelId,
             rawLength: finalText.length,
@@ -1262,6 +1277,9 @@ export async function generateResponse(
           });
         }
       } catch (fallbackErr: any) {
+        if (pendingMessageNotInStreamingStateError) {
+          logError(pendingMessageNotInStreamingStateError);
+        }
         logger.error("Fallback safePostMessage also failed — posting plain text", {
           channelId,
           error: fallbackErr?.message || String(fallbackErr),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat `message_not_in_streaming_state` from `chatStream.append()` as a recoverable Slack stream-state fallback when `postMessage` delivery succeeds.
- Defer the `UnexpectedStreamError` `logError` entry for that specific Slack error until fallback delivery fails.
- Add a regression test covering successful `postMessage` recovery with no `error_events` write and a warning log.

## Verification
- `pnpm --filter aura-api test -- src/pipeline/respond.test.ts`
- `npx tsc --noEmit` (in `apps/api`)
- `pnpm typecheck`

Note: the task references issue #993 for this Slack fallback bug, but the currently visible GitHub issue #993 content appears to describe an unrelated email-sync investigation, so this PR intentionally does not include an auto-closing issue keyword.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd0b62a3-e052-4f01-b0d3-877a5130504e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd0b62a3-e052-4f01-b0d3-877a5130504e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

