### PR TITLE
Optimistic tool card on tool-input-start

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -116,6 +116,7 @@ function mockAgentStreams(results: any[]) {
       run_command: {
         slack: {
           status: "Running a command in the sandbox...",
+          detail: (input: any) => input.command,
         },
       },
     },
@@ -226,6 +227,106 @@ describe("generateResponse Slack stream handling", () => {
         id: "call-1",
         status: "complete",
       })],
+    });
+  });
+
+  it("emits an optimistic tool card on tool-input-start and updates it on tool-call", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-input-start",
+        toolCallId: "call-1",
+        toolName: "run_command",
+      };
+      yield {
+        type: "tool-input-delta",
+        toolCallId: "call-1",
+        inputTextDelta: "{\"command\":\"echo",
+      };
+      yield {
+        type: "tool-input-delta",
+        toolCallId: "call-1",
+        inputTextDelta: " ok\"}",
+      };
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "echo ok" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "ok", stderr: "" },
+      };
+      yield { type: "text-delta", text: "Done." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    const taskUpdates = stream.append.mock.calls
+      .flatMap(([payload]) => payload.chunks ?? [])
+      .filter((chunk) => chunk.type === "task_update" && chunk.id === "call-1");
+    const inProgressUpdates = taskUpdates.filter((chunk) => chunk.status === "in_progress");
+
+    expect(new Set(inProgressUpdates.map((chunk) => chunk.id))).toEqual(new Set(["call-1"]));
+    expect(inProgressUpdates).toHaveLength(2);
+    expect(inProgressUpdates[0]).toMatchObject({
+      type: "task_update",
+      id: "call-1",
+      title: "Running a command in the sandbox...",
+      status: "in_progress",
+    });
+    expect(inProgressUpdates[0]).not.toHaveProperty("details");
+    expect(inProgressUpdates[1]).toMatchObject({
+      type: "task_update",
+      id: "call-1",
+      title: "Running a command in the sandbox...",
+      status: "in_progress",
+      details: "echo ok",
+    });
+  });
+
+  it("terminates an optimistic tool card if the stream errors before tool-call", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-input-start",
+        toolCallId: "call-1",
+        toolName: "run_command",
+      };
+      throw new Error("tool input failed");
+    })());
+
+    await expect(generateResponse(baseOptions(slackClient))).rejects.toThrow("tool input failed");
+
+    expect(stream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "task_update",
+        id: "call-1",
+        status: "in_progress",
+      })],
+    });
+    expect(stream.stop).toHaveBeenCalledWith({
+      chunks: expect.arrayContaining([
+        expect.objectContaining({
+          type: "task_update",
+          id: "call-1",
+          status: "error",
+          output: "tool input failed",
+        }),
+      ]),
     });
   });
 

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -659,6 +659,7 @@ export async function generateResponse(
   let pendingTableBlock: Record<string, any> | null = null;
   const toolCallRecords: ToolCallRecord[] = [];
   const pendingToolInputs = new Map<string, { name: string; input: string }>();
+  const optimisticToolCards = new Map<string, { title: string }>();
   let continuationCount = 0;
   let currentSegmentIndex = 0;
   let currentSegmentTextLength = 0;
@@ -736,6 +737,17 @@ export async function generateResponse(
     }
     chunks.push(toChunkMarkdownText(`\n${STREAM_CONTINUATION_TOMBSTONE}\n`));
     return chunks;
+  }
+
+  function buildOptimisticToolErrorChunks(errorMessage: string): SlackStreamChunk[] {
+    return Array.from(optimisticToolCards.entries()).map(([toolCallId, card]) =>
+      toTaskUpdateChunk({
+        id: toolCallId,
+        title: card.title,
+        status: "error",
+        output: truncate(errorMessage, 200),
+      }),
+    );
   }
 
   async function appendStreamTombstone(): Promise<void> {
@@ -1078,6 +1090,36 @@ export async function generateResponse(
           break;
         }
 
+        case "tool-input-start": {
+          const toolCallId = (chunk as any).toolCallId;
+          const toolName = (chunk as any).toolName;
+          if (typeof toolCallId !== "string" || typeof toolName !== "string") {
+            break;
+          }
+          if (optimisticToolCards.has(toolCallId)) {
+            break;
+          }
+
+          const slackMeta = getSlackMeta(tools[toolName]);
+          const title = slackMeta?.status ?? "Working on it...";
+          optimisticToolCards.set(toolCallId, { title });
+          const toolInputStartPayload = asAppendPayload({
+            chunks: [toTaskUpdateChunk({
+              id: toolCallId,
+              title,
+              status: "in_progress",
+            })],
+          });
+          currentStreamLength += estimateAppendSize(toolInputStartPayload);
+          if (!streamingFailed) {
+            await tryStreamAppend(toolInputStartPayload);
+            if (streamingFailed) {
+              fallbackStartIdx = accumulatedText.length;
+            }
+          }
+          break;
+        }
+
         case "tool-call": {
           // Flush any pending table buffer before tool cards
           if ((tableBuffer.length > 0 || lineCarry) && !streamingFailed) {
@@ -1118,6 +1160,7 @@ export async function generateResponse(
             name: chunk.toolName,
             input: truncateToBytes(JSON.stringify(inputArgs), 1500),
           });
+          optimisticToolCards.delete(chunk.toolCallId);
           startLongToolSplitTimer();
 
           // Keep resetting inactivity timer during long tool execution
@@ -1190,6 +1233,7 @@ export async function generateResponse(
             rawOutput: output,
           });
           pendingToolInputs.delete(chunk.toolCallId);
+          optimisticToolCards.delete(chunk.toolCallId);
 
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
@@ -1235,6 +1279,7 @@ export async function generateResponse(
             is_error: true,
           });
           pendingToolInputs.delete(errToolCallId);
