### PR TITLE
Keep Slack streaming indicators alive

### DIFF
--- a/apps/api/src/lib/slack-status.test.ts
+++ b/apps/api/src/lib/slack-status.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  setStatusUnsupportedChannels,
+  trySetAssistantThreadStatus,
+} from "./slack-status.js";
+
+function createClient(error: unknown) {
+  return {
+    assistant: {
+      threads: {
+        setStatus: vi.fn().mockRejectedValue(error),
+      },
+    },
+  } as any;
+}
+
+describe("trySetAssistantThreadStatus", () => {
+  beforeEach(() => {
+    setStatusUnsupportedChannels.clear();
+    vi.clearAllMocks();
+  });
+
+  it("swallows setStatus failures so callers keep running", async () => {
+    const client = createClient(Object.assign(new Error("rate limited"), {
+      data: { error: "rate_limited" },
+    }));
+
+    await expect(trySetAssistantThreadStatus({
+      client,
+      channelId: "C123",
+      threadTs: "1710000000.000000",
+      status: "Working on it...",
+    })).resolves.toBeUndefined();
+  });
+
+  it("blacklists channel_not_found errors", async () => {
+    const client = createClient(Object.assign(new Error("channel missing"), {
+      data: { error: "channel_not_found" },
+    }));
+
+    await trySetAssistantThreadStatus({
+      client,
+      channelId: "C404",
+      threadTs: "1710000000.000000",
+      status: "Working on it...",
+    });
+
+    expect(setStatusUnsupportedChannels.has("C404")).toBe(true);
+  });
+
+  it("blacklists persistent scope errors", async () => {
+    const client = createClient(Object.assign(new Error("missing scope"), {
+      data: { error: "missing_scope" },
+    }));
+
+    await trySetAssistantThreadStatus({
+      client,
+      channelId: "C_SCOPE",
+      threadTs: "1710000000.000000",
+      status: "Working on it...",
+    });
+
+    expect(setStatusUnsupportedChannels.has("C_SCOPE")).toBe(true);
+  });
+
+  it("does not blacklist transient Slack or network errors", async () => {
+    const transientErrors = [
+      Object.assign(new Error("rate limited"), { data: { error: "rate_limited" } }),
+      Object.assign(new Error("internal error"), { data: { error: "internal_error" } }),
+      Object.assign(new Error("bad gateway"), { statusCode: 502 }),
+      Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+    ];
+
+    for (const [index, error] of transientErrors.entries()) {
+      await trySetAssistantThreadStatus({
+        client: createClient(error),
+        channelId: `C_TRANSIENT_${index}`,
+        threadTs: "1710000000.000000",
+        status: "Working on it...",
+      });
+    }
+
+    expect([...setStatusUnsupportedChannels]).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/slack-status.ts
+++ b/apps/api/src/lib/slack-status.ts
@@ -2,10 +2,35 @@ import type { WebClient } from "@slack/web-api";
 import { logger } from "./logger.js";
 
 /**
- * Channels where assistant.threads.setStatus previously failed.
- * We skip future attempts in these channels to avoid noisy retries.
+ * Channels where assistant.threads.setStatus has a persistent incompatibility.
+ * Transient Slack/network failures are intentionally not cached.
  */
 export const setStatusUnsupportedChannels = new Set<string>();
+
+const PERSISTENT_SET_STATUS_ERRORS = new Set([
+  "missing_scope",
+  "not_authed",
+  "invalid_auth",
+  "token_revoked",
+  "account_inactive",
+  "not_allowed_token_type",
+]);
+
+function getSlackErrorCode(error: any): string | undefined {
+  const code =
+    error?.data?.error ??
+    error?.error ??
+    error?.code ??
+    error?.statusCode ??
+    error?.status;
+  return code == null ? undefined : String(code);
+}
+
+function shouldDisableSetStatusForChannel(error: any): boolean {
+  const code = getSlackErrorCode(error);
+  if (code === "channel_not_found") return true;
+  return !!code && PERSISTENT_SET_STATUS_ERRORS.has(code);
+}
 
 export async function trySetAssistantThreadStatus(params: {
   client: WebClient;
@@ -25,9 +50,20 @@ export async function trySetAssistantThreadStatus(params: {
       ...(loadingMessages ? { loading_messages: loadingMessages } : {}),
     });
   } catch (error: any) {
-    setStatusUnsupportedChannels.add(channelId);
-    logger.warn("assistant.threads.setStatus failed; disabling for channel", {
+    const slackError = getSlackErrorCode(error);
+    if (shouldDisableSetStatusForChannel(error)) {
+      setStatusUnsupportedChannels.add(channelId);
+      logger.warn("assistant.threads.setStatus failed with persistent error; disabling for channel", {
+        channelId,
+        slackError,
+        error: error?.message || String(error),
+      });
+      return;
+    }
+
+    logger.warn("assistant.threads.setStatus failed with transient error; will retry later", {
       channelId,
+      slackError,
       error: error?.message || String(error),
     });
   }

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -284,17 +284,24 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
     // Set assistant thread status — triggers the shimmer animation on
     // Aura's name and shows a loading indicator while processing.
     // Status auto-clears on reply.
-    await trySetAssistantThreadStatus({
-      client,
-      channelId: context.channelId,
-      threadTs: replyThreadTs,
-      status: "Thinking...",
-      loadingMessages: [
-        "Gathering context...",
-        "Searching memories...",
-        "Pulling it together...",
-      ],
-    });
+    try {
+      await trySetAssistantThreadStatus({
+        client,
+        channelId: context.channelId,
+        threadTs: replyThreadTs,
+        status: "Thinking…",
+        loadingMessages: [
+          "Gathering context...",
+          "Searching memories...",
+          "Pulling it together...",
+        ],
+      });
+    } catch (statusError: any) {
+      logger.warn("assistant.threads.setStatus initial pipeline call failed", {
+        channelId: context.channelId,
+        error: statusError?.message || String(statusError),
+      });
+    }
 
     // ── Edge case: extremely long message ────────────────────────────────
     let messageText = context.text || (hasFiles ? "What can you tell me about this file?" : "");

--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -59,6 +59,7 @@ vi.mock("./prepare-step.js", () => ({
 import { generateResponse } from "./respond.js";
 import { logError } from "../lib/error-logger.js";
 import { logger } from "../lib/logger.js";
+import { trySetAssistantThreadStatus } from "../lib/slack-status.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -116,6 +117,7 @@ function mockAgentStreams(results: any[]) {
       run_command: {
         slack: {
           status: "Running a command in the sandbox...",
+          detail: (input: any) => input?.command ? `Command: ${input.command}` : undefined,
         },
       },
     },
@@ -152,6 +154,116 @@ describe("generateResponse Slack stream handling", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("emits an early tool card on tool-input-start and updates it on tool-call", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-input-start",
+        toolCallId: "call-1",
+        toolName: "run_command",
+      };
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "true" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
+      };
+      yield { type: "text-delta", text: "Done." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    const taskUpdateCalls = stream.append.mock.calls
+      .map(([payload]) => payload?.chunks?.[0])
+      .filter((chunk) => chunk?.type === "task_update");
+
+    expect(taskUpdateCalls).toHaveLength(3);
+    expect(taskUpdateCalls[0]).toMatchObject({
+      id: "call-1",
+      status: "in_progress",
+      title: "Running a command in the sandbox...",
+    });
+    expect(taskUpdateCalls[0]).not.toHaveProperty("details");
+    expect(taskUpdateCalls[1]).toMatchObject({
+      id: "call-1",
+      status: "in_progress",
+      details: "Command: true",
+    });
+    expect(taskUpdateCalls[2]).toMatchObject({
+      id: "call-1",
+      status: "complete",
+    });
+    expect(new Set(taskUpdateCalls.map((chunk) => chunk.id))).toEqual(new Set(["call-1"]));
+  });
+
+  it("does not propagate setStatus failures from stream refreshes", async () => {
+    vi.mocked(trySetAssistantThreadStatus).mockRejectedValueOnce(new Error("setStatus unavailable"));
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "reasoning-delta", text: "hidden reasoning" };
+      yield { type: "text-delta", text: "Still alive." };
+    })());
+
+    await expect(generateResponse(baseOptions(slackClient))).resolves.toMatchObject({
+      raw: "Still alive.",
+      alreadyPosted: true,
+    });
+    expect(trySetAssistantThreadStatus).toHaveBeenCalled();
+  });
+
+  it("uses reasoning deltas to reset the Slack stream keepalive timer", async () => {
+    vi.useFakeTimers();
+    const sendReasoningDelta = deferred<void>();
+    const finish = deferred<void>();
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "reasoning-start" };
+      await sendReasoningDelta.promise;
+      yield { type: "reasoning-delta", text: "hidden reasoning" };
+      await finish.promise;
+      yield { type: "text-delta", text: "Done." };
+    })());
+
+    const responsePromise = generateResponse(baseOptions(slackClient));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(19_000);
+
+    sendReasoningDelta.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(999);
+
+    expect(stream.append).not.toHaveBeenCalledWith({ chunks: [{ type: "markdown_text", text: " " }] });
+    expect(stream.append).not.toHaveBeenCalledWith({ markdown_text: " " });
+
+    finish.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(responsePromise).resolves.toMatchObject({
+      raw: "Done.",
+      alreadyPosted: true,
+    });
   });
 
   it("splits to a new stream with a tombstone when a tool call exceeds 75 seconds", async () => {

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -203,6 +203,9 @@ const STREAM_THRESHOLD_WHITESPACE = 9_000;
 const STREAM_HARD_LIMIT = 9_500;
 const MAX_CONTINUATIONS = 5;
 const LONG_TOOL_SPLIT_MS = 75_000;
+const STREAM_KEEPALIVE_MS = 20_000;
+const STATUS_KEEPALIVE_MS = 90_000;
+const STATUS_REFRESH_DEBOUNCE_MS = 1_000;
 const STREAM_CONTINUATION_TOMBSTONE = "_(continuing in a new message...)_";
 const TOOL_CONTINUATION_OUTPUT = "continuing in a new message...";
 const EMPTY_COMPLETION_RELAUNCH_PROMPT = "(continue - you ended without responding. Summarize what you found.)";
@@ -562,8 +565,11 @@ export async function generateResponse(
   // Keepalive interval during long tool calls (e.g. Claude Code via run_command)
   let toolKeepAlive: ReturnType<typeof setInterval> | null = null;
 
-  // Slack stream keepalive — sends minimal payload to prevent ~30s idle timeout
-  let streamKeepAlive: ReturnType<typeof setInterval> | null = null;
+  // Slack stream keepalive — sends a minimal payload only after prolonged quiet.
+  let streamKeepAlive: ReturnType<typeof setTimeout> | null = null;
+  let statusKeepAlive: ReturnType<typeof setInterval> | null = null;
+  let lastStatusRefreshAt = 0;
+  let currentStatusText = "Working on it…";
   let longToolSplitTimer: ReturnType<typeof setTimeout> | null = null;
   let longToolSplitInFlight = false;
 
@@ -971,6 +977,8 @@ export async function generateResponse(
       currentSegmentTextLength = 0;
       currentSegmentToolRecordStart = toolCallRecords.length;
       currentSegmentContinuationReason = reason;
+      resetStreamKeepAlive();
+      refreshAssistantStatus("Continuing…", { force: true });
       return true;
     } catch (startErr: any) {
       logger.warn(
@@ -988,6 +996,68 @@ export async function generateResponse(
       longToolSplitTimer = null;
       void splitLongRunningToolStream();
     }, LONG_TOOL_SPLIT_MS);
+  }
+
+  function clearStreamKeepAlive() {
+    if (streamKeepAlive) {
+      clearTimeout(streamKeepAlive);
+      streamKeepAlive = null;
+    }
+  }
+
+  function resetStreamKeepAlive() {
+    clearStreamKeepAlive();
+    if (streamingFailed || !streamer) return;
+    streamKeepAlive = setTimeout(() => {
+      streamKeepAlive = null;
+      if (streamingFailed || !streamer) return;
+      void (async () => {
+        try {
+          await tryStreamAppend(asAppendPayload({ markdown_text: " " }));
+        } finally {
+          resetStreamKeepAlive();
+        }
+      })();
+    }, STREAM_KEEPALIVE_MS);
+  }
+
+  function clearStatusKeepAlive() {
+    if (statusKeepAlive) {
+      clearInterval(statusKeepAlive);
+      statusKeepAlive = null;
+    }
+  }
+
+  function startStatusKeepAlive() {
+    if (statusKeepAlive) return;
+    statusKeepAlive = setInterval(() => {
+      refreshAssistantStatus(currentStatusText || "Working on it…", { force: true });
+    }, STATUS_KEEPALIVE_MS);
+  }
+
+  function refreshAssistantStatus(status: string, options: { force?: boolean } = {}) {
+    currentStatusText = status || "Working on it…";
+    const now = Date.now();
+    if (!options.force && now - lastStatusRefreshAt < STATUS_REFRESH_DEBOUNCE_MS) {
+      return;
+    }
+    lastStatusRefreshAt = now;
+    const statusText = currentStatusText;
+    void (async () => {
+      try {
+        await trySetAssistantThreadStatus({
+          client: slackClient,
+          channelId,
+          threadTs,
+          status: statusText,
+        });
+      } catch (statusError: any) {
+        logger.warn("assistant.threads.setStatus refresh failed", {
+          channelId,
+          error: statusError?.message || String(statusError),
+        });
+      }
+    })();
   }
 
   async function splitLongRunningToolStream(): Promise<void> {
@@ -1055,12 +1125,23 @@ export async function generateResponse(
 
   try {
     // Signal extended thinking phase to the user via Slack thread status
-    await trySetAssistantThreadStatus({
-      client: slackClient,
-      channelId,
-      threadTs,
-      status: "Thinking deeply...",
-    });
+    try {
+      await trySetAssistantThreadStatus({
+        client: slackClient,
+        channelId,
+        threadTs,
+        status: "Thinking…",
+      });
+    } catch (statusError: any) {
+      logger.warn("assistant.threads.setStatus initial refresh failed", {
+        channelId,
+        error: statusError?.message || String(statusError),
+      });
+    }
+    currentStatusText = "Thinking…";
+    lastStatusRefreshAt = Date.now();
+    startStatusKeepAlive();
+    resetStreamKeepAlive();
 
     let currentStreamCallOptions = streamCallOptions;
     while (true) {
@@ -1071,14 +1152,55 @@ export async function generateResponse(
 
       for await (const chunk of result.fullStream) {
         resetTimer();
+        resetStreamKeepAlive();
 
         switch (chunk.type) {
+        case "reasoning-start":
+        case "reasoning-delta":
+        case "reasoning-end": {
+          refreshAssistantStatus("Thinking…");
+          break;
+        }
+
         case "text-delta": {
           await appendTextDelta(chunk.text);
           break;
         }
 
+        case "tool-input-start": {
+          const toolName = (chunk as any).toolName;
+          const toolCallId = (chunk as any).toolCallId;
+          refreshAssistantStatus(`Calling \`${toolName || "tool"}\`…`);
+
+          if (!toolName || !toolCallId) break;
+          const slackMeta = getSlackMeta(tools[toolName]);
+          const title = slackMeta?.status ?? `Calling ${toolName}…`;
+          const toolInputStartPayload = asAppendPayload({
+            chunks: [toTaskUpdateChunk({
+              id: toolCallId,
+              title,
+              status: "in_progress",
+            })],
+          });
+          currentStreamLength += estimateAppendSize(toolInputStartPayload);
+          if (!streamingFailed) {
+            await tryStreamAppend(toolInputStartPayload);
+            if (streamingFailed) {
+              fallbackStartIdx = accumulatedText.length;
+            }
+          }
+          break;
+        }
+
+        case "tool-input-delta": {
+          const toolName = (chunk as any).toolName;
+          refreshAssistantStatus(`Calling \`${toolName || "tool"}\`…`);
+          break;
+        }
+
         case "tool-call": {
+          refreshAssistantStatus(`Calling \`${chunk.toolName}\`…`);
+
           // Flush any pending table buffer before tool cards
           if ((tableBuffer.length > 0 || lineCarry) && !streamingFailed) {
             const preToolFlush = flushRemainingTableBuffer();
@@ -1124,21 +1246,12 @@ export async function generateResponse(
           if (toolKeepAlive) clearInterval(toolKeepAlive);
           toolKeepAlive = setInterval(() => resetTimer(), 60_000);
 
-          // Keep Slack stream alive during long tool execution (~30s idle timeout)
-          if (!streamingFailed && streamKeepAlive == null) {
-            streamKeepAlive = setInterval(async () => {
-              if (streamingFailed) {
-                clearInterval(streamKeepAlive!);
-                streamKeepAlive = null;
-                return;
-              }
-              await tryStreamAppend(asAppendPayload({ markdown_text: " " }));
-            }, 20_000);
-          }
           break;
         }
 
         case "tool-result": {
+          refreshAssistantStatus("Processing results…");
+
           const resultSlackMeta = getSlackMeta(tools[chunk.toolName]);
           const title = resultSlackMeta?.status ?? "Done";
           const output = chunk.output;
@@ -1192,7 +1305,6 @@ export async function generateResponse(
           pendingToolInputs.delete(chunk.toolCallId);
 
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
-          if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
           if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
 
@@ -1237,7 +1349,6 @@ export async function generateResponse(
           pendingToolInputs.delete(errToolCallId);
 
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
-          if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
           if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
 
@@ -1358,7 +1469,8 @@ export async function generateResponse(
     // ── Finalize ──────────────────────────────────────────────────────────
     clearTimeout(inactivityTimer);
     if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
-    if (streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+    clearStreamKeepAlive();
+    clearStatusKeepAlive();
     clearLongToolSplitTimer();
 
     const llmMs = Date.now() - start;
@@ -1601,7 +1713,8 @@ export async function generateResponse(
   } catch (error: any) {
     clearTimeout(inactivityTimer);
     if (toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
-    if (streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
+    clearStreamKeepAlive();
+    clearStatusKeepAlive();
     clearLongToolSplitTimer();
 
     if (error instanceof InvocationSupersededError) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Emit early Slack task cards on `tool-input-start` and update the same card on the matching `tool-call`.
- Keep Aura visibly active with debounced contextual `setStatus` refreshes, a 90s status ticker, continuation-stream refreshes, and reasoning/tool-input signal handling.
- Tighten `assistant.threads.setStatus` blacklisting so transient Slack/network failures do not disable indicators.
- Use reasoning stream chunks only as keepalive/status signals, without rendering reasoning text.

Closes #1001.

## Rebase note
- Rebases cleanly onto `origin/main` at `814b897` and preserves main's `appendTextDelta` streaming path.

## Verification
- `pnpm --filter aura-api test -- src/pipeline/respond.test.ts src/lib/slack-status.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
- Pre-push typecheck hook passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-365a5f0e-eb85-491b-9024-83fed907cd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-365a5f0e-eb85-491b-9024-83fed907cd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

