### PR TITLE
feat(jobs): orphan sweep + legacy escalation cleanup (#1015 -- PR 3/3)

### DIFF
--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -63,7 +63,6 @@ const sandboxMock = vi.hoisted(() => ({
 }));
 
 const createHeadlessAgentMock = vi.hoisted(() => vi.fn());
-const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../db/client.js", () => ({
   db: {
@@ -113,10 +112,6 @@ vi.mock("./persist-conversation.js", () => ({
 vi.mock("../tools/scratchpad.js", () => ({
   getScratchpadContents: vi.fn(() => null),
   cleanupScratchpad: vi.fn(),
-}));
-
-vi.mock("./job-notifications.js", () => ({
-  sendJobFailureDm: sendJobFailureDmMock,
 }));
 
 function queueDbResults(...results: unknown[][]) {
@@ -175,7 +170,6 @@ describe("executeJob outcome persistence", () => {
         run: sandboxMock.commandRun,
       },
     });
-    sendJobFailureDmMock.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -267,7 +261,6 @@ describe("executeJob outcome persistence", () => {
         }),
       ]),
     );
-    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
   });
 
   it("writes an errored outcome for caught non-script failures", async () => {
@@ -298,7 +291,6 @@ describe("executeJob outcome persistence", () => {
         }),
       ]),
     );
