### PR TITLE
Fix email sync batch miss error logging

### DIFF
--- a/apps/api/src/lib/email-sync.test.ts
+++ b/apps/api/src/lib/email-sync.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const insertValues = vi.fn((rows: unknown[]) => ({
+    onConflictDoNothing: vi.fn(async () => ({
+      rowCount: Array.isArray(rows) ? rows.length : 1,
+    })),
+  }));
+
+  return {
+    getGmailClientForUser: vi.fn(),
+    getHeader: vi.fn((headers: Array<{ name: string; value: string }>, name: string) =>
+      headers.find((header) => header.name.toLowerCase() === name.toLowerCase())?.value ?? "",
+    ),
+    extractBodyParts: vi.fn(() => ({ html: "", plain: "Email body" })),
+    hasAttachmentParts: vi.fn(() => false),
+    logError: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    insert: vi.fn(() => ({
+      values: insertValues,
+    })),
+    insertValues,
+    selectDistinct: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          then: (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve([])),
+        })),
+      })),
+    })),
+    resolveOrCreateFromEmail: vi.fn(async () => ({})),
+    embedTexts: vi.fn(async () => []),
+  };
+});
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    insert: mocks.insert,
+    selectDistinct: mocks.selectDistinct,
+  },
+}));
+
+vi.mock("./gmail.js", () => ({
+  getGmailClientForUser: mocks.getGmailClientForUser,
+  getHeader: mocks.getHeader,
+  extractBodyParts: mocks.extractBodyParts,
+  hasAttachmentParts: mocks.hasAttachmentParts,
+}));
+
+vi.mock("./error-logger.js", () => ({
+  logError: mocks.logError,
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: mocks.logger,
+}));
+
+vi.mock("./person-resolution.js", () => ({
+  resolveOrCreateFromEmail: mocks.resolveOrCreateFromEmail,
+}));
+
+vi.mock("./embeddings.js", () => ({
+  embedTexts: mocks.embedTexts,
+}));
+
+function gmailMessage(id: string) {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    labelIds: ["INBOX"],
+    payload: {
+      headers: [
+        { name: "From", value: "Sender <sender@example.com>" },
+        { name: "To", value: "User <user@example.com>" },
+        { name: "Subject", value: "Test email" },
+        { name: "Date", value: "Thu, 21 May 2026 07:00:35 +0000" },
+      ],
+    },
+  };
+}
+
+function batchResponse(messages: unknown[]): Response {
+  const boundary = "batch_response";
+  const body = messages
+    .map(
+      (message, index) =>
+        [
+          `--${boundary}`,
+          "Content-Type: application/http",
+          `Content-ID: <response-item${index}>`,
+          "",
+          "HTTP/1.1 200 OK",
+          "Content-Type: application/json; charset=UTF-8",
+          "",
+          JSON.stringify(message),
+        ].join("\r\n"),
+    )
+    .join("\r\n");
+
+  return new Response(`${body}\r\n--${boundary}--`, {
+    status: 200,
+    headers: { "Content-Type": `multipart/mixed; boundary=${boundary}` },
+  });
+}
+
+function setupGmailList(messageIds: string[]) {
+  const list = vi.fn(async () => ({
+    data: {
+      messages: messageIds.map((id) => ({ id })),
+    },
+  }));
+
+  mocks.getGmailClientForUser.mockResolvedValue({
+    client: {
+      users: {
+        messages: { list },
+      },
+    },
+    email: "user@example.com",
+    oauth2Client: {
+      getAccessToken: vi.fn(async () => ({ token: "access-token" })),
+    },
+  });
+
+  return list;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn());
+
+  const immediateSetTimeout = ((
+    callback: (...args: unknown[]) => void,
+    _delay?: number,
+    ...args: unknown[]
+  ) => {
+    callback(...args);
+    return 0 as any;
+  }) as typeof setTimeout;
+  vi.spyOn(globalThis, "setTimeout").mockImplementation(immediateSetTimeout);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("syncEmails batch_api_miss retry logging", () => {
+  it("does not create error events when a transient batch_api_miss is recovered", async () => {
+    setupGmailList(["msg-1"]);
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(batchResponse([]))
+      .mockResolvedValueOnce(batchResponse([gmailMessage("msg-1")]));
+
+    const { syncEmails } = await import("./email-sync.js");
+    const result = await syncEmails("U123", {
+      query: "newer_than:1d",
+      maxMessages: 1,
+    });
+
+    expect(result).toMatchObject({
+      synced: 1,
+      skipped: 0,
+      errors: 0,
+      errorDetails: [],
+    });
+    expect(mocks.logError).not.toHaveBeenCalled();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      "Email sync: batch_api_miss before retry",
+      expect.objectContaining({
+        userId: "U123",
+        gmailMessageId: "msg-1",
+      }),
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({ gmailMessageId: "msg-1" }),
+    ]);
+  });
+
+  it("creates a permanent miss error event only after retry also misses", async () => {
+    setupGmailList(["msg-1"]);
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(batchResponse([]))
+      .mockResolvedValueOnce(batchResponse([]));
+
+    const { syncEmails } = await import("./email-sync.js");
+    const result = await syncEmails("U123", {
+      query: "newer_than:1d",
+      maxMessages: 1,
+    });
+
+    expect(result.errors).toBe(1);
+    expect(result.errorDetails).toEqual([
+      {
+        gmailMessageId: "msg-1",
+        reason: "batch_api_miss_persisted: message ID still not returned by batch API after retry",
+      },
+    ]);
+    expect(mocks.logError).toHaveBeenCalledTimes(1);
+    expect(mocks.logError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorName: "EmailSyncPermanentMiss",
+        errorCode: "email_sync_permanent_miss",
+        userId: "U123",
+        context: {
+          gmailMessageId: "msg-1",
+          retryAttempted: true,
+        },
+      }),
+    );
+    expect(mocks.logError).not.toHaveBeenCalledWith(
+      expect.objectContaining({ errorCode: "email_sync_error" }),
+    );
+  });
+});

