### PR TITLE
Fix Slack channel fallback error logging

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -429,6 +429,36 @@ describe("generateResponse Slack stream handling", () => {
     }));
   });
 
+  it("does not record an error event when channel_type_not_supported fallback succeeds", async () => {
+    const stream = {
+      append: vi.fn().mockRejectedValueOnce(Object.assign(new Error("channel_type_not_supported"), {
+        data: { error: "channel_type_not_supported" },
+      })),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Fallback delivered." };
+    })());
+
+    await generateResponse({
+      ...baseOptions(slackClient),
+      channelId: "C_UNSUPPORTED_995",
+    });
+
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "C_UNSUPPORTED_995",
+      thread_ts: "1710000000.000000",
+      text: expect.stringContaining("Fallback delivered."),
+    }));
+
+    const channelTypeLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "channel_type_not_supported",
+    );
+    expect(channelTypeLogs).toHaveLength(0);
+  });
+
   it("logs empty completions after tool errors without recording unexpected stream errors", async () => {
     const stream = {
       append: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -406,6 +406,29 @@ export async function generateResponse(
   let streamingFailed = skipStreaming;
   let streamTombstoneSent = false;
   let pendingMessageNotInStreamingStateError: Parameters<typeof logError>[0] | null = null;
+  let pendingChannelTypeUnsupportedFallback: { errorMessage: string } | null = null;
+
+  function logChannelTypeUnsupportedFallbackFailure(
+    fallbackFailure: string,
+    deliveryError?: any,
+  ): void {
+    if (!pendingChannelTypeUnsupportedFallback) return;
+    logError({
+      errorName: "StreamingUnsupported",
+      errorMessage: pendingChannelTypeUnsupportedFallback.errorMessage,
+      errorCode: "channel_type_not_supported",
+      channelId,
+      context: {
+        fallback: "postMessage",
+        fallbackFailure,
+        ...(deliveryError && {
+          deliveryError: deliveryError?.message || String(deliveryError),
+          slackError: deliveryError?.data?.error,
+        }),
+      },
+    });
+    pendingChannelTypeUnsupportedFallback = null;
+  }
 
   async function tryStreamAppend(
     payload: Omit<ChatAppendStreamArguments, "channel" | "ts">,
@@ -422,13 +445,9 @@ export async function generateResponse(
           "chatStream not supported for this channel, falling back to postMessage",
           { channelId },
         );
-        logError({
-          errorName: "StreamingUnsupported",
+        pendingChannelTypeUnsupportedFallback = {
           errorMessage: err?.message || "channel_type_not_supported",
-          errorCode: "channel_type_not_supported",
-          channelId,
-          context: { fallback: "postMessage" },
-        });
+        };
       } else if (isInvalidChunks(err) || isInvalidArguments(err)) {
         // Non-fatal: some chunk shapes (e.g. the 2026 `plan` / `url_source` /
         // `blocks` chunk types) may be rejected by the Slack API with either
@@ -1539,7 +1558,9 @@ export async function generateResponse(
             rawLength: finalText.length,
             usage: { inputTokens, outputTokens, totalTokens },
           });
+          logChannelTypeUnsupportedFallbackFailure("safePostMessage_returned_not_ok");
         } else {
+          pendingChannelTypeUnsupportedFallback = null;
           logger.info(`LLM completed in ${llmMs}ms (fallback postMessage)`, {
             rawLength: finalText.length,
             channelId,
@@ -1561,8 +1582,14 @@ export async function generateResponse(
             text: fallbackText || "I generated a response but couldn't deliver it. Please try again.",
             thread_ts: threadTs,
           });
-        } catch {
-          logger.error("All message delivery paths failed", { channelId });
+          pendingChannelTypeUnsupportedFallback = null;
+        } catch (plainPostErr: any) {
+          logChannelTypeUnsupportedFallbackFailure("plain_post_failed", plainPostErr);
+          logger.error("All message delivery paths failed", {
+            channelId,
+            error: plainPostErr?.message || String(plainPostErr),
+            slackError: plainPostErr?.data?.error,
+          });
         }
       }
     } else {
@@ -1657,12 +1684,6 @@ export async function generateResponse(
         } else if (isChannelTypeNotSupported(stopErr)) {
           streamingUnsupportedChannels.add(channelId);
           logger.warn("streamer.stop() hit channel_type_not_supported, finalizing without payload", {
-            channelId,
-          });
-          logError({
-            errorName: "StreamStopChannelTypeNotSupported",
-            errorMessage: stopErr?.message || "channel_type_not_supported on streamer.stop()",
-            errorCode: "channel_type_not_supported",
             channelId,
           });
           try { await streamer.stop(); } catch { /* already finalized */ }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Downgrade successful `channel_type_not_supported` stream fallback handling to warn-only behavior.
- Keep `error_events` logging only when the postMessage/plain-text fallback delivery paths fail.
- Remove duplicate `logError` for `streamer.stop()` `channel_type_not_supported` because that path already warns and finalizes safely.
- Add a regression test proving a successful fallback does not record a `channel_type_not_supported` error event.
- Rebased onto latest `origin/main` and preserved the parallel `message_not_in_streaming_state` fallback handling.

Fixes #995.

## Verification
- `pnpm --filter aura-api test -- respond.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e365266c-a18f-406d-9354-38934716bd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e365266c-a18f-406d-9354-38934716bd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

