### PR TITLE
Sub-status 'Thinking…' indicator during generation (re #1009)

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -182,6 +182,7 @@ describe("generateResponse Slack stream handling", () => {
 
     expect(events[0]).toBe("status:Thinking…");
     expect(events.indexOf("status:Thinking…")).toBeLessThan(events.indexOf("append"));
+    expect(statusCallValues()).toEqual(["Thinking…", "", ""]);
   });
 
   it("clears status exactly once on successful completion without visible text", async () => {
@@ -236,6 +237,72 @@ describe("generateResponse Slack stream handling", () => {
     await generateResponse(baseOptions(slackClient));
 
     expect(events.slice(0, 3)).toEqual(["status:Thinking…", "status:", "append"]);
+  });
+
+  it("toggles status back to Thinking during reasoning gaps between text deltas", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "First visible text." };
+      yield { type: "reasoning-delta", text: "private reasoning" };
+      yield { type: "text-delta", text: " More visible text." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(statusCallValues()).toEqual(["Thinking…", "", "Thinking…", "", ""]);
+  });
+
+  it("suspends the sub-status controller during tool input and tool execution", async () => {
+    const events: string[] = [];
+    vi.mocked(trySetAssistantThreadStatus).mockImplementation(async ({ status }: any) => {
+      events.push(`status:${status}`);
+    });
+    const stream = {
+      append: vi.fn().mockImplementation(async (payload: any) => {
+        const firstChunk = payload.chunks?.[0];
+        events.push(firstChunk?.type === "task_update"
+          ? `append:task:${firstChunk.status}`
+          : "append:text");
+      }),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Before tool." };
+      events.push("event:tool-input-start");
+      yield { type: "tool-input-start", toolCallId: "call-1", toolName: "run_command" };
+      events.push("event:tool-call");
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "true" },
+      };
+      events.push("event:tool-result");
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
+      };
+      yield { type: "text-delta", text: " After tool." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(statusCallValues()).toEqual(["Thinking…", "", "Thinking…", "", ""]);
+
+    const toolInputStartIdx = events.indexOf("event:tool-input-start");
+    const toolResultAppendIdx = events.indexOf("append:task:complete");
+    const statusDuringTool = events.slice(toolInputStartIdx + 1, toolResultAppendIdx)
+      .filter((event) => event.startsWith("status:"));
+    expect(statusDuringTool).toEqual([]);
   });
 
   it("splits to a new stream with a tombstone when a tool call exceeds 75 seconds", async () => {

--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -59,6 +59,7 @@ vi.mock("./prepare-step.js", () => ({
 import { generateResponse } from "./respond.js";
 import { logError } from "../lib/error-logger.js";
 import { logger } from "../lib/logger.js";
+import { trySetAssistantThreadStatus } from "../lib/slack-status.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -145,6 +146,12 @@ function baseOptions(slackClient: any) {
   };
 }
 
+function statusCallValues(): string[] {
+  return vi.mocked(trySetAssistantThreadStatus).mock.calls.map(
+    ([params]) => (params as any).status,
+  );
+}
+
 describe("generateResponse Slack stream handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -152,6 +159,83 @@ describe("generateResponse Slack stream handling", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("sets Thinking status on stream start before text is emitted", async () => {
+    const events: string[] = [];
+    vi.mocked(trySetAssistantThreadStatus).mockImplementation(async ({ status }: any) => {
+      events.push(`status:${status}`);
+    });
+    const stream = {
+      append: vi.fn().mockImplementation(async () => {
+        events.push("append");
+      }),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Hello." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(events[0]).toBe("status:Thinking…");
+    expect(events.indexOf("status:Thinking…")).toBeLessThan(events.indexOf("append"));
+  });
+
+  it("clears status exactly once on successful completion without visible text", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "start-step" };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(statusCallValues()).toEqual(["Thinking…", ""]);
+  });
+
+  it("clears status exactly once after a thrown stream error", async () => {
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      throw new Error("stream exploded");
+    })());
+
+    await expect(generateResponse(baseOptions(slackClient))).rejects.toThrow("stream exploded");
+
+    expect(statusCallValues().filter((status) => status === "")).toHaveLength(1);
+  });
+
+  it("clears status when the first text delta arrives", async () => {
+    const events: string[] = [];
+    vi.mocked(trySetAssistantThreadStatus).mockImplementation(async ({ status }: any) => {
+      events.push(`status:${status}`);
+    });
+    const stream = {
+      append: vi.fn().mockImplementation(async () => {
+        events.push("append");
+      }),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Visible text." };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    expect(events.slice(0, 3)).toEqual(["status:Thinking…", "status:", "append"]);
   });
 
   it("splits to a new stream with a tombstone when a tool call exceeds 75 seconds", async () => {
@@ -704,5 +788,6 @@ describe("generateResponse Slack stream handling", () => {
         text: expect.stringContaining("[stream aborted: inactivity]"),
       })],
     });