--- a/apps/api/src/lib/email-sync.ts
+++ b/apps/api/src/lib/email-sync.ts
@@ -186,6 +186,35 @@ async function batchGetMessages(
   return results;
 }
 
+const BATCH_API_MISS_RECOVERY_LOG_INTERVAL = 25;
+let batchApiMissRecoveredSinceStart = 0;
+
+function recordBatchApiMissRecoveries(
+  userId: string,
+  recovered: number,
+  attempted: number,
+): void {
+  if (recovered <= 0) return;
+
+  const previous = batchApiMissRecoveredSinceStart;
+  batchApiMissRecoveredSinceStart += recovered;
+
+  if (
+    Math.floor(previous / BATCH_API_MISS_RECOVERY_LOG_INTERVAL) ===
+    Math.floor(batchApiMissRecoveredSinceStart / BATCH_API_MISS_RECOVERY_LOG_INTERVAL)
+  ) {
+    return;
+  }
+
+  logger.info("Email sync: batch_api_miss recovery counter", {
+    userId,
+    recovered,
+    attempted,
+    recoveredSinceStart: batchApiMissRecoveredSinceStart,
+    logInterval: BATCH_API_MISS_RECOVERY_LOG_INTERVAL,
+  });
+}
+
 // ── Message row conversion ───────────────────────────────────────────────────
 
 function messageToRow(
@@ -312,12 +341,10 @@ export async function syncEmails(
         const reason = "batch_api_miss: message ID listed but not returned by batch API";
         result.errorDetails.push({ gmailMessageId: id, reason });
         result.errors++;
-        logError({
-          errorName: "EmailSyncError",
-          errorMessage: reason,
-          errorCode: "email_sync_error",
+        logger.warn("Email sync: batch_api_miss before retry", {
           userId,
-          context: { gmailMessageId: id },
+          gmailMessageId: id,
+          batchOffset: i,
         });
         continue;
       }
@@ -399,24 +426,54 @@ export async function syncEmails(
     .map((e) => e.gmailMessageId);
 
   if (missedIds.length > 0) {
-    logger.info("Retrying batch_api_miss messages", { count: missedIds.length });
+    const missedIdSet = new Set(missedIds);
+    logger.info("Retrying batch_api_miss messages", { userId, count: missedIds.length });
     await new Promise((r) => setTimeout(r, 5000));
 
     const retryMap = await batchGetMessages(accessToken, missedIds);
 
     const retryRows: NewEmailRaw[] = [];
     const recoveredIds: Set<string> = new Set();
+    const retryFailureReasons = new Map<string, string>();
     for (const e of result.errorDetails) {
       if (!e.reason.startsWith("batch_api_miss")) continue;
       const msg = retryMap.get(e.gmailMessageId);
-      if (!msg) continue;
+      if (!msg) {
+        retryFailureReasons.set(
+          e.gmailMessageId,
+          "batch_api_miss_persisted: message ID still not returned by batch API after retry",
+        );
+        continue;
+      }
       try {
         const row = messageToRow(msg, userId, userEmail);
         if (row) {
           retryRows.push(row);
           recoveredIds.add(e.gmailMessageId);
+        } else {
+          retryFailureReasons.set(
+            e.gmailMessageId,
+            "batch_api_retry_messageToRow_null: missing required fields after retry",
+          );
         }
-      } catch {}
+      } catch (err) {
+        retryFailureReasons.set(
+          e.gmailMessageId,
+          `batch_api_retry_process_failed: ${String(err)}`,
+        );
+        logger.warn("Failed to process retried batch_api_miss message", {
+          userId,
+          gmailMessageId: e.gmailMessageId,
+          error: String(err),
+        });
+      }
+    }
+
+    if (retryFailureReasons.size > 0) {
+      result.errorDetails = result.errorDetails.map((e) => {
+        const retryReason = retryFailureReasons.get(e.gmailMessageId);
+        return retryReason ? { ...e, reason: retryReason } : e;
+      });
     }
 
     if (retryRows.length > 0) {
@@ -433,9 +490,42 @@ export async function syncEmails(
           (e) => !recoveredIds.has(e.gmailMessageId),
         );
         result.errors -= recoveredIds.size;
-        logger.info("Retry recovered messages", { recovered: retryRows.length });
+        logger.info("Retry recovered batch_api_miss messages", {
+          userId,
+          recovered: recoveredIds.size,
+          attempted: missedIds.length,
+          inserted: insertResult.rowCount ?? 0,
+          skipped: retryRows.length - (insertResult.rowCount ?? 0),
+        });
+        recordBatchApiMissRecoveries(userId, recoveredIds.size, missedIds.length);
       } catch (err) {
-        logger.error("Retry batch insert failed", { error: String(err) });
+        logger.error("Retry batch insert failed", {
+          userId,
+          rowCount: retryRows.length,
+          error: String(err),
+        });
+      }
+    }
+
+    const permanentMisses = result.errorDetails.filter((e) =>
+      missedIdSet.has(e.gmailMessageId),
+    );
+    if (permanentMisses.length > 0) {
+      logger.error("Email sync: batch_api_miss persisted after retry", {
+        userId,
+        count: permanentMisses.length,
+      });
+      for (const miss of permanentMisses) {
+        logError({
+          errorName: "EmailSyncPermanentMiss",
+          errorMessage: `batch_api_miss retry failed: ${miss.reason}`,
+          errorCode: "email_sync_permanent_miss",
+          userId,
+          context: {
+            gmailMessageId: miss.gmailMessageId,
+            retryAttempted: true,
+          },
+        });
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Downgrades initial Gmail `batch_api_miss` observations from `logError(...)` to warning logs so transient recoveries no longer create `error_events` rows.
- Logs `email_sync_permanent_miss` only after the retry path also fails to recover a missed message.
- Adds INFO-level recovery counter logging and focused tests for recovered vs permanent batch misses.

## Phase 1 findings

Issue comment posting was attempted before implementation, but this environment did not expose `GITHUB_TOKEN` (`NO_GITHUB_TOKEN`), so I could not post directly to issue #994. Per the guardrail, the Phase 1 findings are included here verbatim.

Using the pre-loaded production data plus a code read of `apps/api/src/lib/email-sync.ts`:

### Production data summary

- Volume: 5-15/day, 107 events in the last 30 days.
- Per-user distribution in the last 30 days:
  - `U0678NQJ2`: 77 events
  - `U066V1AN6`: 30 events
- Only two users have the error, both heavy Gmail-sync users.
- UTC time-of-day clustering:
  - 06:00 hour: 66 events
  - 07:00 hour: 5 events
  - 09:00 hour: 5 events
  - 18:00 hour: 31 events
- These align with scheduled sync jobs at 06:00 and 18:00 UTC, and the bursts happen at sync-job-start.
- Within a burst, five events can fire within about 100ms, which matches one batch API call returning fewer messages than the IDs listed.
- Recovery check against `emails_raw`: 29/30 of the most recent `email_sync_error` events were present in `emails_raw` within about 10 seconds. Example: missed at 07:00:25.026, recovered at 07:00:35.169.
- Only 1/30 checked IDs appeared to be a genuine permanent miss.

### Code-path answers

1. **Does `logError("email_sync_error", "batch_api_miss")` fire before retry, or after?**

   Before retry. In `syncEmails`, the first batch pass calls `batchGetMessages(...)`; for any listed ID missing from the returned map, lines around 311-322 push an error detail, increment `result.errors`, and call `logError({ errorCode: "email_sync_error", ... })`. The retry block does not begin until after the main loop, around lines 396-410, after a 5-second cooldown.

2. **Where does the retry succeed? Does it write to `emails_raw` directly, or requeue?**

   It writes directly to `emails_raw`. The retry block calls `batchGetMessages(accessToken, missedIds)`, converts recovered messages with `messageToRow`, then calls `db.insert(emailsRaw).values(retryRows).onConflictDoNothing(...)`. On successful insert, it increments `result.synced`, adjusts `result.skipped`, removes recovered IDs from `result.errorDetails`, and decrements `result.errors`. There is no requeue in this path.

3. **Is there a code path where retry success/failure is logged separately?**

   Only partially, and not through `error_events`. Retry success emits `logger.info("Retry recovered messages", { recovered: retryRows.length })`. Retry DB insert failure emits `logger.error("Retry batch insert failed", ...)`. There is no separate `logError` for permanent misses after retry, and the initial `email_sync_error` row remains even when the retry succeeds. This is the root observability bug: transient misses recovered seconds later are recorded as error events.

4. **Is listing pagination using `historyId`/`pageToken` correctly?**

   For this query-based sync path, pagination appears correct. The code uses `gmail.users.messages.list({ q, maxResults, pageToken })`, appends message IDs, then follows `listRes.data.nextPageToken` until no token remains or `maxMessages` is reached. This path does not use `historyId`; it is a bounded search query (`newer_than:7d` by default), so `pageToken` is the relevant mechanism here. The data showing IDs reappearing in subsequent listings/retries does not point to a pagination bug.

5. **Could Gmail's batch API be returning the IDs in a later part of the response that our parser misses?**

   Unlikely for the observed pattern, but the parser is brittle. `batchGetMessages` reads the entire multipart response, splits by `/--batch_[^\\r\\n]+/`, and loops over every split part, so if the Gmail response boundary matches that assumption, later parts are scanned. A parser miss due to "later parts" would be more plausible if Gmail returned a boundary not starting with `batch_`, because then the greedy JSON regex could attempt to parse the whole multipart body as one invalid JSON blob and drop many/all messages. The production symptom is only a handful of IDs missing and then recovering on retry, so transient per-part Gmail inconsistency remains the best explanation. It would still be reasonable future hardening to parse the response boundary from the `Content-Type` header and log per-part non-2xx statuses.

### Proposed fix

Proceed with the recommended shape:

- Downgrade the initial `batch_api_miss` from `logError(...)` to `logger.warn(...)`, so a synthetic batch miss followed by a successful retry produces **zero** `error_events` rows.
- Keep the existing retry path that writes recovered messages directly to `emails_raw`.
- After the retry attempt, call `logError` only for batch misses that are still unrecovered, using a new `email_sync_permanent_miss` error code.
- Add INFO-level retry recovery counter logging so successful transient recoveries remain observable without polluting `error_events`.

## Testing

- `pnpm --filter aura-api typecheck`
- `pnpm --filter aura-api test`
- Pre-push hook also passed `aura-api` and `aura-dashboard` typechecks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a09b947-04b4-4601-873f-20dda592cc70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a09b947-04b4-4601-873f-20dda592cc70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

