### PR TITLE
Add AGENTS.md and approve build scripts for dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,18 +15,20 @@ General project conventions and architecture are documented in `CLAUDE.md` at th
 - `ELEVENLABS_API_KEY` must be set (even as a placeholder) because the ElevenLabs client is instantiated at module load time in `apps/api/src/webhook/elevenlabs.ts` — without it the API crashes on startup.
 - `DATABASE_URL` is required for the API to start. The Neon serverless driver connects lazily (server starts even with an invalid URL), but DB queries will fail without a real connection string.
 - The `lint` script in `apps/api` references `eslint` but it is not installed as a dependency. Use `pnpm typecheck` as the primary code quality check (enforced by the pre-push hook).
-- `pnpm install` warnings about ignored build scripts (esbuild, sharp) are safe to ignore — these packages use prebuilt platform binaries.
+- `pnpm install` warnings about ignored build scripts (esbuild, sharp) are safe to ignore — these packages are approved via `pnpm.onlyBuiltDependencies` in root `package.json`.
+- `@aura/db` must be built before running apps — it exports compiled JS from `dist/`. Run `pnpm --filter @aura/db build` (or `pnpm dev` which does it automatically).
+- The dashboard uses `vite-plus` (alias `vp`) as the dev/build CLI, not raw `vite`.
 
 ### Verification commands
 
 ```bash
 pnpm typecheck                # Type-check API + Dashboard (run before committing)
-pnpm --filter aura-api test   # Run API unit/integration tests (vitest)
+pnpm --filter aura-api test   # Run API unit/integration tests (vitest, no DB needed)
 curl http://localhost:3001/    # API health: {"name":"Aura","version":"0.1.0","status":"alive"}
 ```
 
 ### Notes
 
-- The dashboard requires Slack OAuth login. To test authenticated dashboard API routes directly, use `Authorization: Bearer $DASHBOARD_API_SECRET` header.
+- The dashboard requires Slack OAuth login. To test authenticated dashboard API routes directly, use `Authorization: Bearer $DASHBOARD_API_SECRET` header. For local browser testing without Slack OAuth, generate a JWT signed with `DASHBOARD_SESSION_SECRET` containing `{ slackUserId, name, picture }` and pass it as `?token=<jwt>` in the URL.
 - All optional integrations (E2B, Tavily, GitHub, ElevenLabs, Twilio, etc.) degrade gracefully when env vars are missing — they disable features rather than crash.
 - `.env.local` at the repo root is the single env file for local dev (gitignored). Copy from `.env.example` and fill in real values as needed.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "db:studio": "./scripts/env.sh pnpm --filter @aura/db db:studio"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ],
     "overrides": {
       "e2b>chalk": "4.1.2"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up development environment configuration for Cursor Cloud agents:

- **`AGENTS.md`** — Cloud-specific development instructions including quick reference commands, environment setup notes, and gotchas discovered during setup.
- **`package.json`** — Added `pnpm.onlyBuiltDependencies` for `esbuild` and `sharp` to avoid interactive approval prompts during `pnpm install`.

## Development Environment Verification

All core development workflows verified:

- `pnpm install` — 950 packages installed successfully
- `pnpm --filter @aura/db build` — shared DB package compiles
- `pnpm typecheck` — both API and Dashboard pass type checking
- `pnpm --filter aura-api test` — all 153 unit tests pass
- `pnpm --filter aura-api dev` — API starts on port 3001
- `pnpm --filter aura-dashboard dev` — Dashboard starts on port 5173

[Dashboard overview page](https://cursor.com/agents/bc-ec354b6c-c5bb-437a-92aa-420edc11e929/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_overview.webp)
[Dashboard notes page](https://cursor.com/agents/bc-ec354b6c-c5bb-437a-92aa-420edc11e929/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_notes.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec354b6c-c5bb-437a-92aa-420edc11e929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec354b6c-c5bb-437a-92aa-420edc11e929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