-    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 
   it("invokes the supervisor webhook after persisting an outcome", async () => {

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -20,7 +20,6 @@ import { detectScriptOutputError } from "./script-output.js";
 import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
-import { sendJobFailureDm } from "./job-notifications.js";
 import {
   extractLastNSteps,
   persistJobOutcome,
@@ -585,13 +584,6 @@ export async function executeJob(
           updatedAt: new Date(),
         })
         .where(eq(jobs.id, jobId));
-
-      await sendJobFailureDm({
-        jobId,
-        requestedBy: job.requestedBy,
-        text: `I tried 3 times but couldn't complete this job: "${job.description}"\n\nError: ${error.message}`,
-        logContext: { executionId },
-      });
 
       logger.error("Heartbeat: job failed permanently", {
         jobName: job.name,

--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbMock = vi.hoisted(() => {
@@ -59,6 +60,7 @@ const dbMock = vi.hoisted(() => {
 
 const executeJobMock = vi.hoisted(() => vi.fn());
 const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
+const safePostMessageMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../db/client.js", () => ({
   db: {
@@ -90,6 +92,10 @@ vi.mock("./job-notifications.js", async (importOriginal) => {
     sendJobFailureDm: sendJobFailureDmMock,
   };
 });
+
+vi.mock("../lib/slack-messaging.js", () => ({
+  safePostMessage: safePostMessageMock,
+}));
 
 function queueDbResults(...results: unknown[][]) {
   dbMock.results = [...results];
@@ -153,6 +159,7 @@ describe("heartbeat stale running recovery", () => {
     dbMock.operations = [];
     vi.clearAllMocks();
     sendJobFailureDmMock.mockResolvedValue(true);
+    safePostMessageMock.mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -180,7 +187,7 @@ describe("heartbeat stale running recovery", () => {
     }
   });
 
-  it("auto-recovers stale exhausted recurring jobs and sends a DM", async () => {
+  it("auto-recovers stale exhausted recurring jobs without legacy DM escalation", async () => {
     const recurringJob = baseJob({
       cronSchedule: "0 10 * * *",
       name: "sync-meta-comments-daily",
@@ -191,6 +198,9 @@ describe("heartbeat stale running recovery", () => {
       [], // pending jobs
       [], // expired plan notes
       [], // stale plan notes
+      [], // orphan pending_review outcomes
+      [], // orphan in_progress outcomes
+      [], // dequeued jobs without execution rows
       [], // stale running jobs below max retries
       [recurringJob], // stale exhausted jobs
       [], // recurring recovery update
@@ -213,17 +223,10 @@ describe("heartbeat stale running recovery", () => {
     expect((recoveredUpdate?.executeAt as Date).toISOString()).toBe(
       "2026-05-20T10:00:00.000Z",
     );
-    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
-    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        jobId: "job-1",
-        requestedBy: "U_REQUESTER",
-        text: expect.stringContaining("Auto-recovered. Next attempt: 2026-05-20T10:00:00.000Z."),
-      }),
-    );
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 
-  it("fails stale exhausted one-shot jobs and sends a DM", async () => {
+  it("fails stale exhausted one-shot jobs without legacy DM escalation", async () => {
     const oneShotJob = baseJob({
       cronSchedule: null,
       name: "one-shot-followup",
@@ -231,6 +234,9 @@ describe("heartbeat stale running recovery", () => {
     });
 
     queueDbResults(
+      [],
+      [],
+      [],
       [],
       [],
       [],
@@ -251,18 +257,14 @@ describe("heartbeat stale running recovery", () => {
       status: "failed",
       result: "Failed: job stuck in running state and exceeded retry limit",
     });
-    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
-    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        jobId: "job-1",
-        requestedBy: "U_REQUESTER",
-        text: "Job one-shot-followup exhausted retries. Last error: tool failed.",
-      }),
-    );
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 
   it("keeps healthy stale recovery for jobs below the retry limit", async () => {
     queueDbResults(
+      [],
+      [],
+      [],
       [],
       [],
       [],
@@ -294,6 +296,9 @@ describe("heartbeat stale running recovery", () => {
 
   it("writes a pending-review interrupted outcome for stale running recovery", async () => {
     queueDbResults(
+      [],
+      [],
+      [],
       [],
       [],
       [],
@@ -335,6 +340,9 @@ describe("heartbeat stale running recovery", () => {
       [],
       [],
       [],
+      [],
+      [],
+      [],
       [{ id: "job-stale", name: "healthy-retry", workspaceId: "default" }],
       [],
       [{ id: "exec-stale", jobId: "job-stale" }],
@@ -370,6 +378,9 @@ describe("heartbeat stale running recovery", () => {
       [],
       [],
       [],
+      [],
+      [],
+      [],
       [{ id: "job-stale", name: "healthy-retry", workspaceId: "default" }],
       [],
       [{ id: "exec-stale", jobId: "job-stale" }],
@@ -395,212 +406,159 @@ describe("heartbeat stale running recovery", () => {
     expect(resolveJobFailureDmTarget(" U_OWNER ")).toBe("U_OWNER");
   });
 
-  it("escalates after 5 consecutive failed recurring job executions", async () => {
-    const recurringJob = baseJob({
-      status: "pending",
-      cronSchedule: "* * * * *",
-      name: "sync-meta-comments-daily",
-      lastResult: "previous failure",
-    });
-    const recentFailures = [0, 1, 2, 3, 4].map((index) => ({
-      id: `exec-${index}`,
-      status: "failed",
-      startedAt: new Date(`2026-05-20T08:5${4 - index}:00.000Z`),
-      error: index === 0 ? "Meta API timeout" : "previous error",
-    }));
-
-    executeJobMock.mockRejectedValueOnce(new Error("Meta API timeout"));
+  it("sweep refires webhook for outcomes stuck in pending_review past 5min", async () => {
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
     queueDbResults(
-      [recurringJob], // pending jobs
-      [], // expired plan notes
-      [], // stale plan notes
-      [], // stale running jobs below max retries
-      [], // stale exhausted jobs
-      [], // stuck failed recurring jobs (none)
-      recentFailures, // recent job executions
-      [], // no existing marker
-      [], // marker insert
+      [{ id: "00000000-0000-4000-8000-000000000101" }],
+      [],
+      [],
     );
 
-    const { heartbeatApp } = await import("./heartbeat.js");
-    const response = await heartbeatApp.request("/api/cron/heartbeat", {
-      headers: { authorization: "Bearer test-secret" },
-    });
+    const { sweepOrphanedOutcomes } = await import("./heartbeat.js");
+    const result = await sweepOrphanedOutcomes();
 
-    expect(response.status).toBe(200);
-    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
-    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+    expect(result.pendingReviewRefired).toBe(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://aura.test/api/cron/supervisor",
       expect.objectContaining({
-        jobId: "job-1",
-        requestedBy: "U_REQUESTER",
-        text: expect.stringContaining(
-          "Your recurring job `sync-meta-comments-daily` has failed 5 consecutive runs.",
-        ),
+        method: "POST",
+        body: JSON.stringify({ outcomeId: "00000000-0000-4000-8000-000000000101" }),
+        keepalive: true,
       }),
     );
-    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: expect.stringContaining("It's been broken since 2026-05-20T08:50:00.000Z."),
-      }),
+    expect(updateSets()).toEqual([]);
+  });
+
+  it("sweep resets in_progress outcomes past 10min back to pending_review when attempts < 3", async () => {
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    queueDbResults(
+      [],
+      [{ id: "00000000-0000-4000-8000-000000000102", jobId: "job-1", supervisorAttempts: 2 }],
+      [{ id: "00000000-0000-4000-8000-000000000102" }],
+      [],
     );
-    expect(insertValues()).toEqual(
+
+    const { sweepOrphanedOutcomes } = await import("./heartbeat.js");
+    const result = await sweepOrphanedOutcomes();
+
+    expect(result.inProgressReset).toBe(1);
+    expect(updateSets()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          topic: "job-failure-streak:job-1",
-          category: "job_failure_streak_marker",
-          injectInContext: false,
+          supervisorStatus: "pending_review",
+          supervisorInvocationId: null,
+          supervisorStartedAt: null,
         }),
       ]),
     );
-  });
-
-  it("does not duplicate escalation on the 6th consecutive failure in the same streak", async () => {
-    const recurringJob = baseJob({
-      status: "pending",
-      cronSchedule: "* * * * *",
-      name: "sync-meta-comments-daily",
-    });
-    const recentFailures = [0, 1, 2, 3, 4].map((index) => ({
-      id: `exec-${index + 2}`,
-      status: "failed",
-      startedAt: new Date(`2026-05-20T08:5${5 - index}:00.000Z`),
-      error: "still failing",
-    }));
-
-    executeJobMock.mockRejectedValueOnce(new Error("still failing"));
-    queueDbResults(
-      [recurringJob],
-      [],
-      [],
-      [],
-      [],
-      [], // stuck failed recurring jobs (none)
-      recentFailures,
-      [{ id: "marker-1", updatedAt: new Date("2026-05-20T08:54:30.000Z") }],
-      [], // no successful executions since the marker
-    );
-
-    const { heartbeatApp } = await import("./heartbeat.js");
-    const response = await heartbeatApp.request("/api/cron/heartbeat", {
-      headers: { authorization: "Bearer test-secret" },
-    });
-
-    expect(response.status).toBe(200);
-    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
-    expect(insertValues()).toEqual([]);
-  });
-
-  it("does not escalate immediately after a successful run resets the streak", async () => {
-    const recurringJob = baseJob({
-      status: "pending",
-      cronSchedule: "* * * * *",
-      name: "sync-meta-comments-daily",
-    });
-    const recentExecutions = [
-      {
-        id: "exec-latest",
-        status: "failed",
-        startedAt: new Date("2026-05-20T08:58:00.000Z"),
-        error: "new failure",
-      },
-      {
-        id: "exec-success",
-        status: "completed",
-        startedAt: new Date("2026-05-20T08:57:00.000Z"),
-        error: null,
-      },
-      {
-        id: "exec-old-1",
-        status: "failed",
-        startedAt: new Date("2026-05-20T08:56:00.000Z"),
-        error: "old failure",
-      },
-      {
-        id: "exec-old-2",
-        status: "failed",
-        startedAt: new Date("2026-05-20T08:55:00.000Z"),
-        error: "old failure",
-      },
-      {
-        id: "exec-old-3",
-        status: "failed",
-        startedAt: new Date("2026-05-20T08:54:00.000Z"),
-        error: "old failure",
-      },
-    ];
-
-    executeJobMock.mockRejectedValueOnce(new Error("new failure"));
-    queueDbResults(
-      [recurringJob],
-      [],
-      [],
-      [],
-      [],
-      [], // stuck failed recurring jobs (none)
-      recentExecutions,
-      [], // marker reset delete
-    );
-
-    const { heartbeatApp } = await import("./heartbeat.js");
-    const response = await heartbeatApp.request("/api/cron/heartbeat", {
-      headers: { authorization: "Bearer test-secret" },
-    });
-
-    expect(response.status).toBe(200);
-    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
-    expect(insertValues()).toEqual([]);
-  });
-
-  it("escalates a recurring job already parked in status=failed (stuck since prior sweep)", async () => {
-    const stuckJob = baseJob({
-      status: "failed",
-      cronSchedule: "0 * * * *",
-      name: "sync-meta-comments-daily",
-      lastResult: "Execution interrupted: recovered by stale detection",
-    });
-    const recentFailures = [0, 1, 2, 3, 4].map((index) => ({
-      id: `exec-${index}`,
-      status: "failed",
-      startedAt: new Date(`2026-05-09T0${4 - index}:00:00.000Z`),
-      error: "Execution interrupted: recovered by stale detection",
-    }));
-
-    queueDbResults(
-      [], // pending jobs (none — stuck job is in status=failed)
-      [], // expired plan notes
-      [], // stale plan notes
-      [], // stale running jobs below max retries
-      [], // stale exhausted jobs
-      [stuckJob], // stuck failed recurring jobs ← new query
-      recentFailures, // recent job executions
-      [], // no existing marker
-      [], // marker insert
-    );
-
-    const { heartbeatApp } = await import("./heartbeat.js");
-    const response = await heartbeatApp.request("/api/cron/heartbeat", {
-      headers: { authorization: "Bearer test-secret" },
-    });
-
-    expect(response.status).toBe(200);
-    expect(sendJobFailureDmMock).toHaveBeenCalledOnce();
-    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://aura.test/api/cron/supervisor",
       expect.objectContaining({
-        jobId: "job-1",
-        requestedBy: "U_REQUESTER",
-        text: expect.stringContaining(
-          "Your recurring job `sync-meta-comments-daily` has failed 5 consecutive runs.",
-        ),
+        body: JSON.stringify({ outcomeId: "00000000-0000-4000-8000-000000000102" }),
       }),
     );
-    expect(insertValues()).toEqual(
+  });
+
+  it("sweep marks in_progress outcomes as skipped + DMs when attempts >= 3", async () => {
+    queueDbResults(
+      [],
+      [{ id: "00000000-0000-4000-8000-000000000103", jobId: "job-1", supervisorAttempts: 3 }],
+      [{ id: "00000000-0000-4000-8000-000000000103", jobId: "job-1" }],
+      [{ id: "job-1", name: "stuck supervisor job", requestedBy: "U_REQUESTER" }],
+      [],
+    );
+
+    const { sweepOrphanedOutcomes } = await import("./heartbeat.js");
+    const result = await sweepOrphanedOutcomes();
+
+    expect(result.inProgressSkipped).toBe(1);
+    expect(updateSets()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          topic: "job-failure-streak:job-1",
-          category: "job_failure_streak_marker",
+          supervisorStatus: "skipped",
+          supervisorReasoning: "max supervisor attempts exceeded",
         }),
       ]),
     );
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "U_REQUESTER",
+        text: "Supervisor for job stuck supervisor job exhausted retries; manual intervention needed",
+      }),
+    );
+  });
+
+  it("sweep writes process_died_pre_execution outcome for jobs dequeued without execution row", async () => {
+    process.env.AURA_PUBLIC_URL = "https://aura.test";
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    queueDbResults(
+      [],
+      [],
+      [
+        {
+          id: "job-lost",
+          workspaceId: "default",
+          name: "lost before execution",
+          executeAt: new Date("2026-05-20T08:45:00.000Z"),
+          updatedAt: new Date("2026-05-20T08:46:00.000Z"),
+        },
+      ],
+      [{ id: "00000000-0000-4000-8000-000000000104" }],
+      [],
+    );
+
+    const { sweepOrphanedOutcomes } = await import("./heartbeat.js");
+    const result = await sweepOrphanedOutcomes();
+
+    expect(result.dequeuedWithoutExecution).toBe(1);
+    expect(insertValues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workspaceId: "default",
+          jobId: "job-lost",
+          jobExecutionId: null,
+          outcomeStatus: "process_died_pre_execution",
+          output: expect.objectContaining({
+            type: "process_died_pre_execution",
+            recovered_by: "heartbeat",
+            execute_at: "2026-05-20T08:45:00.000Z",
+            dequeued_at: "2026-05-20T08:46:00.000Z",
+          }),
+          error: "Job was dequeued but no execution row was created",
+          lastNSteps: [],
+          supervisorStatus: "pending_review",
+        }),
+      ]),
+    );
+    expect(updateSets()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "failed",
+          result: "Failed: worker died before creating a job execution row",
+        }),
+      ]),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://aura.test/api/cron/supervisor",
+      expect.objectContaining({
+        body: JSON.stringify({ outcomeId: "00000000-0000-4000-8000-000000000104" }),
+      }),
+    );
+  });
+
+  it("legacy escalation is no longer called", () => {
+    const source = readFileSync(new URL("./heartbeat.ts", import.meta.url), "utf8");
+    const legacyFunction = ["maybe", "Escalate", "Consecutive", "Recurring", "Failures"].join("");
+    const legacyMarkerTopic = ["job", "failure", "streak"].join("_");
+
+    expect(source).not.toContain(legacyFunction);
+    expect(source).not.toContain(legacyMarkerTopic);
   });
 
 });

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -1,14 +1,15 @@
 import { Hono } from "hono";
-import { eq, and, lt, lte, gte, gt, desc, sql, isNull, or, inArray } from "drizzle-orm";
+import { WebClient } from "@slack/web-api";
+import { eq, and, lt, lte, gte, sql, isNull, or, inArray } from "drizzle-orm";
 import { CronExpressionParser } from "cron-parser";
 import { db } from "../db/client.js";
-import { jobs, notes, jobExecutions } from "@aura/db/schema";
+import { jobs, notes, jobExecutions, jobOutcomes } from "@aura/db/schema";
 import type { FrequencyConfig } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
 import { executeJob, MAX_RETRIES } from "./execute-job.js";
 import { computeNextCronTick } from "./cron-utils.js";
-import { sendJobFailureDm, truncateJobFailureText } from "./job-notifications.js";
 import { persistJobOutcome, triggerSupervisorReview } from "./job-outcomes.js";
+import { safePostMessage } from "../lib/slack-messaging.js";
 
 /** Max jobs to process per heartbeat sweep */
 const MAX_JOBS_PER_SWEEP = 10;
@@ -16,8 +17,13 @@ const MAX_JOBS_PER_SWEEP = 10;
 /** Threshold for recovering jobs stuck in "running" (15 minutes) */
 const STALE_RUNNING_THRESHOLD_MS = 15 * 60 * 1000;
 
-/** Consecutive failed recurring executions before owner escalation */
-const CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD = 5;
+const ORPHAN_SWEEP_BATCH_SIZE = 20;
+const PENDING_REVIEW_ORPHAN_THRESHOLD_MS = 5 * 60 * 1000;
+const IN_PROGRESS_ORPHAN_THRESHOLD_MS = 10 * 60 * 1000;
+const DEQUEUED_WITHOUT_EXECUTION_THRESHOLD_MS = 10 * 60 * 1000;
+const MAX_SUPERVISOR_ATTEMPTS = 3;
+
+const slackClient = new WebClient(process.env.SLACK_BOT_TOKEN || "");
 
 // ── Job Eligibility (recurring jobs) ─────────────────────────────────────────
 
@@ -73,139 +79,205 @@ function isRecurringJobDue(job: typeof jobs.$inferSelect): boolean {
   return true;
 }
 
-function consecutiveFailureMarkerTopic(jobId: string): string {
-  return `job-failure-streak:${jobId}`;
+type OrphanSweepResult = {
+  pendingReviewRefired: number;
+  inProgressReset: number;
+  inProgressSkipped: number;
+  dequeuedWithoutExecution: number;
+};
+
+async function notifySupervisorRetriesExhausted(job: Pick<typeof jobs.$inferSelect, "id" | "name" | "requestedBy">): Promise<void> {
+  if (!job.requestedBy) return;
+
+  const text = `Supervisor for job ${job.name} exhausted retries; manual intervention needed`;
+  try {
+    const result = await safePostMessage(slackClient, {
+      channel: job.requestedBy,
+      text,
+    });
+
+    if (!result.ok) {
+      logger.warn("orphan_sweep_supervisor_retry_exhausted_dm_failed", {
+        jobId: job.id,
+        requestedBy: job.requestedBy,
+      });
+    }
+  } catch (error: unknown) {
+    logger.warn("orphan_sweep_supervisor_retry_exhausted_dm_error", {
+      jobId: job.id,
+      requestedBy: job.requestedBy,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
-async function clearConsecutiveFailureMarker(job: typeof jobs.$inferSelect): Promise<void> {
-  await db
-    .delete(notes)
+export async function sweepOrphanedOutcomes(now = new Date()): Promise<OrphanSweepResult> {
+  const pendingReviewCutoff = new Date(now.getTime() - PENDING_REVIEW_ORPHAN_THRESHOLD_MS);
+  const inProgressCutoff = new Date(now.getTime() - IN_PROGRESS_ORPHAN_THRESHOLD_MS);
+  const dequeuedWithoutExecutionCutoff = new Date(
+    now.getTime() - DEQUEUED_WITHOUT_EXECUTION_THRESHOLD_MS,
+  );
+
+  let pendingReviewRefired = 0;
+  let inProgressReset = 0;
+  let inProgressSkipped = 0;
+  let dequeuedWithoutExecution = 0;
+
+  const pendingReviewOutcomes = await db
+    .select({ id: jobOutcomes.id })
+    .from(jobOutcomes)
     .where(
       and(
-        eq(notes.workspaceId, job.workspaceId),
-        eq(notes.topic, consecutiveFailureMarkerTopic(job.id)),
+        eq(jobOutcomes.supervisorStatus, "pending_review"),
+        lt(jobOutcomes.createdAt, pendingReviewCutoff),
       ),
-    );
-}
+    )
+    .orderBy(jobOutcomes.createdAt)
+    .limit(ORPHAN_SWEEP_BATCH_SIZE);
 
-async function maybeEscalateConsecutiveRecurringFailures(
-  failedJobs: Array<typeof jobs.$inferSelect>,
-): Promise<number> {
-  let escalated = 0;
+  for (const outcome of pendingReviewOutcomes) {
+    triggerSupervisorReview(outcome.id);
+  }
+  pendingReviewRefired = pendingReviewOutcomes.length;
 
-  for (const job of failedJobs) {
-    const recentExecutions = await db
-      .select({
-        id: jobExecutions.id,
-        status: jobExecutions.status,
-        startedAt: jobExecutions.startedAt,
-        error: jobExecutions.error,
-      })
-      .from(jobExecutions)
-      .where(eq(jobExecutions.jobId, job.id))
-      .orderBy(desc(jobExecutions.startedAt))
-      .limit(CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD);
+  const inProgressOutcomes = await db
+    .select({
+      id: jobOutcomes.id,
+      jobId: jobOutcomes.jobId,
+      supervisorAttempts: jobOutcomes.supervisorAttempts,
+    })
+    .from(jobOutcomes)
+    .where(
+      and(
+        eq(jobOutcomes.supervisorStatus, "in_progress"),
+        lt(jobOutcomes.supervisorStartedAt, inProgressCutoff),
+      ),
+    )
+    .orderBy(jobOutcomes.supervisorStartedAt)
+    .limit(ORPHAN_SWEEP_BATCH_SIZE);
 
-    if (
-      recentExecutions.length < CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD ||
-      recentExecutions.some((execution) => execution.status !== "failed")
-    ) {
-      if (recentExecutions.some((execution) => execution.status === "completed")) {
-        await clearConsecutiveFailureMarker(job);
+  for (const outcome of inProgressOutcomes) {
+    if (outcome.supervisorAttempts < MAX_SUPERVISOR_ATTEMPTS) {
+      const reset = await db
+        .update(jobOutcomes)
+        .set({
+          supervisorStatus: "pending_review",
+          supervisorInvocationId: null,
+          supervisorStartedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(jobOutcomes.id, outcome.id),
+            eq(jobOutcomes.supervisorStatus, "in_progress"),
+            lt(jobOutcomes.supervisorAttempts, MAX_SUPERVISOR_ATTEMPTS),
+          ),
+        )
+        .returning({ id: jobOutcomes.id });
+
+      if (reset.length > 0) {
+        inProgressReset++;
+        triggerSupervisorReview(outcome.id);
       }
       continue;
     }
 
-    const markerTopic = consecutiveFailureMarkerTopic(job.id);
-    const [existingMarker] = await db
-      .select({ id: notes.id, updatedAt: notes.updatedAt })
-      .from(notes)
-      .where(and(eq(notes.workspaceId, job.workspaceId), eq(notes.topic, markerTopic)))
+    const skipped = await db
+      .update(jobOutcomes)
+      .set({
+        supervisorStatus: "skipped",
+        supervisorReasoning: "max supervisor attempts exceeded",
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(jobOutcomes.id, outcome.id),
+          eq(jobOutcomes.supervisorStatus, "in_progress"),
+          gte(jobOutcomes.supervisorAttempts, MAX_SUPERVISOR_ATTEMPTS),
+        ),
+      )
+      .returning({ id: jobOutcomes.id, jobId: jobOutcomes.jobId });
+
+    if (skipped.length === 0) continue;
+
+    inProgressSkipped++;
+    const [job] = await db
+      .select({ id: jobs.id, name: jobs.name, requestedBy: jobs.requestedBy })
+      .from(jobs)
+      .where(eq(jobs.id, outcome.jobId))
       .limit(1);
 
-    if (existingMarker) {
-      const successfulExecutionsSinceMarker = await db
-        .select({ id: jobExecutions.id })
-        .from(jobExecutions)
-        .where(
-          and(
-            eq(jobExecutions.jobId, job.id),
-            eq(jobExecutions.status, "completed"),
-            gt(jobExecutions.startedAt, existingMarker.updatedAt),
-          ),
-        )
-        .limit(1);
-
-      if (successfulExecutionsSinceMarker.length === 0) {
-        logger.info("recurring_job_failure_streak_dm_deduped", {
-          jobId: job.id,
-          jobName: job.name,
-          threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
-        });
-        continue;
-      }
-
-      await clearConsecutiveFailureMarker(job);
+    if (job) {
+      await notifySupervisorRetriesExhausted(job);
     }
-
-    const streakStart = recentExecutions[recentExecutions.length - 1];
-    const latestFailure = recentExecutions[0];
-    const lastError = truncateJobFailureText(latestFailure.error ?? job.lastResult);
-
-    const sent = await sendJobFailureDm({
-      jobId: job.id,
-      requestedBy: job.requestedBy,
-      text: `Your recurring job \`${job.name}\` has failed ${CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD} consecutive runs. Last error: ${lastError}. It's been broken since ${streakStart.startedAt.toISOString()}. Disable it with \`cancel_job\` if it's no longer needed, or fix it.`,
-      logContext: {
-        event: "recurring_job_consecutive_failures",
-        threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
-        streakStartedAt: streakStart.startedAt.toISOString(),
-      },
-    });
-
-    if (!sent) continue;
-
-    const now = new Date();
-    await db
-      .insert(notes)
-      .values({
-        workspaceId: job.workspaceId,
-        topic: markerTopic,
-        content: JSON.stringify({
-          jobId: job.id,
-          threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
-          latestFailureStartedAt: latestFailure.startedAt.toISOString(),
-          streakStartedAt: streakStart.startedAt.toISOString(),
-        }),
-        category: "job_failure_streak_marker",
-        injectInContext: false,
-        ownerId: job.requestedBy,
-        visibility: "private",
-        updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [notes.workspaceId, notes.topic],
-        set: {
-          content: JSON.stringify({
-            jobId: job.id,
-            threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
-            latestFailureStartedAt: latestFailure.startedAt.toISOString(),
-            streakStartedAt: streakStart.startedAt.toISOString(),
-          }),
-          updatedAt: now,
-        },
-      });
-
-    escalated++;
-    logger.warn("recurring_job_consecutive_failures_escalated", {
-      jobId: job.id,
-      jobName: job.name,
-      threshold: CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD,
-      streakStartedAt: streakStart.startedAt.toISOString(),
-    });
   }
 
-  return escalated;
+  const dequeuedJobs = await db
+    .select({
+      id: jobs.id,
+      workspaceId: jobs.workspaceId,
+      name: jobs.name,
+      executeAt: jobs.executeAt,
+      updatedAt: jobs.updatedAt,
+    })
+    .from(jobs)
+    .where(
+      and(
+        eq(jobs.status, "running"),
+        or(isNull(jobs.lastExecutedAt), lt(jobs.lastExecutedAt, dequeuedWithoutExecutionCutoff)),
+        sql`NOT EXISTS (
+          SELECT 1
+          FROM ${jobExecutions}
+          WHERE ${jobExecutions.jobId} = ${jobs.id}
+            AND ${jobExecutions.startedAt} >= COALESCE(${jobs.executeAt}, ${jobs.updatedAt}) - interval '1 minute'
+        )`,
+      ),
+    )
+    .orderBy(jobs.updatedAt)
+    .limit(ORPHAN_SWEEP_BATCH_SIZE);
+
+  for (const job of dequeuedJobs) {
+    const outcomeId = await persistJobOutcome({
+      workspaceId: job.workspaceId,
+      jobId: job.id,
+      jobExecutionId: null,
+      outcomeStatus: "process_died_pre_execution",
+      output: {
+        type: "process_died_pre_execution",
+        recovered_by: "heartbeat",
+        execute_at: job.executeAt?.toISOString() ?? null,
+        dequeued_at: job.updatedAt.toISOString(),
+      },
+      error: "Job was dequeued but no execution row was created",
+      lastNSteps: [],
+    });
+
+    await db
+      .update(jobs)
+      .set({
+        status: "failed",
+        result: "Failed: worker died before creating a job execution row",
+        updatedAt: new Date(),
+      })
+      .where(and(eq(jobs.id, job.id), eq(jobs.status, "running")));
+
+    dequeuedWithoutExecution++;
+    triggerSupervisorReview(outcomeId);
+  }
+
+  logger.info("Heartbeat: orphaned outcome sweep completed", {
+    pendingReviewRefired,
+    inProgressReset,
+    inProgressSkipped,
+    dequeuedWithoutExecution,
+  });
+
+  return {
+    pendingReviewRefired,
+    inProgressReset,
+    inProgressSkipped,
+    dequeuedWithoutExecution,
+  };
 }
 
 // ── Heartbeat Cron App ───────────────────────────────────────────────────────
@@ -229,8 +301,10 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
   let plansExpired = 0;
   let plansAbandoned = 0;
   let staleRunningRecovered = 0;
-  let consecutiveFailureEscalations = 0;
-  const recurringJobsWithFreshFailures = new Map<string, typeof jobs.$inferSelect>();
+  let pendingReviewOutcomesRefired = 0;
+  let inProgressOutcomesReset = 0;
+  let inProgressOutcomesSkipped = 0;
+  let dequeuedWithoutExecutionRecovered = 0;
 
   try {
     const now = new Date();
@@ -291,9 +365,6 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
             jobName: job.name,
             error: error.message,
           });
-          if (job.cronSchedule != null) {
-            recurringJobsWithFreshFailures.set(job.id, job);
-          }
           failed++;
         }
       }
@@ -336,6 +407,12 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       });
     }
 
+    const orphanSweepResult = await sweepOrphanedOutcomes(now);
+    pendingReviewOutcomesRefired = orphanSweepResult.pendingReviewRefired;
+    inProgressOutcomesReset = orphanSweepResult.inProgressReset;
+    inProgressOutcomesSkipped = orphanSweepResult.inProgressSkipped;
+    dequeuedWithoutExecutionRecovered = orphanSweepResult.dequeuedWithoutExecution;
+
     // ── 5. Recover jobs stuck in "running" ─────────────────────────────
 
     const staleRunningCutoff = new Date(now.getTime() - STALE_RUNNING_THRESHOLD_MS);
@@ -370,8 +447,6 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
     const failedExhaustedJobs: Array<{ id: string; name: string }> = [];
 
     for (const job of staleExhausted) {
-      const lastError = truncateJobFailureText(job.lastResult);
-
       if (job.cronSchedule != null) {
         try {
           const executeAt = computeNextCronTick(job.cronSchedule, job.timezone, now);
@@ -395,12 +470,6 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
             executeAt: executeAt.toISOString(),
           });
 
-          await sendJobFailureDm({
-            jobId: job.id,
-            requestedBy: job.requestedBy,
-            text: `Recurring job \`${job.name}\` exhausted retries (last error: ${lastError}). Auto-recovered. Next attempt: ${executeAt.toISOString()}.`,
-            logContext: { event: "recurring_job_recovered_after_exhaustion" },
-          });
         } catch (error: any) {
           await db
             .update(jobs)
@@ -419,13 +488,6 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
             timezone: job.timezone,
             error: error?.message,
           });
-
-          await sendJobFailureDm({
-            jobId: job.id,
-            requestedBy: job.requestedBy,
-            text: `Recurring job \`${job.name}\` exhausted retries but could not be auto-recovered. Last error: ${lastError}.`,
-            logContext: { event: "recurring_job_recovery_failed" },
-          });
         }
       } else {
         await db
@@ -438,13 +500,6 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
           .where(eq(jobs.id, job.id));
 
         failedExhaustedJobs.push({ id: job.id, name: job.name });
-
-        await sendJobFailureDm({
-          jobId: job.id,
-          requestedBy: job.requestedBy,
-          text: `Job ${job.name} exhausted retries. Last error: ${lastError}.`,
-          logContext: { event: "one_shot_job_exhausted_retries" },
-        });
       }
     }
 
@@ -539,32 +594,6 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       });
     }
 
-    // Also escalate recurring jobs that are *already* in status=failed
-    // (parked from prior sweeps). Without this, jobs that died days ago
-    // never trigger a DM because they no longer enter the pending->due path
-    // and therefore don't land in `recurringJobsWithFreshFailures`.
-    // The marker-note dedupe inside maybeEscalateConsecutiveRecurringFailures
-    // ensures we only DM once per streak.
-    const stuckFailedRecurringJobs = await db
-      .select()
-      .from(jobs)
-      .where(
-        and(
-          eq(jobs.status, "failed"),
-          eq(jobs.enabled, 1),
-          sql`${jobs.cronSchedule} IS NOT NULL`,
-        ),
-      );
-
-    const escalationCandidates = new Map<string, typeof jobs.$inferSelect>(
-      recurringJobsWithFreshFailures,
-    );
-    for (const job of stuckFailedRecurringJobs) escalationCandidates.set(job.id, job);
-
-    consecutiveFailureEscalations = await maybeEscalateConsecutiveRecurringFailures(
-      [...escalationCandidates.values()],
-    );
-
     // ── Done ─────────────────────────────────────────────────────────────
 
     const duration = Date.now() - sweepStart;
@@ -574,7 +603,10 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       plansExpired,
       plansAbandoned,
       staleRunningRecovered,
-      consecutiveFailureEscalations,
+      pendingReviewOutcomesRefired,
+      inProgressOutcomesReset,
+      inProgressOutcomesSkipped,
+      dequeuedWithoutExecutionRecovered,
     });
 
     return c.json({
@@ -584,7 +616,10 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       plansExpired,
       plansAbandoned,
       staleRunningRecovered,
-      consecutiveFailureEscalations,
+      pendingReviewOutcomesRefired,
+      inProgressOutcomesReset,
+      inProgressOutcomesSkipped,
+      dequeuedWithoutExecutionRecovered,
       duration,
     });
   } catch (error: any) {

--- a/packages/db/drizzle/0067_process_died_pre_execution_outcome.sql
+++ b/packages/db/drizzle/0067_process_died_pre_execution_outcome.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "job_outcomes" DROP CONSTRAINT IF EXISTS "job_outcomes_outcome_status_check";--> statement-breakpoint
+ALTER TABLE "job_outcomes" ADD CONSTRAINT "job_outcomes_outcome_status_check" CHECK ("outcome_status" IN ('succeeded', 'errored', 'interrupted', 'process_died_pre_execution'));--> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1779440280000,
       "tag": "0066_job_outcomes",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1779440400000,
+      "tag": "0067_process_died_pre_execution_outcome",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -589,7 +589,11 @@ export const jobExecutions = pgTable(
   ],
 );
 
-export type JobOutcomeStatus = "succeeded" | "errored" | "interrupted";
+export type JobOutcomeStatus =
+  | "succeeded"
+  | "errored"
+  | "interrupted"
+  | "process_died_pre_execution";
 export type JobOutcomeSupervisorStatus = "pending_review" | "in_progress" | "resolved" | "skipped";
 export type JobOutcomeSupervisorDecision =
   | "retry_as_is"
@@ -637,7 +641,7 @@ export const jobOutcomes = pgTable(
       .where(sql`job_execution_id IS NOT NULL`),
     check(
       "job_outcomes_outcome_status_check",
-      sql`${table.outcomeStatus} IN ('succeeded', 'errored', 'interrupted')`,
+      sql`${table.outcomeStatus} IN ('succeeded', 'errored', 'interrupted', 'process_died_pre_execution')`,
     ),
     check(
       "job_outcomes_supervisor_status_check",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final PR for the supervisor-pattern job execution work.

Prerequisites: #1016 and #1017 should land before this PR.

## Sweep cases handled

1. Refires supervisor webhooks for `pending_review` outcomes older than 5 minutes.
2. Resets stale `in_progress` supervisor outcomes older than 10 minutes back to `pending_review` when attempts are below 3.
3. Marks stale `in_progress` supervisor outcomes as `skipped` and DMs the requester when attempts are exhausted.
4. Writes `process_died_pre_execution` outcomes for jobs that were dequeued into `running` but never created a `job_executions` row, then fails the job and triggers supervisor review.
5. Keeps existing stale-running recovery while removing legacy recurring failure escalation and direct execute-job failure DMs so supervisor decisions own escalation/reporting.

Closes #1015.

## Validation

- `pnpm --filter aura-api exec vitest run src/cron/heartbeat.test.ts`
- `pnpm --filter aura-api exec vitest run src/cron`
- `pnpm typecheck`
- `npx tsc --noEmit` (apps/api)
- `rg 'maybeEscalateConsecutiveRecurringFailures|job_failure_streak' apps` -> no matches
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54def48b-0593-4753-a739-eaeafc6117a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54def48b-0593-4753-a739-eaeafc6117a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

