### PR TITLE
heartbeat: also escalate already-parked status=failed recurring jobs

### DIFF
--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -317,6 +317,7 @@ describe("heartbeat stale running recovery", () => {
       [], // stale plan notes
       [], // stale running jobs below max retries
       [], // stale exhausted jobs
+      [], // stuck failed recurring jobs (none)
       recentFailures, // recent job executions
       [], // no existing marker
       [], // marker insert
@@ -374,6 +375,7 @@ describe("heartbeat stale running recovery", () => {
       [],
       [],
       [],
+      [], // stuck failed recurring jobs (none)
       recentFailures,
       [{ id: "marker-1", updatedAt: new Date("2026-05-20T08:54:30.000Z") }],
       [], // no successful executions since the marker
@@ -435,6 +437,7 @@ describe("heartbeat stale running recovery", () => {
       [],
       [],
       [],
+      [], // stuck failed recurring jobs (none)
       recentExecutions,
       [], // marker reset delete
     );
@@ -448,4 +451,57 @@ describe("heartbeat stale running recovery", () => {
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
     expect(insertValues()).toEqual([]);
   });
+
+  it("escalates a recurring job already parked in status=failed (stuck since prior sweep)", async () => {
+    const stuckJob = baseJob({
+      status: "failed",
+      cronSchedule: "0 * * * *",
+      name: "sync-meta-comments-daily",
+      lastResult: "Execution interrupted: recovered by stale detection",
+    });
+    const recentFailures = [0, 1, 2, 3, 4].map((index) => ({
+      id: `exec-${index}`,
+      status: "failed",
+      startedAt: new Date(`2026-05-09T0${4 - index}:00:00.000Z`),
+      error: "Execution interrupted: recovered by stale detection",
+    }));
+
+    queueDbResults(
+      [], // pending jobs (none — stuck job is in status=failed)
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // stale running jobs below max retries
+      [], // stale exhausted jobs
+      [stuckJob], // stuck failed recurring jobs ← new query
+      recentFailures, // recent job executions
+      [], // no existing marker
+      [], // marker insert
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
+    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        requestedBy: "U_REQUESTER",
+        text: expect.stringContaining(
+          "Your recurring job `sync-meta-comments-daily` has failed 5 consecutive runs.",
+        ),
+      }),
+    );
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topic: "job-failure-streak:job-1",
+          category: "job_failure_streak_marker",
+        }),
+      ]),
+    );
+  });
+
 });

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -481,8 +481,30 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       });
     }
 
+    // Also escalate recurring jobs that are *already* in status=failed
+    // (parked from prior sweeps). Without this, jobs that died days ago
+    // never trigger a DM because they no longer enter the pending->due path
+    // and therefore don't land in `recurringJobsWithFreshFailures`.
+    // The marker-note dedupe inside maybeEscalateConsecutiveRecurringFailures
+    // ensures we only DM once per streak.
+    const stuckFailedRecurringJobs = await db
+      .select()
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.status, "failed"),
+          eq(jobs.enabled, 1),
+          sql`${jobs.cronSchedule} IS NOT NULL`,
+        ),
+      );
+
+    const escalationCandidates = new Map<string, typeof jobs.$inferSelect>(
+      recurringJobsWithFreshFailures,
+    );
+    for (const job of stuckFailedRecurringJobs) escalationCandidates.set(job.id, job);
+
     consecutiveFailureEscalations = await maybeEscalateConsecutiveRecurringFailures(
-      [...recurringJobsWithFreshFailures.values()],
+      [...escalationCandidates.values()],
     );
 
     // ── Done ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #978.

### Problem
PR #978's `maybeEscalateConsecutiveRecurringFailures` only considers `recurringJobsWithFreshFailures` -- jobs that errored in the current sweep. Once a job is parked in `status=failed` (retries exhausted, stale-recovery flipped it), it never enters that set again and the heartbeat never escalates it.

This is exactly the shape of the May 9 incident with `sync-meta-comments-daily`: 4 consecutive failures (`Execution interrupted: recovered by stale detection`), status flipped to `failed`, and no DM fired. Job has been dead for 13 days with zero alarm.

### Fix
In `heartbeat.ts`, after the existing sweep, query:
```
SELECT * FROM jobs
WHERE status = 'failed'
  AND enabled = true
  AND cron_schedule IS NOT NULL
```
and union those into the escalation candidate map. The marker-note dedupe inside `maybeEscalateConsecutiveRecurringFailures` (`job-failure-streak:<jobId>`) keeps it idempotent across sweeps.

### Tests
- Added `escalates a recurring job already parked in status=failed` -- exact shape of the May 9 incident (job in `status=failed`, 5 prior failed executions, no marker).
- Adjusted 3 existing escalation tests for the new SELECT in query order.
- All 8 tests pass. `pnpm typecheck` clean.

### Note
This is interim. Once the supervisor-pattern issue lands, both `recurringJobsWithFreshFailures` and this stuck-failed sweep get deleted -- the supervisor processes outcomes one at a time and never needs to scan.