+          optimisticToolCards.delete(errToolCallId);
 
           if (pendingToolInputs.size === 0 && toolKeepAlive) { clearInterval(toolKeepAlive); toolKeepAlive = null; }
           if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
@@ -1613,8 +1658,12 @@ export async function generateResponse(
       if (streamer && !streamingFailed) {
         try {
           await streamer.stop({
-            chunks: [toChunkMarkdownText("\n\n_[interrupted — new message received]_")],
+            chunks: [
+              ...buildOptimisticToolErrorChunks("Interrupted by a newer message"),
+              toChunkMarkdownText("\n\n_[interrupted — new message received]_"),
+            ],
           });
+          optimisticToolCards.clear();
         } catch {
           // Stream may already be closed
         }
@@ -1747,7 +1796,13 @@ export async function generateResponse(
 
       if (streamer && !streamingFailed) {
         try {
-          await streamer.stop({ chunks: [toChunkMarkdownText(`\n\n${tombstone}`)] });
+          await streamer.stop({
+            chunks: [
+              ...buildOptimisticToolErrorChunks(tombstone),
+              toChunkMarkdownText(`\n\n${tombstone}`),
+            ],
+          });
+          optimisticToolCards.clear();
         } catch {
           try {
             await safePostMessage(slackClient, {
@@ -1790,7 +1845,13 @@ export async function generateResponse(
           ? "\n\n_...interrupted. Something went wrong._"
           : "_Sorry, I got interrupted before I could finish. Try again?_";
 
-        await streamer.stop({ chunks: [toChunkMarkdownText(errorText)] });
+        await streamer.stop({
+          chunks: [
+            ...buildOptimisticToolErrorChunks(error?.message || String(error)),
+            toChunkMarkdownText(errorText),
+          ],
+        });
+        optimisticToolCards.clear();
       } catch {
         // Stream may already be closed — nothing we can do
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Emit an optimistic Slack task update when AI SDK streams `tool-input-start`, using the existing tool status label and `toolCallId` as the card id.
- Keep the existing `tool-call` card update on the same id so full input details fill in-place.
- Terminate optimistic cards with an error update if the stream errors before the corresponding `tool-call` arrives.

## Verification
- `pnpm --filter aura-api typecheck`
- `pnpm --filter aura-api test`
- `npx tsc --noEmit` (from `apps/api`)

Closes #1007
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a933c5bc-2577-4c99-8528-1d1d6121b9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a933c5bc-2577-4c99-8528-1d1d6121b9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

