### PR TITLE
docs(slack): response gating tiers + gated_channels / always_process_channels

### DIFF
--- a/content/docs/tools/slack.mdx
+++ b/content/docs/tools/slack.mdx
@@ -11,6 +11,43 @@ Aura must **join a channel** before she can read or post. `list_channels` only s
 
 ---
 
+## When Aura responds in channels
+
+Aura's response decision happens in `apps/api/src/pipeline/index.ts` before any LLM call. The order is:
+
+1. **DM** -- always responds.
+2. **Explicit `@Aura` mention** -- always responds.
+3. **Addressed by name** -- always responds.
+4. **LLM gate (thread participant, recent channel activity, or cold observation)** -- a fast model decides whether a response would add value. Fail-closed when in doubt.
+
+Two workspace settings (in the `settings` table, editable via SQL with no redeploy) override these tiers:
+
+### `gated_channels`
+
+A JSON array of channel IDs. Channels in this list **require an explicit `@Aura` mention** to trigger any pipeline processing. The LLM gate is bypassed -- nothing runs without a mention. The raw user message is still stored for memory and search, but no conversation fetch, lock, or LLM call happens.
+
+This is a hard, code-level gate (shipped in PR #921) -- it cannot be overridden by prompt instructions or the LLM gate.
+
+Typical use: noisy channels like `#bugs` where Aura should observe but never speak unless directly asked.
+
+```sql
+INSERT INTO settings (workspace_id, key, value, updated_at)
+VALUES ('<workspace_id>', 'gated_channels', '["C019605SSNN"]', now())
+ON CONFLICT (workspace_id, key)
+DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+```
+
+### `always_process_channels`
+
+A JSON array of channel IDs that **bypass the LLM gate** (Tier 4). Aura still runs the pipeline and the LLM decides whether to send a reply, but the cheap fast-model gate that normally suppresses cold-observation responses is skipped.
+
+Typical use: small high-signal channels where every message is worth full processing.
+
+The two settings are not mutually exclusive but pull in opposite directions -- `gated_channels` closes the gate, `always_process_channels` opens it. If a channel is in both, `gated_channels` wins (the mention check runs first).
+
+---
+
+
 ## Channels
 
 ### `list_channels`


### PR DESCRIPTION
## What

Adds a new section to `content/docs/tools/slack.mdx` documenting:

1. **When Aura responds in channels** -- the four-tier decision (DM / mention / addressed-by-name / LLM gate).
2. **`gated_channels` setting** -- the hard, code-level mention-required gate shipped in PR #921 (closes #918). Used for noisy channels like `#bugs`. Includes the SQL snippet to enable it for a workspace.
3. **`always_process_channels` setting** -- the long-standing override that bypasses the cold-observation LLM gate (Tier 4) for high-signal channels.

## Why

Both workspace settings live in the `settings` table and meaningfully change Aura's behavior in a workspace, but neither was mentioned anywhere in `content/docs/`. Verified by:

- `rg 'gated_channels|always_process_channels' content/` -> 0 matches before this change.
- Behavior cross-checked against `apps/api/src/pipeline/index.ts:155-175` (gated gate) and `apps/api/src/pipeline/context.ts:165-235` (LLM tiers + always-process override).

## Notes

One file, +37/-0. No code changes. Daily docs-maintenance run.