### PR TITLE
Revert "Sub-status 'Thinking…' indicator during generation (#1010)"

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -59,7 +59,6 @@ vi.mock("./prepare-step.js", () => ({
 import { generateResponse } from "./respond.js";
 import { logError } from "../lib/error-logger.js";
 import { logger } from "../lib/logger.js";
-import { trySetAssistantThreadStatus } from "../lib/slack-status.js";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -147,12 +146,6 @@ function baseOptions(slackClient: any) {
   };
 }
 
-function statusCallValues(): string[] {
-  return vi.mocked(trySetAssistantThreadStatus).mock.calls.map(
-    ([params]) => (params as any).status,
-  );
-}
-
 describe("generateResponse Slack stream handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -160,150 +153,6 @@ describe("generateResponse Slack stream handling", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-  });
-
-  it("sets Thinking status on stream start before text is emitted", async () => {
-    const events: string[] = [];
-    vi.mocked(trySetAssistantThreadStatus).mockImplementation(async ({ status }: any) => {
-      events.push(`status:${status}`);
-    });
-    const stream = {
-      append: vi.fn().mockImplementation(async () => {
-        events.push("append");
-      }),
-      stop: vi.fn().mockResolvedValue(undefined),
-    };
-    const slackClient = createSlackClient([stream]);
-
-    mockAgentStream((async function* () {
-      yield { type: "text-delta", text: "Hello." };
-    })());
-
-    await generateResponse(baseOptions(slackClient));
-
-    expect(events[0]).toBe("status:Thinking…");
-    expect(events.indexOf("status:Thinking…")).toBeLessThan(events.indexOf("append"));
-    expect(statusCallValues()).toEqual(["Thinking…", "", ""]);
-  });
-
-  it("clears status exactly once on successful completion without visible text", async () => {
-    const stream = {
-      append: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-    };
-    const slackClient = createSlackClient([stream]);
-
-    mockAgentStream((async function* () {
-      yield { type: "start-step" };
-    })());
-
-    await generateResponse(baseOptions(slackClient));
-
-    expect(statusCallValues()).toEqual(["Thinking…", ""]);
-  });
-
-  it("clears status exactly once after a thrown stream error", async () => {
-    const stream = {
-      append: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-    };
-    const slackClient = createSlackClient([stream]);
-
-    mockAgentStream((async function* () {
-      throw new Error("stream exploded");
-    })());
-
-    await expect(generateResponse(baseOptions(slackClient))).rejects.toThrow("stream exploded");
-
-    expect(statusCallValues().filter((status) => status === "")).toHaveLength(1);
-  });
-
-  it("clears status when the first text delta arrives", async () => {
-    const events: string[] = [];
-    vi.mocked(trySetAssistantThreadStatus).mockImplementation(async ({ status }: any) => {
-      events.push(`status:${status}`);
-    });
-    const stream = {
-      append: vi.fn().mockImplementation(async () => {
-        events.push("append");
-      }),
-      stop: vi.fn().mockResolvedValue(undefined),
-    };
-    const slackClient = createSlackClient([stream]);
-
-    mockAgentStream((async function* () {
-      yield { type: "text-delta", text: "Visible text." };
-    })());
-
-    await generateResponse(baseOptions(slackClient));
-
-    expect(events.slice(0, 3)).toEqual(["status:Thinking…", "status:", "append"]);
-  });
-
-  it("toggles status back to Thinking during reasoning gaps between text deltas", async () => {
-    const stream = {
-      append: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-    };
-    const slackClient = createSlackClient([stream]);
-
-    mockAgentStream((async function* () {
-      yield { type: "text-delta", text: "First visible text." };
-      yield { type: "reasoning-delta", text: "private reasoning" };
-      yield { type: "text-delta", text: " More visible text." };
-    })());
-
-    await generateResponse(baseOptions(slackClient));
-
-    expect(statusCallValues()).toEqual(["Thinking…", "", "Thinking…", "", ""]);
-  });
-
-  it("suspends the sub-status controller during tool input and tool execution", async () => {
-    const events: string[] = [];
-    vi.mocked(trySetAssistantThreadStatus).mockImplementation(async ({ status }: any) => {
-      events.push(`status:${status}`);
-    });
-    const stream = {
-      append: vi.fn().mockImplementation(async (payload: any) => {
-        const firstChunk = payload.chunks?.[0];
-        events.push(firstChunk?.type === "task_update"
-          ? `append:task:${firstChunk.status}`
-          : "append:text");
-      }),
-      stop: vi.fn().mockResolvedValue(undefined),
-    };
-    const slackClient = createSlackClient([stream]);
-
-    mockAgentStream((async function* () {
-      yield { type: "text-delta", text: "Before tool." };
-      events.push("event:tool-input-start");
-      yield { type: "tool-input-start", toolCallId: "call-1", toolName: "run_command" };
-      events.push("event:tool-call");
-      yield {
-        type: "tool-call",
-        toolCallId: "call-1",
-        toolName: "run_command",
-        input: { command: "true" },
-      };
-      events.push("event:tool-result");
-      yield {
-        type: "tool-result",
-        toolCallId: "call-1",
-        toolName: "run_command",
-        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
-      };
-      yield { type: "text-delta", text: " After tool." };
-    })());
-
-    await generateResponse(baseOptions(slackClient));
-
-    expect(statusCallValues()).toEqual(["Thinking…", "", "Thinking…", "", ""]);
-
-    const toolInputStartIdx = events.indexOf("event:tool-input-start");
-    const toolResultAppendIdx = events.indexOf("append:task:complete");
-    const statusDuringTool = events.slice(toolInputStartIdx + 1, toolResultAppendIdx)
-      .filter((event) => event.startsWith("status:"));
-    expect(statusDuringTool).toEqual([]);
   });
 
   it("splits to a new stream with a tombstone when a tool call exceeds 75 seconds", async () => {
@@ -956,6 +805,5 @@ describe("generateResponse Slack stream handling", () => {
         text: expect.stringContaining("[stream aborted: inactivity]"),
       })],
     });
-    expect(statusCallValues().filter((status) => status === "")).toHaveLength(1);
   });
 });

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -1041,53 +1041,6 @@ export async function generateResponse(
     }
   }
 
