### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+General project conventions and architecture are documented in `CLAUDE.md` at the repo root. Read that first.
+
+## Cursor Cloud specific instructions
+
+### Running services locally
+
+- **API**: `cd apps/api && node --env-file=../../.env.local --import tsx --watch src/index.ts` (port 3001)
+- **Dashboard**: `cd apps/dashboard && pnpm dev` (Vite dev server on port 5173, proxies `/api` to localhost:3001)
+- **Both together**: `pnpm dev` from repo root (builds `@aura/db` first, then starts both in parallel)
+
+### Environment setup gotchas
+
+- `ELEVENLABS_API_KEY` must be set (even as a placeholder) because the ElevenLabs client is instantiated at module load time in `apps/api/src/webhook/elevenlabs.ts` — without it the API crashes on startup.
+- `DATABASE_URL` is required for the API to start. The Neon serverless driver connects lazily (server starts even with an invalid URL), but DB queries will fail without a real connection string.
+- The `lint` script in `apps/api` references `eslint` but it is not installed as a dependency. Use `pnpm typecheck` as the primary code quality check (enforced by the pre-push hook).
+- `pnpm install` warnings about ignored build scripts (esbuild, sharp) are safe to ignore — these packages use prebuilt platform binaries.
+
+### Verification commands
+
+```bash
+pnpm typecheck                # Type-check API + Dashboard (run before committing)
+pnpm --filter aura-api test   # Run API unit/integration tests (vitest)
+curl http://localhost:3001/    # API health: {"name":"Aura","version":"0.1.0","status":"alive"}
+```
+
+### Notes
+
+- The dashboard requires Slack OAuth login. To test authenticated dashboard API routes directly, use `Authorization: Bearer $DASHBOARD_API_SECRET` header.
+- All optional integrations (E2B, Tavily, GitHub, ElevenLabs, Twilio, etc.) degrade gracefully when env vars are missing — they disable features rather than crash.
+- `.env.local` at the repo root is the single env file for local dev (gitignored). Copy from `.env.example` and fill in real values as needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions to help future agents set up and run the development environment efficiently.

## Changes

- Created `AGENTS.md` with:
  - Reference to `CLAUDE.md` for general conventions
  - Local service startup commands (API on port 3001, Dashboard on port 5173)
  - Environment setup gotchas (ElevenLabs API key requirement, DATABASE_URL, eslint not installed)
  - Verification commands (typecheck, tests, health check)
  - Notes on authentication and optional integrations

## Evidence of working environment

[aura-dev-environment-demo.mp4](https://cursor.com/agents/bc-e8607a04-6841-4388-9036-77e995187623/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faura-dev-environment-demo.mp4)

[API health check response](https://cursor.com/agents/bc-e8607a04-6841-4388-9036-77e995187623/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_health_check.webp)

[Dashboard running](https://cursor.com/agents/bc-e8607a04-6841-4388-9036-77e995187623/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_running.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8607a04-6841-4388-9036-77e995187623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8607a04-6841-4388-9036-77e995187623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

