### PR TITLE
Handle empty completions after tool calls

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -82,15 +82,34 @@ function createSlackClient(streamers: Array<{ append: any; stop: any }>) {
   };
 }
 
-function mockAgentStream(fullStream: AsyncIterable<any>) {
+function createAgentStreamResult(
+  fullStream: AsyncIterable<any>,
+  options: {
+    text?: string;
+    finishReason?: string;
+    responseMessages?: any[];
+    usage?: any;
+    steps?: any[];
+  } = {},
+) {
+  return {
+    fullStream,
+    usage: Promise.resolve(options.usage ?? { inputTokens: 1, outputTokens: 1 }),
+    finishReason: Promise.resolve(options.finishReason ?? "stop"),
+    text: Promise.resolve(options.text ?? ""),
+    response: Promise.resolve({ messages: options.responseMessages ?? [] }),
+    steps: Promise.resolve(options.steps ?? []),
+  };
+}
+
+function mockAgentStreams(results: any[]) {
+  const stream = vi.fn();
+  for (const result of results) {
+    stream.mockResolvedValueOnce(result);
+  }
   agentMocks.createInteractiveAgent.mockResolvedValue({
     agent: {
-      stream: vi.fn().mockResolvedValue({
-        fullStream,
-        usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
-        finishReason: Promise.resolve("stop"),
-        steps: Promise.resolve([]),
-      }),
+      stream,
     },
     tools: {
       run_command: {
@@ -102,6 +121,14 @@ function mockAgentStream(fullStream: AsyncIterable<any>) {
     modelId: "test-model",
     getStepModelIds: () => ["test-model"],
   });
+  return stream;
+}
+
+function mockAgentStream(
+  fullStream: AsyncIterable<any>,
+  options: Parameters<typeof createAgentStreamResult>[1] = {},
+) {
+  return mockAgentStreams([createAgentStreamResult(fullStream, options)]);
 }
 
 function baseOptions(slackClient: any) {
@@ -300,6 +327,204 @@ describe("generateResponse Slack stream handling", () => {
       thread_ts: "1710000000.000000",
       text: "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_",
     }));
+  });
+
+  it("recovers output from final result.text when streamed text deltas are missing", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "true" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "ok", stderr: "" },
+      };
+    })(), { text: "Recovered summary." });
+
+    await expect(generateResponse(baseOptions(slackClient))).resolves.toMatchObject({
+      raw: "Recovered summary.",
+      alreadyPosted: true,
+    });
+
+    expect(stream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "markdown_text",
+        text: "Recovered summary.",
+      })],
+    });
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools",
+    )).toBe(false);
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "empty_completion_relaunched",
+    )).toBe(false);
+  });
+
+  it("relaunches once with a synthetic user message after useful tool results produce no text", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+    const responseMessages = [
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "call-1", toolName: "run_command", input: { command: "true" } }],
+      },
+      {
+        role: "tool",
+        content: [{ type: "tool-result", toolCallId: "call-1", toolName: "run_command", output: { ok: true } }],
+      },
+    ];
+    const streamMock = mockAgentStreams([
+      createAgentStreamResult((async function* () {
+        yield {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "run_command",
+          input: { command: "true" },
+        };
+        yield {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "run_command",
+          output: { ok: true, exit_code: 0, stdout: "ok", stderr: "" },
+        };
+      })(), { responseMessages }),
+      createAgentStreamResult((async function* () {
+        yield { type: "text-delta", text: "The command succeeded." };
+      })()),
+    ]);
+
+    await expect(generateResponse(baseOptions(slackClient))).resolves.toMatchObject({
+      raw: "The command succeeded.",
+      alreadyPosted: true,
+    });
+
+    expect(streamMock).toHaveBeenCalledTimes(2);
+    expect(streamMock.mock.calls[1]?.[0]).toMatchObject({
+      messages: [
+        { role: "user", content: "run a slow command" },
+        ...responseMessages,
+        { role: "user", content: "(continue - you ended without responding. Summarize what you found.)" },
+      ],
+    });
+    const relaunchLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "empty_completion_relaunched",
+    );
+    expect(relaunchLogs).toHaveLength(1);
+    expect(relaunchLogs[0]?.[0]).toMatchObject({
+      errorName: "EmptyCompletionRelaunched",
+      channelId: "C123",
+      context: {
+        toolCallCount: 1,
+        toolErrorCount: 0,
+        finishReason: "stop",
+        relaunchCount: 1,
+      },
+    });
+  });
+
+  it("bounds empty-completion relaunches to one attempt", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+    const streamMock = mockAgentStreams([
+      createAgentStreamResult((async function* () {
+        yield {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "run_command",
+          input: { command: "true" },
+        };
+        yield {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "run_command",
+          output: { ok: true, exit_code: 0, stdout: "ok", stderr: "" },
+        };
+      })()),
+      createAgentStreamResult((async function* () {
+        // Empty second attempt.
+      })()),
+    ]);
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(streamMock).toHaveBeenCalledTimes(2);
+    const logErrorMock = vi.mocked(logError);
+    expect(logErrorMock.mock.calls.filter(
+      ([entry]) => entry.errorCode === "empty_completion_relaunched",
+    )).toHaveLength(1);
+    expect(logErrorMock.mock.calls.filter(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools",
+    )).toHaveLength(1);
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      text: "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_",
+    }));
+  });
+
+  it("does not relaunch superseded empty completions", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+    const supersededError = Object.assign(
+      new Error("Invocation test-invocation was superseded by a newer message"),
+      { name: "InvocationSupersededError", invocationId: "test-invocation" },
+    );
+    const streamMock = vi.fn().mockImplementation(async (callOptions: any) => createAgentStreamResult((async function* () {
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "true" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "ok", stderr: "" },
+      };
+      callOptions.onError?.({ error: supersededError });
+    })()));
+    agentMocks.createInteractiveAgent.mockResolvedValue({
+      agent: { stream: streamMock },
+      tools: {
+        run_command: {
+          slack: {
+            status: "Running a command in the sandbox...",
+          },
+        },
+      },
+      modelId: "test-model",
+      getStepModelIds: () => ["test-model"],
+    });
+
+    await expect(generateResponse(baseOptions(slackClient))).resolves.toMatchObject({
+      interrupted: true,
+    });
+
+    expect(streamMock).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "empty_completion_relaunched",
+    )).toBe(false);
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools",
+    )).toBe(false);
   });
 
   it("logs empty completions for tool-error-only continuation segments", async () => {

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -1,5 +1,6 @@
 import { streamText } from "ai";
 import type { ChatAppendStreamArguments, WebClient } from "@slack/web-api";
+import type { ModelMessage } from "ai";
 import type { FileContentPart } from "../lib/files.js";
 import { logger } from "../lib/logger.js";
 import { logError } from "../lib/error-logger.js";
@@ -204,6 +205,7 @@ const MAX_CONTINUATIONS = 5;
 const LONG_TOOL_SPLIT_MS = 75_000;
 const STREAM_CONTINUATION_TOMBSTONE = "_(continuing in a new message...)_";
 const TOOL_CONTINUATION_OUTPUT = "continuing in a new message...";
+const EMPTY_COMPLETION_RELAUNCH_PROMPT = "(continue - you ended without responding. Summarize what you found.)";
 
 /**
  * Find the best split index in a text delta for stream continuation.
@@ -574,9 +576,28 @@ export async function generateResponse(
     streamer = slackClient.chatStream(streamParams as any);
   }
 
-  const streamCallOptions: Record<string, any> = {
+  let supersededDuringStream = false;
+  const isSupersededError = (error: unknown): error is InvocationSupersededError => (
+    error instanceof InvocationSupersededError ||
+    (
+      error instanceof Error &&
+      (error.name === "InvocationSupersededError" ||
+        error.message.includes("was superseded by a newer message"))
+    )
+  );
+
+  const baseStreamCallOptions: Record<string, any> = {
     abortSignal: abortController.signal,
     onError: ({ error }: { error: unknown }) => {
+      if (isSupersededError(error)) {
+        supersededDuringStream = true;
+        logger.info("Stream onError ignored — invocation superseded", {
+          invocationId,
+          channelId,
+        });
+        return;
+      }
+
       const streamError = error instanceof Error ? error : undefined;
       const errorLike = error && typeof error === "object"
         ? error as { name?: string; message?: string; stack?: string }
@@ -592,12 +613,21 @@ export async function generateResponse(
     },
   };
 
+  function buildInitialUserMessage(): ModelMessage {
+    if (hasFiles) {
+      const content: any[] = [
+        { type: "text", text: options.userMessage },
+        ...options.files!,
+      ];
+      return { role: "user", content };
+    }
+    return { role: "user", content: options.userMessage };
+  }
+
+  const initialUserMessage = buildInitialUserMessage();
+  const streamCallOptions: Record<string, any> = { ...baseStreamCallOptions };
   if (hasFiles) {
-    const content: any[] = [
-      { type: "text", text: options.userMessage },
-      ...options.files!,
-    ];
-    streamCallOptions.messages = [{ role: "user", content }];
+    streamCallOptions.messages = [initialUserMessage];
   } else {
     streamCallOptions.prompt = options.userMessage;
   }
@@ -626,6 +656,14 @@ export async function generateResponse(
   let tableBuffer: string[] = [];
   let lineCarry = "";
   let emptyCompletionDetected = false;
+  let emptyCompletionRelaunchCount = 0;
+  let latestResult: Awaited<ReturnType<typeof agent.stream>> | null = null;
+  const stepsPromises: Array<PromiseLike<any[]>> = [];
+  const aggregateUsage: DetailedTokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
   const emptyCompletionFallbackText = "_I ran the tools but didn't get usable output back. Can you tell me what to retry?_";
 
   async function logEmptyContinuationSegmentIfNeeded(params: {
@@ -789,6 +827,98 @@ export async function generateResponse(
     return output;
   }
 
+  function addUsage(usage: any) {
+    const inputTokens = usage?.inputTokens ?? 0;
+    const outputTokens = usage?.outputTokens ?? 0;
+    aggregateUsage.inputTokens += inputTokens;
+    aggregateUsage.outputTokens += outputTokens;
+    aggregateUsage.totalTokens += inputTokens + outputTokens;
+
+    if (usage?.inputTokenDetails) {
+      aggregateUsage.inputTokenDetails ??= {};
+      aggregateUsage.inputTokenDetails.noCacheTokens =
+        (aggregateUsage.inputTokenDetails.noCacheTokens ?? 0) + (usage.inputTokenDetails.noCacheTokens ?? 0);
+      aggregateUsage.inputTokenDetails.cacheReadTokens =
+        (aggregateUsage.inputTokenDetails.cacheReadTokens ?? 0) + (usage.inputTokenDetails.cacheReadTokens ?? 0);
+      aggregateUsage.inputTokenDetails.cacheWriteTokens =
+        (aggregateUsage.inputTokenDetails.cacheWriteTokens ?? 0) + (usage.inputTokenDetails.cacheWriteTokens ?? 0);
+    }
+
+    if (usage?.outputTokenDetails) {
+      aggregateUsage.outputTokenDetails ??= {};
+      aggregateUsage.outputTokenDetails.textTokens =
+        (aggregateUsage.outputTokenDetails.textTokens ?? 0) + (usage.outputTokenDetails.textTokens ?? 0);
+      aggregateUsage.outputTokenDetails.reasoningTokens =
+        (aggregateUsage.outputTokenDetails.reasoningTokens ?? 0) + (usage.outputTokenDetails.reasoningTokens ?? 0);
+    }
+  }
+
+  async function appendTextDelta(text: string): Promise<void> {
+    if (!text) return;
+    accumulatedText += text;
+    currentSegmentTextLength += text.length;
+    let remaining = processChunkForTables(text);
+    if (!remaining) return;
+
+    while (remaining) {
+      if (streamingFailed) break;
+
+      if (continuationCount >= MAX_CONTINUATIONS) {
+        currentStreamLength += remaining.length;
+        await tryStreamAppend(asAppendPayload({ markdown_text: remaining }));
+        if (streamingFailed) {
+          fallbackStartIdx = streamedRawIdx;
+        }
+        break;
+      }
+
+      const breakIdx = findContinuationBreak(remaining, currentStreamLength);
+
+      if (breakIdx < 0) {
+        currentStreamLength += remaining.length;
+        await tryStreamAppend(asAppendPayload({ markdown_text: remaining }));
+        if (streamingFailed) {
+          fallbackStartIdx = streamedRawIdx;
+        }
+        break;
+      }
+
+      const before = remaining.slice(0, breakIdx);
+      remaining = remaining.slice(breakIdx);
+
+      if (before) {
+        currentStreamLength += before.length;
+        await tryStreamAppend(asAppendPayload({ markdown_text: before }));
+      }
+
+      if (streamingFailed) {
+        fallbackStartIdx = streamedRawIdx;
+        break;
+      }
+
+      if (!remaining) break;
+
+      if (await splitToNewStream()) {
+        // Split succeeded, currentStreamLength reset, loop continues.
+      } else if (streamingFailed) {
+        fallbackStartIdx = streamedRawIdx;
+        break;
+      } else {
+        // Max continuations reached, stream still active — flush remaining.
+        currentStreamLength += remaining.length;
+        await tryStreamAppend(asAppendPayload({ markdown_text: remaining }));
+        if (streamingFailed) {
+          fallbackStartIdx = streamedRawIdx;
+        }
+        break;
+      }
+    }
+
+    if (!streamingFailed) {
+      streamedRawIdx = accumulatedText.length;
+    }
+  }
+
   async function splitToNewStream(reason: ContinuationReason = "length"): Promise<boolean> {
     if (streamingFailed || continuationCount >= MAX_CONTINUATIONS) {
       if (continuationCount >= MAX_CONTINUATIONS) {
@@ -868,6 +998,49 @@ export async function generateResponse(
     }
   }
 
+  async function getFinishReason(result: Awaited<ReturnType<typeof agent.stream>>): Promise<unknown> {
+    try {
+      return (result as any).finishReason
+        ? await (result as any).finishReason
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function getFinalResultText(result: Awaited<ReturnType<typeof agent.stream>>): Promise<string> {
+    try {
+      const text = (result as any).text ? await (result as any).text : "";
+      return typeof text === "string" ? text : "";
+    } catch {
+      return "";
+    }
+  }
+
+  async function buildRelaunchCallOptions(
+    result: Awaited<ReturnType<typeof agent.stream>>,
+  ): Promise<Record<string, any>> {
+    let responseMessages: ModelMessage[] = [];
+    try {
+      const response = await result.response;
+      if (Array.isArray(response?.messages)) {
+        responseMessages = response.messages as ModelMessage[];
+      }
+    } catch {
+      // If response messages are unavailable, relaunch with the user turn and
+      // the synthetic continuation rather than dropping the recovery entirely.
+    }
+
+    return {
+      ...baseStreamCallOptions,
+      messages: [
+        initialUserMessage,
+        ...responseMessages,
+        { role: "user", content: EMPTY_COMPLETION_RELAUNCH_PROMPT } satisfies ModelMessage,
+      ],
+    };
+  }
+
   try {
     // Signal extended thinking phase to the user via Slack thread status
     await trySetAssistantThreadStatus({
@@ -877,75 +1050,19 @@ export async function generateResponse(
       status: "Thinking deeply...",
     });
 
-    const result = await agent.stream(streamCallOptions as any);
+    let currentStreamCallOptions = streamCallOptions;
+    while (true) {
+      supersededDuringStream = false;
+      const result = await agent.stream(currentStreamCallOptions as any);
+      latestResult = result;
+      stepsPromises.push(result.steps);
 
-    for await (const chunk of result.fullStream) {
-      resetTimer();
+      for await (const chunk of result.fullStream) {
+        resetTimer();
 
-      switch (chunk.type) {
+        switch (chunk.type) {
         case "text-delta": {
-          accumulatedText += chunk.text;
-          currentSegmentTextLength += chunk.text.length;
-          let remaining = processChunkForTables(chunk.text);
-          if (!remaining) break;
-
-          while (remaining) {
-            if (streamingFailed) break;
-
-            if (continuationCount >= MAX_CONTINUATIONS) {
-              currentStreamLength += remaining.length;
-              await tryStreamAppend(asAppendPayload({ markdown_text: remaining }));
-              if (streamingFailed) {
-                fallbackStartIdx = streamedRawIdx;
-              }
-              break;
-            }
-
-            const breakIdx = findContinuationBreak(remaining, currentStreamLength);
-
-            if (breakIdx < 0) {
-              currentStreamLength += remaining.length;
-              await tryStreamAppend(asAppendPayload({ markdown_text: remaining }));
-              if (streamingFailed) {
-                fallbackStartIdx = streamedRawIdx;
-              }
-              break;
-            }
-
-            const before = remaining.slice(0, breakIdx);
-            remaining = remaining.slice(breakIdx);
-
-            if (before) {
-              currentStreamLength += before.length;
-              await tryStreamAppend(asAppendPayload({ markdown_text: before }));
-            }
-
-            if (streamingFailed) {
-              fallbackStartIdx = streamedRawIdx;
-              break;
-            }
-
-            if (!remaining) break;
-
-            if (await splitToNewStream()) {
-              // Split succeeded, currentStreamLength reset, loop continues
-            } else if (streamingFailed) {
-              fallbackStartIdx = streamedRawIdx;
-              break;
-            } else {
-              // Max continuations reached, stream still active — flush remaining
-              currentStreamLength += remaining.length;
-              await tryStreamAppend(asAppendPayload({ markdown_text: remaining }));
-              if (streamingFailed) {
-                fallbackStartIdx = streamedRawIdx;
-              }
-              break;
-            }
-          }
-
-          if (!streamingFailed) {
-            streamedRawIdx = accumulatedText.length;
-          }
+          await appendTextDelta(chunk.text);
           break;
         }
 
@@ -1119,67 +1236,111 @@ export async function generateResponse(
           }
           break;
         }
-      }
-    }
-
-    // Flush any remaining table buffer content before finalizing
-    const finalTableFlush = flushRemainingTableBuffer();
-    if (finalTableFlush && !streamingFailed) {
-      currentStreamLength += finalTableFlush.length;
-      await tryStreamAppend(asAppendPayload({ markdown_text: finalTableFlush }));
-      if (streamingFailed) {
-        fallbackStartIdx = streamedRawIdx;
-      }
-    }
-
-    let continuationFinishReason: unknown;
-    try {
-      continuationFinishReason = (result as any).finishReason
-        ? await (result as any).finishReason
-        : undefined;
-    } catch {
-      continuationFinishReason = undefined;
-    }
-
-    await logEmptyContinuationSegmentIfNeeded({
-      segmentEnd: "final",
-      finishReason: continuationFinishReason,
-    });
-
-    if (accumulatedText.length === 0 && toolCallRecords.length > 0) {
-      let finishReason: unknown;
-      try {
-        finishReason = (result as any).finishReason
-          ? await (result as any).finishReason
-          : undefined;
-      } catch {
-        finishReason = undefined;
-      }
-
-      logError({
-        errorName: "EmptyCompletion",
-        errorMessage: "Stream completed without usable output after tool calls",
-        errorCode: "empty_completion_after_tools",
-        channelId,
-        context: {
-          toolCallCount: toolCallRecords.length,
-          toolErrorCount: toolCallRecords.filter((record) => record.is_error).length,
-          finishReason,
-        },
-      });
-
-      streamingFailed = true;
-      emptyCompletionDetected = true;
-
-      if (streamer) {
-        try {
-          await streamer.stop({
-            chunks: [toChunkMarkdownText("\n\n_...(no output generated — see Aura logs)_")],
-          });
-        } catch {
-          // Stream may already be unrecoverable.
         }
       }
+
+      // Flush any remaining table buffer content before deciding whether the
+      // completed attempt produced user-visible text.
+      const finalTableFlush = flushRemainingTableBuffer();
+      if (finalTableFlush && !streamingFailed) {
+        currentStreamLength += finalTableFlush.length;
+        await tryStreamAppend(asAppendPayload({ markdown_text: finalTableFlush }));
+        if (streamingFailed) {
+          fallbackStartIdx = streamedRawIdx;
+        }
+      }
+
+      const finishReason = await getFinishReason(result);
+
+      await logEmptyContinuationSegmentIfNeeded({
+        segmentEnd: "final",
+        finishReason,
+      });
+
+      if (supersededDuringStream) {
+        throw new InvocationSupersededError(invocationId);
+      }
+
+      if (accumulatedText.length === 0) {
+        const finalResultText = await getFinalResultText(result);
+        if (finalResultText.length > 0) {
+          logger.warn("Recovered empty streamed response from final result.text", {
+            channelId,
+            recoveredLength: finalResultText.length,
+            finishReason,
+          });
+          await appendTextDelta(finalResultText);
+          const recoveredTableFlush = flushRemainingTableBuffer();
+          if (recoveredTableFlush && !streamingFailed) {
+            currentStreamLength += recoveredTableFlush.length;
+            await tryStreamAppend(asAppendPayload({ markdown_text: recoveredTableFlush }));
+            if (streamingFailed) {
+              fallbackStartIdx = streamedRawIdx;
+            }
+          }
+        }
+      }
+
+      try {
+        addUsage(await result.usage);
+      } catch {
+        // Preserve the response path even if usage metadata is unavailable.
+      }
+
+      if (accumulatedText.length === 0 && toolCallRecords.length > 0) {
+        const toolErrorCount = toolCallRecords.filter((record) => record.is_error).length;
+        const hasUsefulToolResults = toolCallRecords.some((record) => !record.is_error);
+        const canRelaunch =
+          hasUsefulToolResults &&
+          finishReason !== "tool-calls" &&
+          emptyCompletionRelaunchCount < 1;
+
+        if (canRelaunch) {
+          emptyCompletionRelaunchCount++;
+          logError({
+            errorName: "EmptyCompletionRelaunched",
+            errorMessage: "Stream completed without output after useful tool calls; relaunching once",
+            errorCode: "empty_completion_relaunched",
+            channelId,
+            context: {
+              toolCallCount: toolCallRecords.length,
+              toolErrorCount,
+              finishReason,
+              relaunchCount: emptyCompletionRelaunchCount,
+            },
+          });
+          currentStreamCallOptions = await buildRelaunchCallOptions(result);
+          continue;
+        }
+
+        logError({
+          errorName: "EmptyCompletion",
+          errorMessage: "Stream completed without usable output after tool calls",
+          errorCode: "empty_completion_after_tools",
+          channelId,
+          context: {
+            toolCallCount: toolCallRecords.length,
+            toolErrorCount,
+            finishReason,
+            relaunchCount: emptyCompletionRelaunchCount,
+          },
+        });
+
+        streamingFailed = true;
+        emptyCompletionDetected = true;
+
+        if (streamer) {
+          try {
+            await streamer.stop({
+              chunks: [toChunkMarkdownText("\n\n_...(no output generated — see Aura logs)_")],
+            });
+          } catch {
+            // Stream may already be unrecoverable.
+          }
+        }
+      }
+
+      break;
     }
 
     // ── Finalize ──────────────────────────────────────────────────────────
@@ -1189,13 +1350,10 @@ export async function generateResponse(
     clearLongToolSplitTimer();
 
     const llmMs = Date.now() - start;
-    const usage = await result.usage;
-
     const finalText = accumulatedText;
-
-    const inputTokens = usage.inputTokens ?? 0;
-    const outputTokens = usage.outputTokens ?? 0;
-    const totalTokens = inputTokens + outputTokens;
+    const inputTokens = aggregateUsage.inputTokens;
+    const outputTokens = aggregateUsage.outputTokens;
+    const totalTokens = aggregateUsage.totalTokens;
 
     if (streamingFailed) {
       // Stop the current streamer to avoid leaving an orphaned stream on Slack
@@ -1408,10 +1566,18 @@ export async function generateResponse(
     return {
       raw: finalText,
       alreadyPosted: true,
-      usage: { inputTokens, outputTokens, totalTokens, inputTokenDetails: usage.inputTokenDetails, outputTokenDetails: usage.outputTokenDetails },
+      usage: {
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        inputTokenDetails: aggregateUsage.inputTokenDetails,
+        outputTokenDetails: aggregateUsage.outputTokenDetails,
+      },
       toolCalls: toolCallRecords,
       modelId,
-      stepsPromise: result.steps,
+      stepsPromise: stepsPromises.length > 1
+        ? Promise.all(stepsPromises).then((steps) => steps.flat())
+        : latestResult?.steps,
       stepModelIds: getStepModelIds(),
     };
   } catch (error: any) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Recover a missing streamed response from final `result.text` when the local stream accumulator is empty.
- Add a bounded one-shot synthetic user continuation when useful tool results produce no final text and the finish reason is not `tool-calls`.
- Suppress relaunch for superseded streams and log `empty_completion_relaunched` for measurement.
- Add tests for final-text recovery, relaunch, relaunch bound, and supersede skip.

## Phase 1 findings

- `accumulatedText` is updated before Slack append delivery, so Slack `streamer.append()` failures cannot erase model text from the accumulator.
- AI SDK v6 `result.text` is derived from the final recorded step text; there is no obvious race after `fullStream` completion, but it is still a cheap source-of-truth recovery guard.
- AI SDK finish reasons do not guarantee non-empty text. In particular, Anthropic `end_turn` maps to SDK `stop`, and Anthropic documents empty `end_turn` responses after tool results as provider-legal.
- Anthropic recommends adding a new user continuation prompt for empty responses after tool results, which matches the safety net implemented here.
- I attempted to post these findings to #996 before opening this PR, but the available GitHub token returned 403 for issue comments and the sandbox had no `DATABASE_URL`/Vercel/Neon auth for independently re-querying `error_events`.

## Verification

- `pnpm typecheck`
- `npx tsc --noEmit` (in `apps/api`)
- `pnpm --filter aura-api test`

Note: root `pnpm test` is not defined in this monorepo and exits with code 1 without output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cff5d612-d9c3-4886-b0ee-9eb09133e5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cff5d612-d9c3-4886-b0ee-9eb09133e5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