+    expect(statusCallValues().filter((status) => status === "")).toHaveLength(1);
   });
 });

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -1029,6 +1029,36 @@ export async function generateResponse(
     }
   }
 
+  let thinkingStatusNeedsTextClear = false;
+
+  async function setThreadStatus(status: string): Promise<void> {
+    try {
+      await trySetAssistantThreadStatus({
+        client: slackClient,
+        channelId,
+        threadTs,
+        status,
+      });
+    } catch (error: any) {
+      logger.warn("assistant.threads.setStatus failed in stream pipeline", {
+        channelId,
+        error: error?.message || String(error),
+      });
+    }
+  }
+
+  async function setThinkingStatus(): Promise<void> {
+    if (thinkingStatusNeedsTextClear) return;
+    await setThreadStatus("Thinking…");
+    thinkingStatusNeedsTextClear = true;
+  }
+
+  async function clearStatusOnFirstTextDelta(): Promise<void> {
+    if (!thinkingStatusNeedsTextClear) return;
+    await setThreadStatus("");
+    thinkingStatusNeedsTextClear = false;
+  }
+
   async function buildRelaunchCallOptions(
     result: Awaited<ReturnType<typeof agent.stream>>,
   ): Promise<Record<string, any>> {
@@ -1054,17 +1084,10 @@ export async function generateResponse(
   }
 
   try {
-    // Signal extended thinking phase to the user via Slack thread status
-    await trySetAssistantThreadStatus({
-      client: slackClient,
-      channelId,
-      threadTs,
-      status: "Thinking deeply...",
-    });
-
     let currentStreamCallOptions = streamCallOptions;
     while (true) {
       supersededDuringStream = false;
+      await setThinkingStatus();
       const result = await agent.stream(currentStreamCallOptions as any);
       latestResult = result;
       stepsPromises.push(result.steps);
@@ -1073,12 +1096,19 @@ export async function generateResponse(
         resetTimer();
 
         switch (chunk.type) {
+        case "start-step": {
+          await setThinkingStatus();
+          break;
+        }
+
         case "text-delta": {
+          await clearStatusOnFirstTextDelta();
           await appendTextDelta(chunk.text);
           break;
         }
 
         case "tool-call": {
+          thinkingStatusNeedsTextClear = false;
           // Flush any pending table buffer before tool cards
           if ((tableBuffer.length > 0 || lineCarry) && !streamingFailed) {
             const preToolFlush = flushRemainingTableBuffer();
@@ -1822,6 +1852,8 @@ export async function generateResponse(
 
     throw error;
   } finally {
+    await setThreadStatus("");
+    thinkingStatusNeedsTextClear = false;
     cleanupScratchpad(invocationId);
   }
 }

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -1029,8 +1029,6 @@ export async function generateResponse(
     }
   }
 
-  let thinkingStatusNeedsTextClear = false;
-
   async function setThreadStatus(status: string): Promise<void> {
     try {
       await trySetAssistantThreadStatus({
@@ -1047,17 +1045,36 @@ export async function generateResponse(
     }
   }
 
-  async function setThinkingStatus(): Promise<void> {
-    if (thinkingStatusNeedsTextClear) return;
-    await setThreadStatus("Thinking…");
-    thinkingStatusNeedsTextClear = true;
-  }
+  type SubStatusState = "thinking" | "streaming_text" | "tool_suspended";
+  const subStatusController = (() => {
+    let state: SubStatusState | null = null;
 
-  async function clearStatusOnFirstTextDelta(): Promise<void> {
-    if (!thinkingStatusNeedsTextClear) return;
-    await setThreadStatus("");
-    thinkingStatusNeedsTextClear = false;
-  }
+    return {
+      async enterThinking(): Promise<void> {
+        if (state === "thinking" || state === "tool_suspended") return;
+        await setThreadStatus("Thinking…");
+        state = "thinking";
+      },
+      async enterStreaming(): Promise<void> {
+        if (state === "streaming_text" || state === "tool_suspended") return;
+        await setThreadStatus("");
+        state = "streaming_text";
+      },
+      suspendForTool(): void {
+        state = "tool_suspended";
+      },
+      async resumeAfterTool(): Promise<void> {
+        if (state === "tool_suspended") {
+          state = null;
+        }
+        await this.enterThinking();
+      },
+      async clearStatus(): Promise<void> {
+        await setThreadStatus("");
+        state = null;
+      },
+    };
+  })();
 
   async function buildRelaunchCallOptions(
     result: Awaited<ReturnType<typeof agent.stream>>,
@@ -1087,7 +1104,7 @@ export async function generateResponse(
     let currentStreamCallOptions = streamCallOptions;
     while (true) {
       supersededDuringStream = false;
-      await setThinkingStatus();
+      await subStatusController.enterThinking();
       const result = await agent.stream(currentStreamCallOptions as any);
       latestResult = result;
       stepsPromises.push(result.steps);
@@ -1097,18 +1114,29 @@ export async function generateResponse(
 
         switch (chunk.type) {
         case "start-step": {
-          await setThinkingStatus();
+          await subStatusController.enterThinking();
+          break;
+        }
+
+        case "reasoning-start":
+        case "reasoning-delta": {
+          await subStatusController.enterThinking();
+          break;
+        }
+
+        case "tool-input-start": {
+          subStatusController.suspendForTool();
           break;
         }
 
         case "text-delta": {
-          await clearStatusOnFirstTextDelta();
+          await subStatusController.enterStreaming();
           await appendTextDelta(chunk.text);
           break;
         }
 
         case "tool-call": {
-          thinkingStatusNeedsTextClear = false;
+          subStatusController.suspendForTool();
           // Flush any pending table buffer before tool cards
           if ((tableBuffer.length > 0 || lineCarry) && !streamingFailed) {
             const preToolFlush = flushRemainingTableBuffer();
@@ -1226,6 +1254,10 @@ export async function generateResponse(
           if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
 
+          if (pendingToolInputs.size === 0) {
+            await subStatusController.resumeAfterTool();
+          }
+
           if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
             if (!await splitToNewStream() && streamingFailed) {
               fallbackStartIdx = accumulatedText.length;
@@ -1270,6 +1302,10 @@ export async function generateResponse(
           if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
           if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
+
+          if (pendingToolInputs.size === 0) {
+            await subStatusController.resumeAfterTool();
+          }
 
           if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
             if (!await splitToNewStream() && streamingFailed) {
@@ -1852,8 +1888,7 @@ export async function generateResponse(
 
     throw error;
   } finally {
-    await setThreadStatus("");
-    thinkingStatusNeedsTextClear = false;
+    await subStatusController.clearStatus();
     cleanupScratchpad(invocationId);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Implements the LLM-generation sub-status as an event-driven state machine: THINKING sets `"Thinking…"`; STREAMING_TEXT clears it.
- Toggles back to THINKING when reasoning resumes after visible text, and clears again on the next visible `text-delta`.
- Suspends the sub-status controller during tool input/execution so existing tool status/task handling is not overwritten, then re-enters THINKING after the tool lifecycle completes.
- Keeps the terminal cleanup centralized: Single clear-on-finish in `finally` block — no re-pingers, no ticker. Lesson from reverted PR #1003.

## Verification
- `pnpm --filter aura-api test -- src/pipeline/respond.test.ts`
- `pnpm --filter aura-api typecheck`
- `npx tsc --noEmit` from `apps/api`
- `pnpm typecheck`
- `git diff --check`
- Pre-push hook typecheck passed on push

## Manual verification to perform
Trigger a stream in a DM, observe `"Thinking…"` at stream start and during non-text generation gaps, observe it clear while text is visibly streaming, observe tool labels/task handling are not overwritten during tool calls, observe it cleared after final response, and observe it cleared if cancelling mid-stream.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8eafbcf5-2ce1-4d37-80c7-41ba8f5df68f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8eafbcf5-2ce1-4d37-80c7-41ba8f5df68f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

