### PR TITLE
feat(jobs): webhook-triggered supervisor invocation (#1015 -- PR 2/3)

### DIFF
--- a/apps/api/api/cron/supervisor.ts
+++ b/apps/api/api/cron/supervisor.ts
@@ -1,0 +1,8 @@
+import { handle } from "hono/vercel";
+import app from "../../src/app.js";
+
+/**
+ * Webhook-triggered job supervisor.
+ * Runs in a separate Vercel invocation from the worker that persisted the outcome.
+ */
+export const POST = handle(app);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import { WebClient } from "@slack/web-api";
 import { waitUntil } from "@vercel/functions";
 import { cronApp } from "./cron/consolidate.js";
 import { heartbeatApp } from "./cron/heartbeat.js";
+import { supervisorApp } from "./cron/supervisor.js";
 import { elevenlabsWebhookApp } from "./webhook/elevenlabs.js";
 import { createSandboxCommandWebhookApp } from "./webhook/sandbox-command.js";
 import { dashboardApp } from "./routes/dashboard/index.js";
@@ -143,6 +144,7 @@ app.get("/api/health", (c) => {
 // Mount cron routes
 app.route("/", cronApp);
 app.route("/", heartbeatApp);
+app.route("/", supervisorApp);
 
 // Mount ElevenLabs voice webhook routes
 app.route("/api/webhook/elevenlabs", elevenlabsWebhookApp);

--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -162,6 +162,9 @@ function baseJob(overrides: Record<string, unknown> = {}) {
 }
 
 describe("executeJob outcome persistence", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+  const originalAuraPublicUrl = process.env.AURA_PUBLIC_URL;
+
   beforeEach(() => {
     dbMock.results = [];
     dbMock.operations = [];
@@ -177,6 +180,17 @@ describe("executeJob outcome persistence", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+    if (originalAuraPublicUrl === undefined) {
+      delete process.env.AURA_PUBLIC_URL;
+    } else {
+      process.env.AURA_PUBLIC_URL = originalAuraPublicUrl;
+    }
   });
 
   it("writes a pending-review succeeded outcome for script-only success", async () => {
@@ -285,6 +299,65 @@ describe("executeJob outcome persistence", () => {
       ]),
     );
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+  });
+
+  it("invokes the supervisor webhook after persisting an outcome", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    sandboxMock.commandRun.mockResolvedValue({
+      exitCode: 0,
+      stdout: "{\"ok\":true,\"summary\":\"done\"}",
+      stderr: "",
+    });
+    queueDbResults(
+      [{ id: "job-1" }],
+      [{ id: "exec-1" }],
+      [],
+      [],
+      [{ id: "00000000-0000-4000-8000-000000000001" }],
+    );
+
+    const { executeJob } = await import("./execute-job.js");
+    await expect(executeJob(baseJob() as any, "heartbeat")).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://aura.test/api/cron/supervisor",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-secret",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ outcomeId: "00000000-0000-4000-8000-000000000001" }),
+        keepalive: true,
+      }),
+    );
+  });
+
+  it("does not fail the worker when the supervisor webhook rejects", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("network down");
+    }));
+    sandboxMock.commandRun.mockResolvedValue({
+      exitCode: 0,
+      stdout: "{\"ok\":true,\"summary\":\"done\"}",
+      stderr: "",
+    });
+    queueDbResults(
+      [{ id: "job-1" }],
+      [{ id: "exec-1" }],
+      [],
+      [],
+      [{ id: "00000000-0000-4000-8000-000000000001" }],
+    );
+
+    const { executeJob } = await import("./execute-job.js");
+
+    await expect(executeJob(baseJob() as any, "heartbeat")).resolves.toBe(true);
   });
 });
 describe("detectScriptOutputError", () => {

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -21,7 +21,12 @@ import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
 import { sendJobFailureDm } from "./job-notifications.js";
-import { extractLastNSteps, persistJobOutcome, serializeJobError } from "./job-outcomes.js";
+import {
+  extractLastNSteps,
+  persistJobOutcome,
+  serializeJobError,
+  triggerSupervisorReview,
+} from "./job-outcomes.js";
 
 const botToken = process.env.SLACK_BOT_TOKEN || "";
 const slackClient = new WebClient(botToken);
@@ -303,7 +308,7 @@ export async function executeJob(
               summary: resultText.slice(0, 500),
             }).where(eq(jobExecutions.id, executionId));
 
-            await persistJobOutcome({
+            const outcomeId = await persistJobOutcome({
               workspaceId: job.workspaceId,
               jobId,
               jobExecutionId: executionId,
@@ -318,6 +323,7 @@ export async function executeJob(
               },
               lastNSteps: [],
             });
+            triggerSupervisorReview(outcomeId);
 
             logger.info("executeJob: script-only job completed", { jobId, jobName: job.name });
             return true;
@@ -489,7 +495,7 @@ export async function executeJob(
       });
     }
 
-    await persistJobOutcome({
+    const outcomeId = await persistJobOutcome({
       workspaceId: job.workspaceId,
       jobId,
       jobExecutionId: executionId,
@@ -502,6 +508,7 @@ export async function executeJob(
       },
       lastNSteps,
     });
+    triggerSupervisorReview(outcomeId);
 
     return true;
   } catch (error: any) {
@@ -535,7 +542,7 @@ export async function executeJob(
     const retryExhausted = newRetries >= MAX_RETRIES;
     const scratchpadContents = getScratchpadContents(invocationId);
 
-    await persistJobOutcome({
+    const outcomeId = await persistJobOutcome({
       workspaceId: job.workspaceId,
       jobId,
       jobExecutionId: executionId,
@@ -549,6 +556,7 @@ export async function executeJob(
       error: serializeJobError(error),
       lastNSteps,
     });
+    triggerSupervisorReview(outcomeId);
 
     if (!executionId) {
       throw error;

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -143,6 +143,7 @@ describe("heartbeat stale running recovery", () => {
   const originalCronSecret = process.env.CRON_SECRET;
   const originalFounderUserId = process.env.FOUNDER_USER_ID;
   const originalAuraAdminUserIds = process.env.AURA_ADMIN_USER_IDS;
+  const originalAuraPublicUrl = process.env.AURA_PUBLIC_URL;
 
   beforeEach(() => {
     process.env.CRON_SECRET = "test-secret";
@@ -156,6 +157,7 @@ describe("heartbeat stale running recovery", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     if (originalCronSecret === undefined) {
       delete process.env.CRON_SECRET;
     } else {
@@ -170,6 +172,11 @@ describe("heartbeat stale running recovery", () => {
       delete process.env.AURA_ADMIN_USER_IDS;
     } else {
       process.env.AURA_ADMIN_USER_IDS = originalAuraAdminUserIds;
+    }
+    if (originalAuraPublicUrl === undefined) {
+      delete process.env.AURA_PUBLIC_URL;
+    } else {
+      process.env.AURA_PUBLIC_URL = originalAuraPublicUrl;
     }
   });
 
@@ -318,6 +325,63 @@ describe("heartbeat stale running recovery", () => {
         }),
       ]),
     );
+  });
+
+  it("invokes the supervisor webhook after persisting a stale recovery outcome", async () => {
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    queueDbResults(
+      [],
+      [],
+      [],
+      [{ id: "job-stale", name: "healthy-retry", workspaceId: "default" }],
+      [],
+      [{ id: "exec-stale", jobId: "job-stale" }],
+      [{ id: "00000000-0000-4000-8000-000000000001" }],
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://aura.test/api/cron/supervisor",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-secret",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ outcomeId: "00000000-0000-4000-8000-000000000001" }),
+        keepalive: true,
+      }),
+    );
+  });
+
+  it("does not fail heartbeat when the supervisor webhook rejects", async () => {
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("network down");
+    }));
+    queueDbResults(
+      [],
+      [],
+      [],
+      [{ id: "job-stale", name: "healthy-retry", workspaceId: "default" }],
+      [],
+      [{ id: "exec-stale", jobId: "job-stale" }],
+      [{ id: "00000000-0000-4000-8000-000000000001" }],
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
   });
 
   it("does not fall back to founder or admin env vars for system-owned jobs", async () => {

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -8,7 +8,7 @@ import { logger } from "../lib/logger.js";
 import { executeJob, MAX_RETRIES } from "./execute-job.js";
 import { computeNextCronTick } from "./cron-utils.js";
 import { sendJobFailureDm, truncateJobFailureText } from "./job-notifications.js";
-import { persistJobOutcome } from "./job-outcomes.js";
+import { persistJobOutcome, triggerSupervisorReview } from "./job-outcomes.js";
 
 /** Max jobs to process per heartbeat sweep */
 const MAX_JOBS_PER_SWEEP = 10;
@@ -490,7 +490,7 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
         if (!job) continue;
 
         jobIdsWithExecutionOutcomes.add(job.id);
-        await persistJobOutcome({
+        const outcomeId = await persistJobOutcome({
           workspaceId: job.workspaceId,
           jobId: job.id,
           jobExecutionId: execution.id,
@@ -503,12 +503,13 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
           error: "Execution interrupted: recovered by stale detection",
           lastNSteps: [],
         });
+        triggerSupervisorReview(outcomeId);
       }
 
       for (const job of staleJobs) {
         if (jobIdsWithExecutionOutcomes.has(job.id)) continue;
 
-        await persistJobOutcome({
+        const outcomeId = await persistJobOutcome({
           workspaceId: job.workspaceId,
           jobId: job.id,
           jobExecutionId: null,
@@ -521,6 +522,7 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
           error: "Execution interrupted: recovered by stale detection",
           lastNSteps: [],
         });
+        triggerSupervisorReview(outcomeId);
       }
     }
 

--- a/apps/api/src/cron/job-outcomes.ts
+++ b/apps/api/src/cron/job-outcomes.ts
@@ -4,6 +4,7 @@ import { jobOutcomes, type JobOutcomeStatus } from "@aura/db/schema";
 
 const MAX_LAST_STEPS = 3;
 const MAX_STEP_TEXT_CHARS = 4_000;
+const DEFAULT_PUBLIC_URL = "https://aura-alpha-five.vercel.app";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -81,26 +82,72 @@ export async function persistJobOutcome({
   output?: JsonRecord;
   error?: string | null;
   lastNSteps?: JsonRecord[];
-}): Promise<void> {
+}): Promise<string | null> {
   try {
-    await db.insert(jobOutcomes).values({
-      workspaceId: workspaceId ?? "default",
-      jobId,
-      jobExecutionId: jobExecutionId ?? null,
-      outcomeStatus,
-      output,
-      error,
-      lastNSteps,
-      supervisorStatus: "pending_review",
-      supervisorAttempts: 0,
-      updatedAt: new Date(),
-    });
-  } catch (insertError: any) {
+    const [outcome] = await db
+      .insert(jobOutcomes)
+      .values({
+        workspaceId: workspaceId ?? "default",
+        jobId,
+        jobExecutionId: jobExecutionId ?? null,
+        outcomeStatus,
+        output,
+        error,
+        lastNSteps,
+        supervisorStatus: "pending_review",
+        supervisorAttempts: 0,
+        updatedAt: new Date(),
+      })
+      .returning({ id: jobOutcomes.id });
+
+    return outcome?.id ?? null;
+  } catch (insertError: unknown) {
     logger.error("persistJobOutcome: failed to insert outcome row", {
       jobId,
       jobExecutionId,
       outcomeStatus,
-      error: insertError?.message,
+      error: insertError instanceof Error ? insertError.message : String(insertError),
     });
+    return null;
   }
+}
+
+function getSupervisorWebhookUrl(): string {
+  if (process.env.AURA_PUBLIC_URL) {
+    return `${process.env.AURA_PUBLIC_URL.replace(/\/+$/, "")}/api/cron/supervisor`;
+  }
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}/api/cron/supervisor`;
+  }
+  if (process.env.VERCEL_URL) {
+    const host = process.env.VERCEL_URL;
+    const protocol = host.includes("localhost") ? "http" : "https";
+    return `${protocol}://${host}/api/cron/supervisor`;
+  }
+  return `${DEFAULT_PUBLIC_URL}/api/cron/supervisor`;
+}
+
+export function triggerSupervisorReview(outcomeId: string | null | undefined): void {
+  if (!outcomeId) return;
+
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    logger.warn("triggerSupervisorReview: CRON_SECRET not configured", { outcomeId });
+    return;
+  }
+
+  void fetch(getSupervisorWebhookUrl(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${cronSecret}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ outcomeId }),
+    keepalive: true,
+  }).catch((error: unknown) => {
+    logger.warn("triggerSupervisorReview: supervisor webhook failed", {
+      outcomeId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }

--- a/apps/api/src/cron/supervisor.test.ts
+++ b/apps/api/src/cron/supervisor.test.ts
@@ -1,0 +1,382 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => {
+  type Operation = {
+    kind: "select" | "update" | "insert";
+    setArg?: Record<string, unknown>;
+    valuesArg?: Record<string, unknown>;
+  };
+
+  const state = {
+    results: [] as unknown[][],
+    operations: [] as Operation[],
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  };
+
+  function nextResult() {
+    return state.results.shift() ?? [];
+  }
+
+  function createQuery(operation: Operation) {
+    const query: any = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      set: vi.fn((setArg: Record<string, unknown>) => {
+        operation.setArg = setArg;
+        return query;
+      }),
+      values: vi.fn((valuesArg: Record<string, unknown>) => {
+        operation.valuesArg = valuesArg;
+        return query;
+      }),
+      returning: vi.fn(() => {
+        state.operations.push(operation);
+        return Promise.resolve(nextResult());
+      }),
+      then: (onFulfilled: any, onRejected: any) => {
+        state.operations.push(operation);
+        return Promise.resolve(nextResult()).then(onFulfilled, onRejected);
+      },
+    };
+
+    return query;
+  }
+
+  state.select.mockImplementation(() => createQuery({ kind: "select" }));
+  state.update.mockImplementation(() => createQuery({ kind: "update" }));
+  state.insert.mockImplementation(() => createQuery({ kind: "insert" }));
+
+  return state;
+});
+
+const generateObjectMock = vi.hoisted(() => vi.fn());
+const getCredentialMock = vi.hoisted(() => vi.fn());
+const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: dbMock.select,
+    update: dbMock.update,
+    insert: dbMock.insert,
+  },
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/ai.js", () => ({
+  getFastModel: vi.fn(async () => "fast-model"),
+}));
+
+vi.mock("ai", () => ({
+  generateObject: generateObjectMock,
+}));
+
+vi.mock("../lib/credentials.js", () => ({
+  getCredential: getCredentialMock,
+}));
+
+vi.mock("./job-notifications.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./job-notifications.js")>();
+  return {
+    ...actual,
+    sendJobFailureDm: sendJobFailureDmMock,
+  };
+});
+
+function queueDbResults(...results: unknown[][]) {
+  dbMock.results = [...results];
+}
+
+function updateSets() {
+  return dbMock.operations
+    .filter((operation) => operation.kind === "update")
+    .map((operation) => operation.setArg ?? {});
+}
+
+function jobMutationSets() {
+  return updateSets().filter((set) => !("supervisorStatus" in set));
+}
+
+function finalOutcomeUpdate() {
+  return updateSets().find((set) => set.supervisorStatus === "resolved");
+}
+
+function baseOutcome(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    workspaceId: "default",
+    jobId: "00000000-0000-4000-8000-000000000010",
+    jobExecutionId: "00000000-0000-4000-8000-000000000020",
+    outcomeStatus: "errored",
+    output: { retry_exhausted: true },
+    error: "model stream dropped",
+    lastNSteps: [{ index: 0, text: "last step" }],
+    supervisorStatus: "in_progress",
+    supervisorInvocationId: "iad1::invocation",
+    supervisorStartedAt: new Date("2026-05-20T09:00:00.000Z"),
+    supervisorDecision: null,
+    supervisorReasoning: null,
+    supervisorAttempts: 1,
+    createdAt: new Date("2026-05-20T08:59:00.000Z"),
+    updatedAt: new Date("2026-05-20T09:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function baseJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "00000000-0000-4000-8000-000000000010",
+    workspaceId: "default",
+    name: "daily sync",
+    description: "sync the external system",
+    playbook: null,
+    script: null,
+    cronSchedule: null,
+    frequencyConfig: null,
+    channelId: null,
+    threadTs: null,
+    executeAt: null,
+    requestedBy: "U_REQUESTER",
+    priority: "normal",
+    status: "failed",
+    timezone: "UTC",
+    result: null,
+    retries: 3,
+    lastExecutedAt: null,
+    lastResult: "model stream dropped",
+    executionCount: 1,
+    todayExecutions: 1,
+    lastExecutionDate: "2026-05-20",
+    enabled: 1,
+    requiredCredentialIds: [],
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-20T08:59:00.000Z"),
+    ...overrides,
+  };
+}
+
+function baseExecution(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "00000000-0000-4000-8000-000000000020",
+    workspaceId: "default",
+    jobId: "00000000-0000-4000-8000-000000000010",
+    startedAt: new Date("2026-05-20T08:55:00.000Z"),
+    finishedAt: new Date("2026-05-20T08:58:00.000Z"),
+    status: "failed",
+    trigger: "heartbeat",
+    callbackChannel: null,
+    callbackThreadTs: null,
+    steps: null,
+    summary: null,
+    tokenUsage: null,
+    error: "model stream dropped",
+    ...overrides,
+  };
+}
+
+async function invokeSupervisor() {
+  const { supervisorApp } = await import("./supervisor.js");
+  return supervisorApp.request("/api/cron/supervisor", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-secret",
+      "content-type": "application/json",
+      "x-vercel-id": "iad1::invocation",
+    },
+    body: JSON.stringify({ outcomeId: "00000000-0000-4000-8000-000000000001" }),
+  });
+}
+
+describe("supervisor cron", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+  const originalFounderUserId = process.env.FOUNDER_USER_ID;
+  const originalAuraPublicUrl = process.env.AURA_PUBLIC_URL;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = "test-secret";
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T09:00:00.000Z"));
+    dbMock.results = [];
+    dbMock.operations = [];
+    vi.clearAllMocks();
+    generateObjectMock.mockResolvedValue({
+      object: {
+        decision: "report_failure",
+        reasoning: "The job failed permanently.",
+        user_message: "I could not complete the job.",
+      },
+    });
+    getCredentialMock.mockResolvedValue("gh-token");
+    sendJobFailureDmMock.mockResolvedValue(true);
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ html_url: "https://github.com/AuraHQ-ai/aura/issues/123" }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+    if (originalFounderUserId === undefined) {
+      delete process.env.FOUNDER_USER_ID;
+    } else {
+      process.env.FOUNDER_USER_ID = originalFounderUserId;
+    }
+    if (originalAuraPublicUrl === undefined) {
+      delete process.env.AURA_PUBLIC_URL;
+    } else {
+      process.env.AURA_PUBLIC_URL = originalAuraPublicUrl;
+    }
+  });
+
+  it("acquires the idempotency lock and finalizes the outcome", async () => {
+    queueDbResults([baseOutcome()], [baseJob()], [baseExecution()]);
+
+    const response = await invokeSupervisor();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ ok: true, decision: "report_failure" });
+    expect(updateSets()[0]).toMatchObject({
+      supervisorStatus: "in_progress",
+      supervisorInvocationId: "iad1::invocation",
+    });
+    expect(updateSets()[0].supervisorAttempts).toBeDefined();
+    expect(finalOutcomeUpdate()).toMatchObject({
+      supervisorStatus: "resolved",
+      supervisorDecision: "report_failure",
+      supervisorReasoning: "The job failed permanently.",
+    });
+  });
+
+  it("skips when another invocation already claimed the outcome", async () => {
+    queueDbResults([]);
+
+    const response = await invokeSupervisor();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ ok: true, skipped: true, reason: "already_claimed" });
+    expect(generateObjectMock).not.toHaveBeenCalled();
+    expect(updateSets()).toHaveLength(1);
+  });
+
+  it.each([
+    ["report_success", { outcomeStatus: "succeeded", error: null }, { dmCount: 1 }],
+    ["report_failure", {}, { dmCount: 1 }],
+    ["retry_as_is", {}, { dmCount: 1, jobUpdate: { status: "pending", retries: 0 } }],
+    ["retry_with_fix", {}, { dmCount: 1, jobUpdate: { status: "pending", retries: 0 }, issue: true }],
+    ["escalate", {}, { dmCount: 2, founder: true }],
+    ["disable_job", {}, { dmCount: 1, jobUpdate: { enabled: 0 } }],
+  ])(
+    "applies %s with the right side effects",
+    async (decisionName, outcomeOverrides, expected) => {
+      if ("founder" in expected && expected.founder) {
+        process.env.FOUNDER_USER_ID = "U_FOUNDER";
+      }
+      generateObjectMock.mockResolvedValue({
+        object: {
+          decision: decisionName,
+          reasoning: `reason for ${decisionName}`,
+          user_message: `message for ${decisionName}`,
+        },
+      });
+      queueDbResults([baseOutcome(outcomeOverrides)], [baseJob()], [baseExecution()]);
+
+      const response = await invokeSupervisor();
+
+      expect(response.status).toBe(200);
+      expect(sendJobFailureDmMock).toHaveBeenCalledTimes(expected.dmCount);
+      if ("founder" in expected && expected.founder) {
+        expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+          expect.objectContaining({ requestedBy: "U_FOUNDER" }),
+        );
+      }
+      if ("jobUpdate" in expected && expected.jobUpdate) {
+        expect(jobMutationSets()).toEqual(
+          expect.arrayContaining([expect.objectContaining(expected.jobUpdate)]),
+        );
+      } else {
+        expect(jobMutationSets()).toEqual([]);
+      }
+      if ("issue" in expected && expected.issue) {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "https://api.github.com/repos/AuraHQ-ai/aura/issues",
+          expect.objectContaining({
+            method: "POST",
+            body: expect.stringContaining("last_n_steps"),
+          }),
+        );
+        expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: expect.stringContaining("https://github.com/AuraHQ-ai/aura/issues/123"),
+          }),
+        );
+      }
+      expect(finalOutcomeUpdate()).toMatchObject({
+        supervisorStatus: "resolved",
+        supervisorDecision: decisionName,
+      });
+    },
+  );
+
+  it("returns errored outcomes to pending_review when the LLM fails", async () => {
+    generateObjectMock.mockRejectedValue(new Error("gateway unavailable"));
+    queueDbResults([baseOutcome()], [baseJob()], [baseExecution()]);
+
+    const response = await invokeSupervisor();
+
+    expect(response.status).toBe(500);
+    expect(updateSets()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          supervisorStatus: "pending_review",
+          supervisorReasoning: "Supervisor failed: gateway unavailable",
+        }),
+      ]),
+    );
+  });
+
+  it("short-circuits outcomes that reached the max supervisor attempts", async () => {
+    queueDbResults([baseOutcome({ supervisorAttempts: 3 })]);
+
+    const response = await invokeSupervisor();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      skipped: true,
+      reason: "max_supervisor_attempts_exceeded",
+    });
+    expect(generateObjectMock).not.toHaveBeenCalled();
+    expect(updateSets()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          supervisorStatus: "skipped",
+          supervisorReasoning: "max supervisor attempts exceeded",
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/api/src/cron/supervisor.ts
+++ b/apps/api/src/cron/supervisor.ts
@@ -1,0 +1,457 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { generateObject } from "ai";
+import { db } from "../db/client.js";
+import { getFastModel } from "../lib/ai.js";
+import { getCredential } from "../lib/credentials.js";
+import { logger } from "../lib/logger.js";
+import { jobExecutions, jobOutcomes, jobs } from "@aura/db/schema";
+import { sendJobFailureDm, truncateJobFailureText } from "./job-notifications.js";
+
+const SUPERVISOR_LLM_TIMEOUT_MS = 60_000;
+const MAX_SUPERVISOR_ATTEMPTS = 3;
+const DEFAULT_PUBLIC_URL = "https://aura-alpha-five.vercel.app";
+const GITHUB_REPO = "AuraHQ-ai/aura";
+const GITHUB_ISSUE_LABEL = "auto-supervisor-fix";
+
+const supervisorRequestSchema = z.object({
+  outcomeId: z.string().uuid(),
+});
+
+const supervisorDecisionSchema = z.object({
+  decision: z.enum([
+    "retry_as_is",
+    "retry_with_fix",
+    "report_success",
+    "report_failure",
+    "escalate",
+    "disable_job",
+  ]),
+  reasoning: z.string().min(1).max(4_000),
+  user_message: z.string().max(2_000).optional(),
+});
+
+type SupervisorDecision = z.infer<typeof supervisorDecisionSchema>;
+type ClaimedOutcome = typeof jobOutcomes.$inferSelect;
+type JobRow = typeof jobs.$inferSelect;
+type JobExecutionRow = typeof jobExecutions.$inferSelect;
+
+type SupervisorContext = {
+  outcome: ClaimedOutcome;
+  job: JobRow;
+  executions: JobExecutionRow[];
+};
+
+export const supervisorApp = new Hono();
+
+function getPublicBaseUrl(): string {
+  if (process.env.AURA_PUBLIC_URL) {
+    return process.env.AURA_PUBLIC_URL.replace(/\/+$/, "");
+  }
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`.replace(/\/+$/, "");
+  }
+  if (process.env.VERCEL_URL) {
+    const host = process.env.VERCEL_URL;
+    const protocol = host.includes("localhost") ? "http" : "https";
+    return `${protocol}://${host}`.replace(/\/+$/, "");
+  }
+  return DEFAULT_PUBLIC_URL;
+}
+
+function jobLink(jobId: string): string {
+  return `${getPublicBaseUrl()}/jobs/${jobId}`;
+}
+
+function jsonForPrompt(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_key, nestedValue) => {
+      if (nestedValue instanceof Date) return nestedValue.toISOString();
+      return nestedValue;
+    },
+    2,
+  );
+}
+
+function truncateForPrompt(value: string, maxChars = 12_000): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n... [truncated]`;
+}
+
+function invocationIdFromHeader(headerValue: string | undefined): string {
+  return headerValue?.trim() || crypto.randomUUID();
+}
+
+async function acquireSupervisorLock(
+  outcomeId: string,
+  invocationId: string,
+): Promise<ClaimedOutcome | null> {
+  const [outcome] = await db
+    .update(jobOutcomes)
+    .set({
+      supervisorStatus: "in_progress",
+      supervisorInvocationId: invocationId,
+      supervisorStartedAt: new Date(),
+      supervisorAttempts: sql`${jobOutcomes.supervisorAttempts} + 1`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(jobOutcomes.id, outcomeId),
+        eq(jobOutcomes.supervisorStatus, "pending_review"),
+      ),
+    )
+    .returning();
+
+  return outcome ?? null;
+}
+
+async function loadSupervisorContext(outcome: ClaimedOutcome): Promise<SupervisorContext> {
+  const [job] = await db
+    .select()
+    .from(jobs)
+    .where(eq(jobs.id, outcome.jobId))
+    .limit(1);
+
+  if (!job) {
+    throw new Error(`Job not found for supervisor outcome ${outcome.id}`);
+  }
+
+  const executions = await db
+    .select()
+    .from(jobExecutions)
+    .where(eq(jobExecutions.jobId, outcome.jobId))
+    .orderBy(desc(jobExecutions.startedAt))
+    .limit(5);
+
+  return { outcome, job, executions };
+}
+
+async function runSupervisorLlm(context: SupervisorContext): Promise<SupervisorDecision> {
+  const model = await getFastModel();
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), SUPERVISOR_LLM_TIMEOUT_MS);
+
+  try {
+    const { object } = await generateObject({
+      model,
+      schema: supervisorDecisionSchema,
+      system:
+        "You are Aura's job execution supervisor. Make one conservative decision from the provided fixed enum. Return only the structured object. Do not call tools.",
+      prompt: truncateForPrompt(`Review this completed job outcome and decide the next action.
+
+Decision meanings:
+- report_success: outcome succeeded and the requester should be told.
+- report_failure: outcome failed in a way the requester should know about; do not retry.
+- retry_as_is: transient failure or likely timeout; retry immediately without changing the job.
+- retry_with_fix: likely Aura code/config bug; retry now and create an engineering issue.
+- escalate: ambiguous, high-risk, or needs human judgment.
+- disable_job: the job is harmful, obsolete, or repeatedly broken and should be disabled.
+
+Context:
+${jsonForPrompt({
+  outcome: {
+    id: context.outcome.id,
+    status: context.outcome.outcomeStatus,
+    error: context.outcome.error,
+    output: context.outcome.output,
+    last_n_steps: context.outcome.lastNSteps,
+    created_at: context.outcome.createdAt,
+  },
+  job: {
+    id: context.job.id,
+    name: context.job.name,
+    description: context.job.description,
+    playbook: context.job.playbook,
+    script: context.job.script,
+    status: context.job.status,
+    retries: context.job.retries,
+    enabled: context.job.enabled,
+    requested_by: context.job.requestedBy,
+    cron_schedule: context.job.cronSchedule,
+    frequency_config: context.job.frequencyConfig,
+    last_result: context.job.lastResult,
+  },
+  last_5_executions: context.executions.map((execution) => ({
+    id: execution.id,
+    status: execution.status,
+    trigger: execution.trigger,
+    started_at: execution.startedAt,
+    finished_at: execution.finishedAt,
+    summary: execution.summary,
+    error: execution.error,
+  })),
+})}`),
+      temperature: 0,
+      abortSignal: abortController.signal,
+    });
+
+    return object;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function sendSupervisorDm(
+  job: JobRow,
+  text: string,
+  logContext: Record<string, unknown> = {},
+): Promise<void> {
+  await sendJobFailureDm({
+    jobId: job.id,
+    requestedBy: job.requestedBy,
+    text,
+    logContext: { event: "job_supervisor", ...logContext },
+  });
+}
+
+async function sendFounderDm(job: JobRow, text: string): Promise<void> {
+  const founderUserId = process.env.FOUNDER_USER_ID?.trim() || job.requestedBy;
+  if (!founderUserId || founderUserId === job.requestedBy) return;
+
+  await sendJobFailureDm({
+    jobId: job.id,
+    requestedBy: founderUserId,
+    text,
+    logContext: { event: "job_supervisor_founder_escalation" },
+  });
+}
+
+function buildUserMessage(decision: SupervisorDecision, fallback: string): string {
+  return decision.user_message?.trim() || fallback;
+}
+
+async function createSupervisorFixIssue(
+  context: SupervisorContext,
+  decision: SupervisorDecision,
+): Promise<string> {
+  const ghToken = await getCredential("github_token");
+  if (!ghToken) {
+    throw new Error("GitHub token not configured for supervisor fix issue creation");
+  }
+
+  const issueBody = [
+    `Supervisor decision: \`${decision.decision}\``,
+    "",
+    "## Reasoning",
+    decision.reasoning,
+    "",
+    "## Job",
+    `- id: ${context.job.id}`,
+    `- name: ${context.job.name}`,
+    `- requested_by: ${context.job.requestedBy}`,
+    "",
+    "## Outcome",
+    `- id: ${context.outcome.id}`,
+    `- status: ${context.outcome.outcomeStatus}`,
+    `- error: ${context.outcome.error ?? "none"}`,
+    "",
+    "## last_n_steps",
+    "```json",
+    jsonForPrompt(context.outcome.lastNSteps ?? []),
+    "```",
+  ].join("\n");
+
+  const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
+    method: "POST",
+    headers: {
+      Authorization: `token ${ghToken}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      title: `Supervisor fix needed: ${context.job.name}`,
+      body: issueBody,
+      labels: [GITHUB_ISSUE_LABEL],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`GitHub issue creation failed (${response.status}): ${errorText}`);
+  }
+
+  const issue = (await response.json()) as { html_url?: string };
+  if (!issue.html_url) {
+    throw new Error("GitHub issue creation response did not include html_url");
+  }
+
+  return issue.html_url;
+}
+
+async function applySupervisorDecision(
+  context: SupervisorContext,
+  decision: SupervisorDecision,
+): Promise<void> {
+  const now = new Date();
+  const link = jobLink(context.job.id);
+
+  switch (decision.decision) {
+    case "report_success": {
+      await sendSupervisorDm(
+        context.job,
+        `${buildUserMessage(decision, `Job \`${context.job.name}\` completed successfully.`)}\n\nDetails: ${link}`,
+        { outcomeId: context.outcome.id, decision: decision.decision },
+      );
+      return;
+    }
+
+    case "report_failure": {
+      const error = truncateJobFailureText(context.outcome.error);
+      await sendSupervisorDm(
+        context.job,
+        `${buildUserMessage(decision, `Job \`${context.job.name}\` failed.`)}\n\nError: ${error}\nDetails: ${link}`,
+        { outcomeId: context.outcome.id, decision: decision.decision },
+      );
+      return;
+    }
+
+    case "retry_as_is": {
+      await db
+        .update(jobs)
+        .set({ status: "pending", retries: 0, executeAt: now, updatedAt: now })
+        .where(eq(jobs.id, context.job.id));
+      await sendSupervisorDm(
+        context.job,
+        `${buildUserMessage(decision, `Job \`${context.job.name}\` looked retryable, so I queued it to run again now.`)}\n\nDetails: ${link}`,
+        { outcomeId: context.outcome.id, decision: decision.decision },
+      );
+      return;
+    }
+
+    case "retry_with_fix": {
+      await db
+        .update(jobs)
+        .set({ status: "pending", retries: 0, executeAt: now, updatedAt: now })
+        .where(eq(jobs.id, context.job.id));
+      const issueUrl = await createSupervisorFixIssue(context, decision);
+      await sendSupervisorDm(
+        context.job,
+        `${buildUserMessage(decision, `Job \`${context.job.name}\` was queued to retry and I opened an engineering follow-up.`)}\n\nIssue: ${issueUrl}\nDetails: ${link}`,
+        { outcomeId: context.outcome.id, decision: decision.decision, issueUrl },
+      );
+      return;
+    }
+
+    case "escalate": {
+      const text = `${buildUserMessage(decision, `Job \`${context.job.name}\` needs human review.`)}\n\nReason: ${decision.reasoning}\nDetails: ${link}`;
+      await sendSupervisorDm(context.job, text, {
+        outcomeId: context.outcome.id,
+        decision: decision.decision,
+      });
+      await sendFounderDm(context.job, text);
+      return;
+    }
+
+    case "disable_job": {
+      await db
+        .update(jobs)
+        .set({ enabled: 0, updatedAt: now })
+        .where(eq(jobs.id, context.job.id));
+      await sendSupervisorDm(
+        context.job,
+        `${buildUserMessage(decision, `Job \`${context.job.name}\` was disabled by the supervisor.`)}\n\nReason: ${decision.reasoning}\nDetails: ${link}`,
+        { outcomeId: context.outcome.id, decision: decision.decision },
+      );
+      return;
+    }
+  }
+}
+
+async function finalizeOutcome(
+  outcomeId: string,
+  decision: SupervisorDecision,
+): Promise<void> {
+  await db
+    .update(jobOutcomes)
+    .set({
+      supervisorStatus: "resolved",
+      supervisorDecision: decision.decision,
+      supervisorReasoning: decision.reasoning,
+      updatedAt: new Date(),
+    })
+    .where(eq(jobOutcomes.id, outcomeId));
+}
+
+async function releaseOutcomeForRetry(outcome: ClaimedOutcome | null, error: unknown): Promise<void> {
+  if (!outcome) return;
+
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const maxAttemptsExceeded = outcome.supervisorAttempts >= MAX_SUPERVISOR_ATTEMPTS;
+
+  await db
+    .update(jobOutcomes)
+    .set({
+      supervisorStatus: maxAttemptsExceeded ? "skipped" : "pending_review",
+      supervisorReasoning: maxAttemptsExceeded
+        ? "max supervisor attempts exceeded"
+        : `Supervisor failed: ${errorMessage}`,
+      updatedAt: new Date(),
+    })
+    .where(eq(jobOutcomes.id, outcome.id));
+}
+
+async function skipMaxAttempts(outcome: ClaimedOutcome): Promise<void> {
+  await db
+    .update(jobOutcomes)
+    .set({
+      supervisorStatus: "skipped",
+      supervisorReasoning: "max supervisor attempts exceeded",
+      updatedAt: new Date(),
+    })
+    .where(eq(jobOutcomes.id, outcome.id));
+}
+
+supervisorApp.post("/api/cron/supervisor", async (c) => {
+  const authHeader = c.req.header("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    logger.warn("Unauthorized supervisor cron invocation");
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  let outcomeId: string;
+  try {
+    const parsed = supervisorRequestSchema.safeParse(await c.req.json());
+    if (!parsed.success) {
+      return c.json({ error: "outcomeId required" }, 400);
+    }
+    outcomeId = parsed.data.outcomeId;
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const invocationId = invocationIdFromHeader(c.req.header("x-vercel-id"));
+  let claimedOutcome: ClaimedOutcome | null = null;
+
+  try {
+    claimedOutcome = await acquireSupervisorLock(outcomeId, invocationId);
+    if (!claimedOutcome) {
+      return c.json({ ok: true, skipped: true, reason: "already_claimed" });
+    }
+
+    if (claimedOutcome.supervisorAttempts >= MAX_SUPERVISOR_ATTEMPTS) {
+      await skipMaxAttempts(claimedOutcome);
+      return c.json({ ok: true, skipped: true, reason: "max_supervisor_attempts_exceeded" });
+    }
+
+    const context = await loadSupervisorContext(claimedOutcome);
+    const decision = await runSupervisorLlm(context);
+    await applySupervisorDecision(context, decision);
+    await finalizeOutcome(claimedOutcome.id, decision);
+
+    return c.json({ ok: true, outcomeId, decision: decision.decision });
+  } catch (error) {
+    logger.error("Supervisor invocation failed", {
+      outcomeId,
+      invocationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await releaseOutcomeForRetry(claimedOutcome, error);
+    return c.json({ ok: false, error: "Supervisor failed" }, 500);
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `POST /api/cron/supervisor` as a separately invoked supervisor endpoint with bearer auth, idempotent outcome claiming, fast-model structured decisions, decision application, and retryable error handling.
- Return inserted outcome ids from `persistJobOutcome` and fire-and-forget the supervisor webhook after execute-job and heartbeat outcome writes.
- Cover supervisor lock/error/decision paths and worker webhook triggering in Vitest.

## Verification
- `pnpm --filter aura-api exec vitest run src/cron/supervisor.test.ts src/cron/execute-job.test.ts src/cron/heartbeat.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm --filter aura-api test`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49815cfe-d328-407d-bd58-8586a8890ce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49815cfe-d328-407d-bd58-8586a8890ce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