-  async function setThreadStatus(status: string): Promise<void> {
-    try {
-      await trySetAssistantThreadStatus({
-        client: slackClient,
-        channelId,
-        threadTs,
-        status,
-      });
-    } catch (error: any) {
-      logger.warn("assistant.threads.setStatus failed in stream pipeline", {
-        channelId,
-        error: error?.message || String(error),
-      });
-    }
-  }
-
-  type SubStatusState = "thinking" | "streaming_text" | "tool_suspended";
-  const subStatusController = (() => {
-    let state: SubStatusState | null = null;
-
-    return {
-      async enterThinking(): Promise<void> {
-        if (state === "thinking" || state === "tool_suspended") return;
-        await setThreadStatus("Thinking…");
-        state = "thinking";
-      },
-      async enterStreaming(): Promise<void> {
-        if (state === "streaming_text" || state === "tool_suspended") return;
-        await setThreadStatus("");
-        state = "streaming_text";
-      },
-      suspendForTool(): void {
-        state = "tool_suspended";
-      },
-      async resumeAfterTool(): Promise<void> {
-        if (state === "tool_suspended") {
-          state = null;
-        }
-        await this.enterThinking();
-      },
-      async clearStatus(): Promise<void> {
-        await setThreadStatus("");
-        state = null;
-      },
-    };
-  })();
-
   async function buildRelaunchCallOptions(
     result: Awaited<ReturnType<typeof agent.stream>>,
   ): Promise<Record<string, any>> {
@@ -1113,10 +1066,17 @@ export async function generateResponse(
   }
 
   try {
+    // Signal extended thinking phase to the user via Slack thread status
+    await trySetAssistantThreadStatus({
+      client: slackClient,
+      channelId,
+      threadTs,
+      status: "Thinking deeply...",
+    });
+
     let currentStreamCallOptions = streamCallOptions;
     while (true) {
       supersededDuringStream = false;
-      await subStatusController.enterThinking();
       const result = await agent.stream(currentStreamCallOptions as any);
       latestResult = result;
       stepsPromises.push(result.steps);
@@ -1125,24 +1085,7 @@ export async function generateResponse(
         resetTimer();
 
         switch (chunk.type) {
-        case "start-step": {
-          await subStatusController.enterThinking();
-          break;
-        }
-
-        case "reasoning-start":
-        case "reasoning-delta": {
-          await subStatusController.enterThinking();
-          break;
-        }
-
-        case "tool-input-start": {
-          subStatusController.suspendForTool();
-          break;
-        }
-
         case "text-delta": {
-          await subStatusController.enterStreaming();
           await appendTextDelta(chunk.text);
           break;
         }
@@ -1178,7 +1121,6 @@ export async function generateResponse(
         }
 
         case "tool-call": {
-          subStatusController.suspendForTool();
           // Flush any pending table buffer before tool cards
           if ((tableBuffer.length > 0 || lineCarry) && !streamingFailed) {
             const preToolFlush = flushRemainingTableBuffer();
@@ -1298,10 +1240,6 @@ export async function generateResponse(
           if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
 
-          if (pendingToolInputs.size === 0) {
-            await subStatusController.resumeAfterTool();
-          }
-
           if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
             if (!await splitToNewStream() && streamingFailed) {
               fallbackStartIdx = accumulatedText.length;
@@ -1347,10 +1285,6 @@ export async function generateResponse(
           if (pendingToolInputs.size === 0 && streamKeepAlive) { clearInterval(streamKeepAlive); streamKeepAlive = null; }
           if (pendingToolInputs.size === 0) clearLongToolSplitTimer();
           resetTimer();
-
-          if (pendingToolInputs.size === 0) {
-            await subStatusController.resumeAfterTool();
-          }
 
           if (pendingToolInputs.size === 0 && currentStreamLength > STREAM_THRESHOLD_NEWLINE && !streamingFailed) {
             if (!await splitToNewStream() && streamingFailed) {
@@ -1949,7 +1883,6 @@ export async function generateResponse(
 
     throw error;
   } finally {
-    await subStatusController.clearStatus();
     cleanupScratchpad(invocationId);
   }
 }


### PR DESCRIPTION
Reverts #1010.

The sub-status toggling caused a regression: a new empty placeholder message with shimmering 'Thinking…' appears below the actual responding Aura, after splitToNewStream. The state machine itself is correct, but the surface (sub-status on a split-stream placeholder) makes it look like there's a ghost Aura with no content.

Of the streaming-indicator work, only the optimistic tool cards from #1008 added real UX value without lifecycle risk. Keeping that, reverting this.

Follow-up: investigate suppressing the split-to-new-stream placeholder rendering until first text-delta lands (separate issue).

Typecheck passes. Clean revert of f1674b4.