### PR TITLE
feat(jobs): add job_outcomes table for supervisor pattern (#1015 -- PR 1/3)

### DIFF
--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -179,7 +179,7 @@ describe("executeJob outcome persistence", () => {
     vi.useRealTimers();
   });
 
-  it("writes a completed outcome for script-only success", async () => {
+  it("writes a pending-review succeeded outcome for script-only success", async () => {
     sandboxMock.commandRun.mockResolvedValue({
       exitCode: 0,
       stdout: "{\"ok\":true,\"summary\":\"done\"}",
@@ -198,8 +198,8 @@ describe("executeJob outcome persistence", () => {
         expect.objectContaining({
           workspaceId: "default",
           jobId: "job-1",
-          executionId: "exec-1",
-          status: "completed",
+          jobExecutionId: "exec-1",
+          outcomeStatus: "succeeded",
           output: expect.objectContaining({
             type: "script",
             script: expect.objectContaining({
@@ -208,13 +208,15 @@ describe("executeJob outcome persistence", () => {
               exit_code: 0,
             }),
           }),
-          toolTrace: [],
+          lastNSteps: [],
+          supervisorStatus: "pending_review",
+          supervisorAttempts: 0,
         }),
       ]),
     );
   });
 
-  it("writes a script_failed outcome when retries are exhausted", async () => {
+  it("writes a pending-review errored outcome when retries are exhausted", async () => {
     sandboxMock.commandRun.mockResolvedValue({
       exitCode: 2,
       stdout: "partial output",
@@ -235,20 +237,19 @@ describe("executeJob outcome persistence", () => {
         expect.objectContaining({
           workspaceId: "default",
           jobId: "job-1",
-          executionId: "exec-1",
-          status: "script_failed",
+          jobExecutionId: "exec-1",
+          outcomeStatus: "errored",
           output: expect.objectContaining({
             script: expect.objectContaining({
               stdout: "partial output",
               stderr: "boom",
               exit_code: 2,
             }),
+            retry_exhausted: true,
           }),
-          error: expect.objectContaining({
-            message: expect.stringContaining("Script exited with code 2"),
-            retryExhausted: true,
-          }),
-          toolTrace: [],
+          error: expect.stringContaining("Script exited with code 2"),
+          lastNSteps: [],
+          supervisorStatus: "pending_review",
         }),
       ]),
     );
@@ -272,13 +273,14 @@ describe("executeJob outcome persistence", () => {
         expect.objectContaining({
           workspaceId: "default",
           jobId: "job-1",
-          executionId: "exec-1",
-          status: "errored",
-          error: expect.objectContaining({
-            message: "model unavailable",
-            retryExhausted: false,
+          jobExecutionId: "exec-1",
+          outcomeStatus: "errored",
+          output: expect.objectContaining({
+            retry_exhausted: false,
           }),
-          toolTrace: [],
+          error: "model unavailable",
+          lastNSteps: [],
+          supervisorStatus: "pending_review",
         }),
       ]),
     );

--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -1,6 +1,290 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { detectScriptOutputError } from "./script-output.js";
 
+const dbMock = vi.hoisted(() => {
+  type Operation = {
+    kind: "select" | "update" | "delete" | "insert";
+    setArg?: Record<string, unknown>;
+    valuesArg?: Record<string, unknown>;
+  };
+
+  const state = {
+    results: [] as unknown[][],
+    operations: [] as Operation[],
+    select: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    insert: vi.fn(),
+  };
+
+  function nextResult() {
+    return state.results.shift() ?? [];
+  }
+
+  function createQuery(operation: Operation) {
+    const query: any = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      set: vi.fn((setArg: Record<string, unknown>) => {
+        operation.setArg = setArg;
+        return query;
+      }),
+      values: vi.fn((valuesArg: Record<string, unknown>) => {
+        operation.valuesArg = valuesArg;
+        return query;
+      }),
+      returning: vi.fn(() => {
+        state.operations.push(operation);
+        return Promise.resolve(nextResult());
+      }),
+      then: (onFulfilled: any, onRejected: any) => {
+        state.operations.push(operation);
+        return Promise.resolve(nextResult()).then(onFulfilled, onRejected);
+      },
+    };
+
+    return query;
+  }
+
+  state.select.mockImplementation(() => createQuery({ kind: "select" }));
+  state.update.mockImplementation(() => createQuery({ kind: "update" }));
+  state.delete.mockImplementation(() => createQuery({ kind: "delete" }));
+  state.insert.mockImplementation(() => createQuery({ kind: "insert" }));
+
+  return state;
+});
+
+const sandboxMock = vi.hoisted(() => ({
+  commandRun: vi.fn(),
+  getOrCreateSandbox: vi.fn(),
+  getSandboxEnvs: vi.fn(),
+}));
+
+const createHeadlessAgentMock = vi.hoisted(() => vi.fn());
+const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: dbMock.select,
+    update: dbMock.update,
+    delete: dbMock.delete,
+    insert: dbMock.insert,
+  },
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/sandbox.js", () => ({
+  getOrCreateSandbox: sandboxMock.getOrCreateSandbox,
+  getSandboxEnvs: sandboxMock.getSandboxEnvs,
+  truncateOutput: (value: string, maxChars: number) => value.slice(0, maxChars),
+}));
+
+vi.mock("../personality/system-prompt.js", () => ({
+  buildStablePrefix: vi.fn(async () => "system prompt"),
+}));
+
+vi.mock("../lib/temporal.js", () => ({
+  getCurrentTimeContext: vi.fn(() => "current time"),
+}));
+
+vi.mock("../lib/agents.js", () => ({
+  createHeadlessAgent: createHeadlessAgentMock,
+}));
+
+vi.mock("./persist-conversation.js", () => ({
+  createConversationTrace: vi.fn(),
+  persistConversationInputs: vi.fn(),
+  persistConversationSteps: vi.fn(),
+  persistConversationError: vi.fn(),
+  updateConversationTraceUsage: vi.fn(),
+  buildConversationSteps: vi.fn(),
+}));
+
+vi.mock("../tools/scratchpad.js", () => ({
+  getScratchpadContents: vi.fn(() => null),
+  cleanupScratchpad: vi.fn(),
+}));
+
+vi.mock("./job-notifications.js", () => ({
+  sendJobFailureDm: sendJobFailureDmMock,
+}));
+
+function queueDbResults(...results: unknown[][]) {
+  dbMock.results = [...results];
+}
+
+function insertValues() {
+  return dbMock.operations
+    .filter((operation) => operation.kind === "insert")
+    .map((operation) => operation.valuesArg ?? {});
+}
+
+function baseJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "job-1",
+    workspaceId: "default",
+    name: "test-job",
+    description: "do the thing",
+    playbook: null,
+    script: "node script.js",
+    cronSchedule: null,
+    frequencyConfig: null,
+    channelId: null,
+    threadTs: null,
+    executeAt: new Date("2026-05-20T09:00:00.000Z"),
+    requestedBy: "U_REQUESTER",
+    priority: "normal",
+    status: "pending",
+    timezone: "UTC",
+    result: null,
+    retries: 0,
+    lastExecutedAt: null,
+    lastResult: null,
+    executionCount: 0,
+    todayExecutions: 0,
+    lastExecutionDate: null,
+    enabled: 1,
+    requiredCredentialIds: [],
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-20T08:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("executeJob outcome persistence", () => {
+  beforeEach(() => {
+    dbMock.results = [];
+    dbMock.operations = [];
+    vi.clearAllMocks();
+    sandboxMock.getSandboxEnvs.mockResolvedValue({});
+    sandboxMock.getOrCreateSandbox.mockResolvedValue({
+      commands: {
+        run: sandboxMock.commandRun,
+      },
+    });
+    sendJobFailureDmMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes a completed outcome for script-only success", async () => {
+    sandboxMock.commandRun.mockResolvedValue({
+      exitCode: 0,
+      stdout: "{\"ok\":true,\"summary\":\"done\"}",
+      stderr: "",
+    });
+    queueDbResults(
+      [{ id: "job-1" }],
+      [{ id: "exec-1" }],
+    );
+
+    const { executeJob } = await import("./execute-job.js");
+    await expect(executeJob(baseJob() as any, "heartbeat")).resolves.toBe(true);
+
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workspaceId: "default",
+          jobId: "job-1",
+          executionId: "exec-1",
+          status: "completed",
+          output: expect.objectContaining({
+            type: "script",
+            script: expect.objectContaining({
+              stdout: "{\"ok\":true,\"summary\":\"done\"}",
+              stderr: "",
+              exit_code: 0,
+            }),
+          }),
+          toolTrace: [],
+        }),
+      ]),
+    );
+  });
+
+  it("writes a script_failed outcome when retries are exhausted", async () => {
+    sandboxMock.commandRun.mockResolvedValue({
+      exitCode: 2,
+      stdout: "partial output",
+      stderr: "boom",
+    });
+    queueDbResults(
+      [{ id: "job-1" }],
+      [{ id: "exec-1" }],
+    );
+
+    const { executeJob } = await import("./execute-job.js");
+    await expect(
+      executeJob(baseJob({ retries: 2 }) as any, "heartbeat"),
+    ).rejects.toThrow("Script exited with code 2");
+
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workspaceId: "default",
+          jobId: "job-1",
+          executionId: "exec-1",
+          status: "script_failed",
+          output: expect.objectContaining({
+            script: expect.objectContaining({
+              stdout: "partial output",
+              stderr: "boom",
+              exit_code: 2,
+            }),
+          }),
+          error: expect.objectContaining({
+            message: expect.stringContaining("Script exited with code 2"),
+            retryExhausted: true,
+          }),
+          toolTrace: [],
+        }),
+      ]),
+    );
+    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
+  });
+
+  it("writes an errored outcome for caught non-script failures", async () => {
+    createHeadlessAgentMock.mockRejectedValue(new Error("model unavailable"));
+    queueDbResults(
+      [{ id: "job-1" }],
+      [{ id: "exec-1" }],
+    );
+
+    const { executeJob } = await import("./execute-job.js");
+    await expect(
+      executeJob(baseJob({ script: null }) as any, "heartbeat"),
+    ).rejects.toThrow("model unavailable");
+
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workspaceId: "default",
+          jobId: "job-1",
+          executionId: "exec-1",
+          status: "errored",
+          error: expect.objectContaining({
+            message: "model unavailable",
+            retryExhausted: false,
+          }),
+          toolTrace: [],
+        }),
+      ]),
+    );
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+  });
+});
 describe("detectScriptOutputError", () => {
   it("returns null for clean stdout with no error envelope", () => {
     const output = '{"status": "ok", "count": 42}\nDone processing.';

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -21,6 +21,7 @@ import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
 import { sendJobFailureDm } from "./job-notifications.js";
+import { extractToolTrace, persistJobOutcome, serializeJobError } from "./job-outcomes.js";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -30,6 +31,23 @@ export const MAX_RETRIES = 3;
 
 /** Retry delay in ms (30 minutes — matches heartbeat cron interval) */
 const RETRY_DELAY_MS = 30 * 60 * 1000;
+
+type ScriptExecutionOutput = {
+  stdout: string;
+  stderr: string;
+  exit_code: number | null;
+  detected_error?: string;
+};
+
+class ScriptJobError extends Error {
+  readonly scriptOutput: ScriptExecutionOutput | null;
+
+  constructor(message: string, scriptOutput: ScriptExecutionOutput | null) {
+    super(message);
+    this.name = "ScriptJobError";
+    this.scriptOutput = scriptOutput;
+  }
+}
 
 // ── Job-specific additive instructions ───────────────────────────────────────
 
@@ -77,40 +95,47 @@ export async function executeJob(
 ): Promise<boolean> {
   const jobId = job.id;
 
-  // Atomically claim the job to prevent duplicate execution.
-  // If another process already claimed it, this updates 0 rows.
-  const claimed = await db
-    .update(jobs)
-    .set({ status: "running", updatedAt: new Date() })
-    .where(and(eq(jobs.id, jobId), eq(jobs.status, "pending"), eq(jobs.enabled, 1)))
-    .returning({ id: jobs.id });
-
-  if (claimed.length === 0) {
-    logger.info("executeJob: job already claimed or disabled, skipping", { jobId, jobName: job.name });
-    return false;
-  }
-
-  // Insert execution trace row
-  const [execution] = await db
-    .insert(jobExecutions)
-    .values({
-      jobId,
-      status: "running",
-      trigger,
-      callbackChannel: job.channelId || null,
-      callbackThreadTs: job.threadTs || null,
-    })
-    .returning({ id: jobExecutions.id });
-
-  const executionId = execution.id;
-
   // Tracks next message order_index; set by persistConversationInputs,
   // used by error handler if generate throws.
   let conversationOrderIndex = 0;
   let conversationId: string | undefined;
+  let executionId: string | null = null;
   const invocationId = crypto.randomUUID();
+  let latestToolTrace: Array<Record<string, unknown>> = [];
+  let scriptExecutionOutput: ScriptExecutionOutput | null = null;
 
   try {
+    // Atomically claim the job to prevent duplicate execution.
+    // If another process already claimed it, this updates 0 rows.
+    const claimed = await db
+      .update(jobs)
+      .set({ status: "running", updatedAt: new Date() })
+      .where(and(eq(jobs.id, jobId), eq(jobs.status, "pending"), eq(jobs.enabled, 1)))
+      .returning({ id: jobs.id });
+
+    if (claimed.length === 0) {
+      logger.info("executeJob: job already claimed or disabled, skipping", { jobId, jobName: job.name });
+      return false;
+    }
+
+    // Insert execution trace row.
+    const [execution] = await db
+      .insert(jobExecutions)
+      .values({
+        workspaceId: job.workspaceId,
+        jobId,
+        status: "running",
+        trigger,
+        callbackChannel: job.channelId || null,
+        callbackThreadTs: job.threadTs || null,
+      })
+      .returning({ id: jobExecutions.id });
+
+    executionId = execution.id;
+    if (!executionId) {
+      throw new Error("Failed to create job execution trace");
+    }
+
     const planTopic = parseContinuationTag(job.description);
     const isContinuation = planTopic !== null;
     const isRecurring = !!job.cronSchedule || !!job.frequencyConfig;
@@ -199,6 +224,14 @@ export async function executeJob(
         const exitCode = scriptResult.exitCode;
         const stdout = scriptResult.stdout || "";
         const stderr = scriptResult.stderr || "";
+        const truncatedStdout = truncateOutput(stdout, 50_000);
+        const truncatedStderr = truncateOutput(stderr, 50_000);
+
+        scriptExecutionOutput = {
+          stdout: truncatedStdout,
+          stderr: truncatedStderr,
+          exit_code: exitCode,
+        };
 
         if (exitCode !== 0) {
           if (job.playbook) {
@@ -210,19 +243,24 @@ export async function executeJob(
             });
           } else {
             const outputTail = (stderr || stdout).slice(-2000);
-            throw new Error(
+            throw new ScriptJobError(
               `Script exited with code ${exitCode}:\n${outputTail}`,
+              scriptExecutionOutput,
             );
           }
         } else {
-          scriptOutput = truncateOutput(stdout, 50_000);
+          scriptOutput = truncatedStdout;
 
           const outputError = detectScriptOutputError(stdout);
+          if (outputError) {
+            scriptExecutionOutput.detected_error = outputError;
+          }
 
           if (outputError && !job.playbook) {
             const outputTail = stdout.slice(-2000);
-            throw new Error(
+            throw new ScriptJobError(
               `Script reported error: ${outputError}\n${outputTail}`,
+              scriptExecutionOutput,
             );
           }
 
@@ -265,6 +303,22 @@ export async function executeJob(
               summary: resultText.slice(0, 500),
             }).where(eq(jobExecutions.id, executionId));
 
+            await persistJobOutcome({
+              workspaceId: job.workspaceId,
+              jobId,
+              executionId,
+              status: "completed",
+              output: {
+                type: "script",
+                script: scriptExecutionOutput ?? {
+                  stdout: scriptOutput ?? "",
+                  stderr: "",
+                  exit_code: 0,
+                },
+              },
+              toolTrace: [],
+            });
+
             logger.info("executeJob: script-only job completed", { jobId, jobName: job.name });
             return true;
           }
@@ -282,7 +336,9 @@ export async function executeJob(
           throw scriptErr;
         }
         if (!job.playbook) {
-          throw scriptErr;
+          throw scriptErr instanceof ScriptJobError
+            ? scriptErr
+            : new ScriptJobError(scriptErr?.message ?? String(scriptErr), scriptExecutionOutput);
         }
         logger.warn("executeJob: script execution error, falling through to LLM", {
           jobId,
@@ -296,7 +352,7 @@ export async function executeJob(
       prompt = `## Pre-computed data (from script)\n\n\`\`\`json\n${scriptOutput}\n\`\`\`\n\n---\n\n${prompt}`;
     }
 
-  const { agent, modelId, getStepModelIds } = await createHeadlessAgent({
+    const { agent, modelId, getStepModelIds } = await createHeadlessAgent({
       slackClient,
       context: {
         userId: job.requestedBy,
@@ -351,6 +407,7 @@ export async function executeJob(
         output: tr.output,
       })),
     }));
+    latestToolTrace = extractToolTrace(steps);
 
     const tokenUsage: DetailedTokenUsage = {
       inputTokens: usage.inputTokens ?? 0,
@@ -432,6 +489,20 @@ export async function executeJob(
       });
     }
 
+    await persistJobOutcome({
+      workspaceId: job.workspaceId,
+      jobId,
+      executionId,
+      status: "completed",
+      output: {
+        type: "llm",
+        finalMessage: text || null,
+        scratchpad: scratchpadContents ?? null,
+        ...(scriptExecutionOutput ? { script: scriptExecutionOutput } : {}),
+      },
+      toolTrace: latestToolTrace,
+    });
+
     return true;
   } catch (error: any) {
     // Persist the error in conversation history regardless of error type
@@ -440,25 +511,49 @@ export async function executeJob(
     }
 
     // Update execution trace with failure (protected so it can't break retry logic)
-    try {
-      await db
-        .update(jobExecutions)
-        .set({
-          status: "failed",
-          finishedAt: new Date(),
-          error: error.message,
-        })
-        .where(eq(jobExecutions.id, executionId));
-    } catch (traceErr: any) {
-      logger.error("executeJob: failed to update execution trace", {
-        jobId,
-        executionId,
-        error: traceErr.message,
-      });
+    if (executionId) {
+      try {
+        await db
+          .update(jobExecutions)
+          .set({
+            status: "failed",
+            finishedAt: new Date(),
+            error: error.message,
+          })
+          .where(eq(jobExecutions.id, executionId));
+      } catch (traceErr: any) {
+        logger.error("executeJob: failed to update execution trace", {
+          jobId,
+          executionId,
+          error: traceErr.message,
+        });
+      }
     }
 
     // Retry logic
     const newRetries = job.retries + 1;
+    const retryExhausted = newRetries >= MAX_RETRIES;
+    const scratchpadContents = getScratchpadContents(invocationId);
+
+    await persistJobOutcome({
+      workspaceId: job.workspaceId,
+      jobId,
+      executionId,
+      status: error instanceof ScriptJobError ? "script_failed" : "errored",
+      output: {
+        ...(scriptExecutionOutput ? { script: scriptExecutionOutput } : {}),
+        ...(scratchpadContents ? { scratchpad: scratchpadContents } : {}),
+      },
+      error: serializeJobError(error, {
+        retries: newRetries,
+        retryExhausted,
+      }),
+      toolTrace: latestToolTrace,
+    });
+
+    if (!executionId) {
+      throw error;
+    }
 
     if (newRetries < MAX_RETRIES) {
       const retryAt = new Date(Date.now() + RETRY_DELAY_MS);

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -21,7 +21,7 @@ import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
 import { sendJobFailureDm } from "./job-notifications.js";
-import { extractToolTrace, persistJobOutcome, serializeJobError } from "./job-outcomes.js";
+import { extractLastNSteps, persistJobOutcome, serializeJobError } from "./job-outcomes.js";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -101,7 +101,7 @@ export async function executeJob(
   let conversationId: string | undefined;
   let executionId: string | null = null;
   const invocationId = crypto.randomUUID();
-  let latestToolTrace: Array<Record<string, unknown>> = [];
+  let lastNSteps: Array<Record<string, unknown>> = [];
   let scriptExecutionOutput: ScriptExecutionOutput | null = null;
 
   try {
@@ -306,8 +306,8 @@ export async function executeJob(
             await persistJobOutcome({
               workspaceId: job.workspaceId,
               jobId,
-              executionId,
-              status: "completed",
+              jobExecutionId: executionId,
+              outcomeStatus: "succeeded",
               output: {
                 type: "script",
                 script: scriptExecutionOutput ?? {
@@ -316,7 +316,7 @@ export async function executeJob(
                   exit_code: 0,
                 },
               },
-              toolTrace: [],
+              lastNSteps: [],
             });
 
             logger.info("executeJob: script-only job completed", { jobId, jobName: job.name });
@@ -407,7 +407,7 @@ export async function executeJob(
         output: tr.output,
       })),
     }));
-    latestToolTrace = extractToolTrace(steps);
+    lastNSteps = extractLastNSteps(steps);
 
     const tokenUsage: DetailedTokenUsage = {
       inputTokens: usage.inputTokens ?? 0,
@@ -492,15 +492,15 @@ export async function executeJob(
     await persistJobOutcome({
       workspaceId: job.workspaceId,
       jobId,
-      executionId,
-      status: "completed",
+      jobExecutionId: executionId,
+      outcomeStatus: "succeeded",
       output: {
         type: "llm",
-        finalMessage: text || null,
+        final_message: text || null,
         scratchpad: scratchpadContents ?? null,
         ...(scriptExecutionOutput ? { script: scriptExecutionOutput } : {}),
       },
-      toolTrace: latestToolTrace,
+      lastNSteps,
     });
 
     return true;
@@ -538,17 +538,16 @@ export async function executeJob(
     await persistJobOutcome({
       workspaceId: job.workspaceId,
       jobId,
-      executionId,
-      status: error instanceof ScriptJobError ? "script_failed" : "errored",
+      jobExecutionId: executionId,
+      outcomeStatus: "errored",
       output: {
         ...(scriptExecutionOutput ? { script: scriptExecutionOutput } : {}),
         ...(scratchpadContents ? { scratchpad: scratchpadContents } : {}),
-      },
-      error: serializeJobError(error, {
         retries: newRetries,
-        retryExhausted,
-      }),
-      toolTrace: latestToolTrace,
+        retry_exhausted: retryExhausted,
+      },
+      error: serializeJobError(error),
+      lastNSteps,
     });
 
     if (!executionId) {

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -285,6 +285,42 @@ describe("heartbeat stale running recovery", () => {
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 
+  it("writes a process_died outcome for stale running recovery", async () => {
+    queueDbResults(
+      [],
+      [],
+      [],
+      [{ id: "job-stale", name: "healthy-retry", workspaceId: "default" }],
+      [],
+      [{ id: "exec-stale", jobId: "job-stale" }],
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workspaceId: "default",
+          jobId: "job-stale",
+          executionId: "exec-stale",
+          status: "process_died",
+          output: expect.objectContaining({
+            type: "stale_recovery",
+            recoveredBy: "heartbeat",
+          }),
+          error: expect.objectContaining({
+            message: "Execution interrupted: recovered by stale detection",
+          }),
+          toolTrace: [],
+        }),
+      ]),
+    );
+  });
+
   it("does not fall back to founder or admin env vars for system-owned jobs", async () => {
     process.env.FOUNDER_USER_ID = "U_FOUNDER";
     process.env.AURA_ADMIN_USER_IDS = "U_ADMIN";

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -285,7 +285,7 @@ describe("heartbeat stale running recovery", () => {
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 
-  it("writes a process_died outcome for stale running recovery", async () => {
+  it("writes a pending-review interrupted outcome for stale running recovery", async () => {
     queueDbResults(
       [],
       [],
@@ -306,16 +306,15 @@ describe("heartbeat stale running recovery", () => {
         expect.objectContaining({
           workspaceId: "default",
           jobId: "job-stale",
-          executionId: "exec-stale",
-          status: "process_died",
+          jobExecutionId: "exec-stale",
+          outcomeStatus: "interrupted",
           output: expect.objectContaining({
             type: "stale_recovery",
-            recoveredBy: "heartbeat",
+            recovered_by: "heartbeat",
           }),
-          error: expect.objectContaining({
-            message: "Execution interrupted: recovered by stale detection",
-          }),
-          toolTrace: [],
+          error: "Execution interrupted: recovered by stale detection",
+          lastNSteps: [],
+          supervisorStatus: "pending_review",
         }),
       ]),
     );

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -8,6 +8,7 @@ import { logger } from "../lib/logger.js";
 import { executeJob, MAX_RETRIES } from "./execute-job.js";
 import { computeNextCronTick } from "./cron-utils.js";
 import { sendJobFailureDm, truncateJobFailureText } from "./job-notifications.js";
+import { persistJobOutcome } from "./job-outcomes.js";
 
 /** Max jobs to process per heartbeat sweep */
 const MAX_JOBS_PER_SWEEP = 10;
@@ -352,7 +353,7 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
           lt(jobs.retries, MAX_RETRIES),
         ),
       )
-      .returning({ id: jobs.id, name: jobs.name });
+      .returning({ id: jobs.id, name: jobs.name, workspaceId: jobs.workspaceId });
 
     const staleExhausted = await db
       .select()
@@ -452,8 +453,10 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       ...staleExhausted.map((j) => j.id),
     ];
 
+    let interruptedExecutions: Array<{ id: string; jobId: string | null }> = [];
+
     if (allStaleIds.length > 0) {
-      await db
+      interruptedExecutions = await db
         .update(jobExecutions)
         .set({
           status: "failed",
@@ -465,7 +468,64 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
             inArray(jobExecutions.jobId, allStaleIds),
             eq(jobExecutions.status, "running"),
           ),
-        );
+        )
+        .returning({ id: jobExecutions.id, jobId: jobExecutions.jobId });
+    }
+
+    if (allStaleIds.length > 0) {
+      const staleJobs = [
+        ...staleRunning,
+        ...staleExhausted.map((job) => ({
+          id: job.id,
+          name: job.name,
+          workspaceId: job.workspaceId,
+        })),
+      ];
+      const jobIdsWithExecutionOutcomes = new Set<string>();
+
+      for (const execution of interruptedExecutions) {
+        if (!execution.jobId) continue;
+
+        const job = staleJobs.find((candidate) => candidate.id === execution.jobId);
+        if (!job) continue;
+
+        jobIdsWithExecutionOutcomes.add(job.id);
+        await persistJobOutcome({
+          workspaceId: job.workspaceId,
+          jobId: job.id,
+          executionId: execution.id,
+          status: "process_died",
+          output: {
+            type: "stale_recovery",
+            recoveredBy: "heartbeat",
+            staleRunningThresholdMs: STALE_RUNNING_THRESHOLD_MS,
+          },
+          error: {
+            message: "Execution interrupted: recovered by stale detection",
+          },
+          toolTrace: [],
+        });
+      }
+
+      for (const job of staleJobs) {
+        if (jobIdsWithExecutionOutcomes.has(job.id)) continue;
+
+        await persistJobOutcome({
+          workspaceId: job.workspaceId,
+          jobId: job.id,
+          executionId: null,
+          status: "process_died",
+          output: {
+            type: "stale_recovery",
+            recoveredBy: "heartbeat",
+            staleRunningThresholdMs: STALE_RUNNING_THRESHOLD_MS,
+          },
+          error: {
+            message: "Execution interrupted: recovered by stale detection",
+          },
+          toolTrace: [],
+        });
+      }
     }
 
     staleRunningRecovered = staleRunning.length;

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -493,17 +493,15 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
         await persistJobOutcome({
           workspaceId: job.workspaceId,
           jobId: job.id,
-          executionId: execution.id,
-          status: "process_died",
+          jobExecutionId: execution.id,
+          outcomeStatus: "interrupted",
           output: {
             type: "stale_recovery",
-            recoveredBy: "heartbeat",
-            staleRunningThresholdMs: STALE_RUNNING_THRESHOLD_MS,
+            recovered_by: "heartbeat",
+            stale_running_threshold_ms: STALE_RUNNING_THRESHOLD_MS,
           },
-          error: {
-            message: "Execution interrupted: recovered by stale detection",
-          },
-          toolTrace: [],
+          error: "Execution interrupted: recovered by stale detection",
+          lastNSteps: [],
         });
       }
 
@@ -513,17 +511,15 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
         await persistJobOutcome({
           workspaceId: job.workspaceId,
           jobId: job.id,
-          executionId: null,
-          status: "process_died",
+          jobExecutionId: null,
+          outcomeStatus: "interrupted",
           output: {
             type: "stale_recovery",
-            recoveredBy: "heartbeat",
-            staleRunningThresholdMs: STALE_RUNNING_THRESHOLD_MS,
+            recovered_by: "heartbeat",
+            stale_running_threshold_ms: STALE_RUNNING_THRESHOLD_MS,
           },
-          error: {
-            message: "Execution interrupted: recovered by stale detection",
-          },
-          toolTrace: [],
+          error: "Execution interrupted: recovered by stale detection",
+          lastNSteps: [],
         });
       }
     }

--- a/apps/api/src/cron/job-outcomes.ts
+++ b/apps/api/src/cron/job-outcomes.ts
@@ -1,0 +1,98 @@
+import { db } from "../db/client.js";
+import { logger } from "../lib/logger.js";
+import { jobOutcomes, type JobOutcomeStatus } from "@aura/db/schema";
+
+const MAX_TOOL_TRACE_ITEMS = 10;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function serializeJobError(error: unknown, extra?: JsonRecord): JsonRecord {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+      ...extra,
+    };
+  }
+
+  return {
+    message: String(error),
+    ...extra,
+  };
+}
+
+export function extractToolTrace(steps: unknown, maxItems = MAX_TOOL_TRACE_ITEMS): JsonRecord[] {
+  if (!Array.isArray(steps)) return [];
+
+  const trace: JsonRecord[] = [];
+
+  steps.forEach((step, stepIndex) => {
+    if (!isRecord(step)) return;
+
+    const toolCalls = Array.isArray(step.toolCalls) ? step.toolCalls : [];
+    const toolResults = Array.isArray(step.toolResults) ? step.toolResults : [];
+
+    toolCalls.forEach((toolCall, callIndex) => {
+      if (!isRecord(toolCall)) return;
+
+      const toolCallId = typeof toolCall.toolCallId === "string" ? toolCall.toolCallId : undefined;
+      const matchingResult = toolResults.find((result, resultIndex) => {
+        if (!isRecord(result)) return false;
+        if (toolCallId && result.toolCallId === toolCallId) return true;
+        return resultIndex === callIndex;
+      });
+
+      trace.push({
+        stepIndex,
+        toolCallId,
+        toolName: toolCall.toolName,
+        input: toolCall.input,
+        output: isRecord(matchingResult) ? matchingResult.output : undefined,
+      });
+    });
+  });
+
+  return trace.slice(-maxItems);
+}
+
+export async function persistJobOutcome({
+  workspaceId,
+  jobId,
+  executionId,
+  status,
+  output,
+  error,
+  toolTrace,
+}: {
+  workspaceId?: string | null;
+  jobId: string;
+  executionId?: string | null;
+  status: JobOutcomeStatus;
+  output?: JsonRecord;
+  error?: JsonRecord;
+  toolTrace?: JsonRecord[];
+}): Promise<void> {
+  try {
+    await db.insert(jobOutcomes).values({
+      workspaceId: workspaceId ?? "default",
+      jobId,
+      executionId: executionId ?? null,
+      status,
+      output,
+      error,
+      toolTrace,
+    });
+  } catch (insertError: any) {
+    logger.error("persistJobOutcome: failed to insert outcome row", {
+      jobId,
+      executionId,
+      status,
+      error: insertError?.message,
+    });
+  }
+}

--- a/apps/api/src/cron/job-outcomes.ts
+++ b/apps/api/src/cron/job-outcomes.ts
@@ -2,7 +2,8 @@ import { db } from "../db/client.js";
 import { logger } from "../lib/logger.js";
 import { jobOutcomes, type JobOutcomeStatus } from "@aura/db/schema";
 
-const MAX_TOOL_TRACE_ITEMS = 10;
+const MAX_LAST_STEPS = 3;
+const MAX_STEP_TEXT_CHARS = 4_000;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -10,88 +11,95 @@ function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function serializeJobError(error: unknown, extra?: JsonRecord): JsonRecord {
+export function serializeJobError(error: unknown): string {
   if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-      ...extra,
-    };
+    return error.message;
   }
 
-  return {
-    message: String(error),
-    ...extra,
-  };
+  return String(error);
 }
 
-export function extractToolTrace(steps: unknown, maxItems = MAX_TOOL_TRACE_ITEMS): JsonRecord[] {
+function truncateText(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  if (value.length <= MAX_STEP_TEXT_CHARS) return value;
+  return `${value.slice(0, MAX_STEP_TEXT_CHARS)}...`;
+}
+
+export function extractLastNSteps(steps: unknown, maxSteps = MAX_LAST_STEPS): JsonRecord[] {
   if (!Array.isArray(steps)) return [];
 
-  const trace: JsonRecord[] = [];
+  const firstStepIndex = steps.length - Math.min(maxSteps, steps.length);
 
-  steps.forEach((step, stepIndex) => {
-    if (!isRecord(step)) return;
+  return steps.slice(-maxSteps).map((step, index) => {
+    if (!isRecord(step)) {
+      return { index: firstStepIndex + index, value: step };
+    }
 
-    const toolCalls = Array.isArray(step.toolCalls) ? step.toolCalls : [];
-    const toolResults = Array.isArray(step.toolResults) ? step.toolResults : [];
-
-    toolCalls.forEach((toolCall, callIndex) => {
-      if (!isRecord(toolCall)) return;
-
-      const toolCallId = typeof toolCall.toolCallId === "string" ? toolCall.toolCallId : undefined;
-      const matchingResult = toolResults.find((result, resultIndex) => {
-        if (!isRecord(result)) return false;
-        if (toolCallId && result.toolCallId === toolCallId) return true;
-        return resultIndex === callIndex;
-      });
-
-      trace.push({
-        stepIndex,
-        toolCallId,
-        toolName: toolCall.toolName,
-        input: toolCall.input,
-        output: isRecord(matchingResult) ? matchingResult.output : undefined,
-      });
-    });
+    return {
+      index: firstStepIndex + index,
+      finishReason: step.finishReason,
+      text: truncateText(step.text),
+      toolCalls: Array.isArray(step.toolCalls)
+        ? step.toolCalls.map((toolCall) =>
+            isRecord(toolCall)
+              ? {
+                  toolCallId: toolCall.toolCallId,
+                  toolName: toolCall.toolName,
+                  input: toolCall.input,
+                }
+              : toolCall,
+          )
+        : undefined,
+      toolResults: Array.isArray(step.toolResults)
+        ? step.toolResults.map((toolResult) =>
+            isRecord(toolResult)
+              ? {
+                  toolCallId: toolResult.toolCallId,
+                  toolName: toolResult.toolName,
+                  output: toolResult.output,
+                }
+              : toolResult,
+          )
+        : undefined,
+    };
   });
-
-  return trace.slice(-maxItems);
 }
 
 export async function persistJobOutcome({
   workspaceId,
   jobId,
-  executionId,
-  status,
+  jobExecutionId,
+  outcomeStatus,
   output,
   error,
-  toolTrace,
+  lastNSteps,
 }: {
   workspaceId?: string | null;
   jobId: string;
-  executionId?: string | null;
-  status: JobOutcomeStatus;
+  jobExecutionId?: string | null;
+  outcomeStatus: JobOutcomeStatus;
   output?: JsonRecord;
-  error?: JsonRecord;
-  toolTrace?: JsonRecord[];
+  error?: string | null;
+  lastNSteps?: JsonRecord[];
 }): Promise<void> {
   try {
     await db.insert(jobOutcomes).values({
       workspaceId: workspaceId ?? "default",
       jobId,
-      executionId: executionId ?? null,
-      status,
+      jobExecutionId: jobExecutionId ?? null,
+      outcomeStatus,
       output,
       error,
-      toolTrace,
+      lastNSteps,
+      supervisorStatus: "pending_review",
+      supervisorAttempts: 0,
+      updatedAt: new Date(),
     });
   } catch (insertError: any) {
     logger.error("persistJobOutcome: failed to insert outcome row", {
       jobId,
-      executionId,
-      status,
+      jobExecutionId,
+      outcomeStatus,
       error: insertError?.message,
     });
   }

--- a/packages/db/drizzle/0066_job_outcomes.sql
+++ b/packages/db/drizzle/0066_job_outcomes.sql
@@ -4,17 +4,23 @@ CREATE TABLE IF NOT EXISTS "job_outcomes" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "workspace_id" text NOT NULL DEFAULT 'default' REFERENCES "workspaces"("id"),
   "job_id" uuid NOT NULL REFERENCES "jobs"("id"),
-  "execution_id" uuid REFERENCES "job_executions"("id"),
-  "status" text NOT NULL,
+  "job_execution_id" uuid REFERENCES "job_executions"("id"),
+  "outcome_status" text NOT NULL,
   "output" jsonb,
-  "error" jsonb,
-  "tool_trace" jsonb,
+  "error" text,
+  "last_n_steps" jsonb,
+  "supervisor_status" text NOT NULL DEFAULT 'pending_review',
+  "supervisor_invocation_id" text,
+  "supervisor_started_at" timestamp with time zone,
   "supervisor_decision" text,
   "supervisor_reasoning" text,
-  "supervisor_dm_ts" text,
+  "supervisor_attempts" integer NOT NULL DEFAULT 0,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
-  "supervised_at" timestamp with time zone,
-  CONSTRAINT "job_outcomes_status_check" CHECK ("status" IN ('completed', 'errored', 'process_died', 'script_failed'))
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "job_outcomes_outcome_status_check" CHECK ("outcome_status" IN ('succeeded', 'errored', 'interrupted')),
+  CONSTRAINT "job_outcomes_supervisor_status_check" CHECK ("supervisor_status" IN ('pending_review', 'in_progress', 'resolved', 'skipped')),
+  CONSTRAINT "job_outcomes_supervisor_decision_check" CHECK ("supervisor_decision" IS NULL OR "supervisor_decision" IN ('retry_as_is', 'retry_with_fix', 'report_success', 'report_failure', 'escalate', 'disable_job'))
 );--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "job_outcomes_job_created_idx" ON "job_outcomes" ("job_id", "created_at");--> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS "job_outcomes_execution_id_idx" ON "job_outcomes" ("execution_id") WHERE execution_id IS NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "job_outcomes_supervisor_status_started_idx" ON "job_outcomes" ("supervisor_status", "supervisor_started_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "job_outcomes_job_execution_id_idx" ON "job_outcomes" ("job_execution_id") WHERE job_execution_id IS NOT NULL;--> statement-breakpoint

--- a/packages/db/drizzle/0066_job_outcomes.sql
+++ b/packages/db/drizzle/0066_job_outcomes.sql
@@ -1,0 +1,20 @@
+-- Raw worker outcomes for the supervisor pattern.
+-- PR 1 stores outcomes only; supervisor_* columns are populated by follow-up PRs.
+CREATE TABLE IF NOT EXISTS "job_outcomes" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workspace_id" text NOT NULL DEFAULT 'default' REFERENCES "workspaces"("id"),
+  "job_id" uuid NOT NULL REFERENCES "jobs"("id"),
+  "execution_id" uuid REFERENCES "job_executions"("id"),
+  "status" text NOT NULL,
+  "output" jsonb,
+  "error" jsonb,
+  "tool_trace" jsonb,
+  "supervisor_decision" text,
+  "supervisor_reasoning" text,
+  "supervisor_dm_ts" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "supervised_at" timestamp with time zone,
+  CONSTRAINT "job_outcomes_status_check" CHECK ("status" IN ('completed', 'errored', 'process_died', 'script_failed'))
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "job_outcomes_job_created_idx" ON "job_outcomes" ("job_id", "created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "job_outcomes_execution_id_idx" ON "job_outcomes" ("execution_id") WHERE execution_id IS NOT NULL;--> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1779283871000,
       "tag": "0065_detached_commands",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1779440280000,
+      "tag": "0066_job_outcomes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -589,6 +589,41 @@ export const jobExecutions = pgTable(
   ],
 );
 
+export type JobOutcomeStatus = "completed" | "errored" | "process_died" | "script_failed";
+
+export const jobOutcomes = pgTable(
+  "job_outcomes",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    workspaceId: workspaceId().references(() => workspaces.id),
+    jobId: uuid("job_id")
+      .notNull()
+      .references(() => jobs.id),
+    executionId: uuid("execution_id").references(() => jobExecutions.id),
+    status: text("status").$type<JobOutcomeStatus>().notNull(),
+    output: jsonb("output").$type<Record<string, unknown>>(),
+    error: jsonb("error").$type<Record<string, unknown>>(),
+    toolTrace: jsonb("tool_trace").$type<Array<Record<string, unknown>>>(),
+    supervisorDecision: text("supervisor_decision"),
+    supervisorReasoning: text("supervisor_reasoning"),
+    supervisorDmTs: text("supervisor_dm_ts"),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+    supervisedAt: timestamptz("supervised_at"),
+  },
+  (table) => [
+    index("job_outcomes_job_created_idx").on(table.jobId, table.createdAt),
+    uniqueIndex("job_outcomes_execution_id_idx")
+      .on(table.executionId)
+      .where(sql`execution_id IS NOT NULL`),
+    check(
+      "job_outcomes_status_check",
+      sql`${table.status} IN ('completed', 'errored', 'process_died', 'script_failed')`,
+    ),
+  ],
+);
+
 // ── Detached Sandbox Commands ────────────────────────────────────────────────
 
 export const detachedCommands = pgTable(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -589,7 +589,15 @@ export const jobExecutions = pgTable(
   ],
 );
 
-export type JobOutcomeStatus = "completed" | "errored" | "process_died" | "script_failed";
+export type JobOutcomeStatus = "succeeded" | "errored" | "interrupted";
+export type JobOutcomeSupervisorStatus = "pending_review" | "in_progress" | "resolved" | "skipped";
+export type JobOutcomeSupervisorDecision =
+  | "retry_as_is"
+  | "retry_with_fix"
+  | "report_success"
+  | "report_failure"
+  | "escalate"
+  | "disable_job";
 
 export const jobOutcomes = pgTable(
   "job_outcomes",
@@ -601,25 +609,43 @@ export const jobOutcomes = pgTable(
     jobId: uuid("job_id")
       .notNull()
       .references(() => jobs.id),
-    executionId: uuid("execution_id").references(() => jobExecutions.id),
-    status: text("status").$type<JobOutcomeStatus>().notNull(),
+    jobExecutionId: uuid("job_execution_id").references(() => jobExecutions.id),
+    outcomeStatus: text("outcome_status").$type<JobOutcomeStatus>().notNull(),
     output: jsonb("output").$type<Record<string, unknown>>(),
-    error: jsonb("error").$type<Record<string, unknown>>(),
-    toolTrace: jsonb("tool_trace").$type<Array<Record<string, unknown>>>(),
-    supervisorDecision: text("supervisor_decision"),
+    error: text("error"),
+    lastNSteps: jsonb("last_n_steps").$type<Array<Record<string, unknown>>>(),
+    supervisorStatus: text("supervisor_status")
+      .$type<JobOutcomeSupervisorStatus>()
+      .notNull()
+      .default("pending_review"),
+    supervisorInvocationId: text("supervisor_invocation_id"),
+    supervisorStartedAt: timestamptz("supervisor_started_at"),
+    supervisorDecision: text("supervisor_decision").$type<JobOutcomeSupervisorDecision>(),
     supervisorReasoning: text("supervisor_reasoning"),
-    supervisorDmTs: text("supervisor_dm_ts"),
+    supervisorAttempts: integer("supervisor_attempts").notNull().default(0),
     createdAt: timestamptz("created_at").notNull().defaultNow(),
-    supervisedAt: timestamptz("supervised_at"),
+    updatedAt: timestamptz("updated_at").notNull().defaultNow(),
   },
   (table) => [
     index("job_outcomes_job_created_idx").on(table.jobId, table.createdAt),
-    uniqueIndex("job_outcomes_execution_id_idx")
-      .on(table.executionId)
-      .where(sql`execution_id IS NOT NULL`),
+    index("job_outcomes_supervisor_status_started_idx").on(
+      table.supervisorStatus,
+      table.supervisorStartedAt,
+    ),
+    uniqueIndex("job_outcomes_job_execution_id_idx")
+      .on(table.jobExecutionId)
+      .where(sql`job_execution_id IS NOT NULL`),
     check(
-      "job_outcomes_status_check",
-      sql`${table.status} IN ('completed', 'errored', 'process_died', 'script_failed')`,
+      "job_outcomes_outcome_status_check",
+      sql`${table.outcomeStatus} IN ('succeeded', 'errored', 'interrupted')`,
+    ),
+    check(
+      "job_outcomes_supervisor_status_check",
+      sql`${table.supervisorStatus} IN ('pending_review', 'in_progress', 'resolved', 'skipped')`,
+    ),
+    check(
+      "job_outcomes_supervisor_decision_check",
+      sql`${table.supervisorDecision} IS NULL OR ${table.supervisorDecision} IN ('retry_as_is', 'retry_with_fix', 'report_success', 'report_failure', 'escalate', 'disable_job')`,
     ),
   ],
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes part of https://github.com/AuraHQ-ai/aura/issues/1015 (PR 1/3 only). Also incorporates the callback/event-driven supervisor correction from https://github.com/AuraHQ-ai/aura/issues/1015#issuecomment-4517263062.

This PR adds outcome persistence for the supervisor pattern while keeping the existing job decision logic, DM routing, retry behavior, escalation sweeps, and stale corpse-collection behavior intact.

## Changes

- Add `job_outcomes` schema + migration `0066_job_outcomes.sql` with the callback-oriented fields required by the issue update:
  - `outcome_status`: `succeeded` / `errored` / `interrupted`
  - `last_n_steps` for a truncated supervisor context tail
  - `supervisor_status`, `supervisor_invocation_id`, `supervisor_started_at`, `supervisor_attempts`, and decision/reasoning fields for PR 2/3
  - `(supervisor_status, supervisor_started_at)` index for the later orphan-recovery sweep
- Add `persistJobOutcome()` helper that writes rows with `supervisor_status='pending_review'`.
- Persist outcome rows from `execute-job.ts` on success and caught error paths.
- Persist synthetic `interrupted` outcomes from heartbeat stale recovery.
- Add Vitest coverage for success, error, and stale-interrupted outcome paths.

## Callback design note

This PR does **not** run, trigger, or inline a supervisor. It only writes durable `pending_review` outcome rows shaped for a separate Vercel supervisor invocation in PR 2/3. The idempotency/orphan-recovery fields are present so a later callback/webhook-driven supervisor can acquire rows independently and a future sweep can find stuck `pending_review`/`in_progress` rows cheaply.

## Follow-ups

- PR 2: supervisor invocation endpoint + fire-and-forget webhook trigger from worker + idempotency lock, behind `SUPERVISOR_ENABLED=false` by default.
- PR 3: orphan recovery sweep in heartbeat + cleanup of existing heartbeat escalation paths + feature flag flip.

## Verification

- `pnpm typecheck`
- `pnpm --filter aura-api exec vitest run`
- `npx tsc --noEmit` from `apps/api`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1a5dde7-6028-4042-a393-25269fb0d054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1a5dde7-6028-4042-a393-25269fb0d054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

