### PR TITLE
Fix Cursor agent finished PR links

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -911,6 +911,7 @@ app.post("/api/webhook/cursor-agent", async (c) => {
       let requester = "";
       let channelId = "";
       let threadTs = "";
+      let repo = process.env.AURA_REPO_DEFAULT || "AuraHQ-ai/aura";
 
       if (agentId) {
         const trackingRows = await db
@@ -926,11 +927,13 @@ app.post("/api/webhook/cursor-agent", async (c) => {
           );
           const channelMatch = content.match(/\*\*Channel\*\*:\s*(\S+)/);
           const threadMatch = content.match(/\*\*Thread\*\*:\s*(\S+)/);
+          const repoMatch = content.match(/\*\*Repo\*\*:\s*(\S+)/);
           if (requesterMatch && requesterMatch[1] !== "unknown")
             requester = requesterMatch[1];
           if (channelMatch) channelId = channelMatch[1];
           if (threadMatch && threadMatch[1] !== "none")
             threadTs = threadMatch[1];
+          if (repoMatch) repo = repoMatch[1];
         }
       }
 
@@ -952,16 +955,34 @@ app.post("/api/webhook/cursor-agent", async (c) => {
         status.toLowerCase() === "error" ||
         status.toLowerCase() === "failed";
 
+      let resolvedPrUrl = prUrl;
+      if (isFinished && !resolvedPrUrl && branchName) {
+        try {
+          const { getCredential } = await import("./lib/credentials.js");
+          const { resolveCursorAgentPrUrl } = await import(
+            "./lib/cursor-agent.js"
+          );
+          const ghToken = await getCredential("github_token");
+          resolvedPrUrl = await resolveCursorAgentPrUrl({
+            branchName,
+            repo,
+            githubToken: ghToken,
+          });
+        } catch {
+          /* fall back to current behavior */
+        }
+      }
+
       let prTitle = "";
-      if (prUrl) {
-        const prMatch = prUrl.match(/\/pull\/(\d+)$/);
+      if (resolvedPrUrl) {
+        const prMatch = resolvedPrUrl.match(/\/pull\/(\d+)$/);
         if (prMatch) {
           try {
             const { getCredential } = await import("./lib/credentials.js");
             const ghToken = await getCredential("github_token");
             if (ghToken) {
               const prNumber = prMatch[1];
-              const repoMatch = prUrl.match(
+              const repoMatch = resolvedPrUrl.match(
                 /github\.com\/([^/]+\/[^/]+)\/pull/,
               );
               if (repoMatch) {
@@ -993,10 +1014,12 @@ app.post("/api/webhook/cursor-agent", async (c) => {
           .replace(/</g, "&lt;")
           .replace(/>/g, "&gt;")
           .replace(/\|/g, "\u2758");
-        const prLine = prUrl
+        const isPullRequestUrl = /\/pull\/\d+$/.test(resolvedPrUrl);
+        const linkLabel = safePrTitle || (isPullRequestUrl ? "PR" : "branch");
+        const prLine = resolvedPrUrl
           ? safePrTitle
-            ? `\u2705 *<${prUrl}|${safePrTitle}>*`
-            : `\u2705 *<${prUrl}|PR>*`
+            ? `\u2705 *<${resolvedPrUrl}|${safePrTitle}>*`
+            : `\u2705 *<${resolvedPrUrl}|${linkLabel}>*`
           : "\u2705 Agent finished";
         const branchLine = branchName
           ? `\n_Branch:_ \`${branchName}\``

--- a/apps/api/src/lib/cursor-agent.test.ts
+++ b/apps/api/src/lib/cursor-agent.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
+
+const { resolveCursorAgentPrUrl } = await import("./cursor-agent.js");
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    json: vi.fn(async () => data),
+  } as unknown as Response;
+}
+
+describe("resolveCursorAgentPrUrl", () => {
+  it("passes through the payload PR URL when present", async () => {
+    const fetchMock = vi.fn();
+
+    const result = await resolveCursorAgentPrUrl({
+      prUrl: "https://github.com/AuraHQ-ai/aura/pull/123",
+      branchName: "cursor/fix-issue-1019",
+      repo: "AuraHQ-ai/aura",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("https://github.com/AuraHQ-ai/aura/pull/123");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("looks up the open PR from the branch when the payload PR URL is absent", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const requestUrl = new URL(url);
+      expect(requestUrl.pathname).toBe("/repos/AuraHQ-ai/aura/pulls");
+      expect(requestUrl.searchParams.get("head")).toBe(
+        "AuraHQ-ai:cursor/fix-issue-1019",
+      );
+      expect(requestUrl.searchParams.get("state")).toBe("open");
+      expect(init?.headers).toMatchObject({ Authorization: "token gh-token" });
+      return jsonResponse([
+        { html_url: "https://github.com/AuraHQ-ai/aura/pull/456" },
+      ]);
+    });
+
+    const result = await resolveCursorAgentPrUrl({
+      branchName: "cursor/fix-issue-1019",
+      repo: "AuraHQ-ai/aura",
+      githubToken: "gh-token",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("https://github.com/AuraHQ-ai/aura/pull/456");
+  });
+
+  it("falls back to the branch tree when no open PR matches the branch", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse([]));
+
+    const result = await resolveCursorAgentPrUrl({
+      branchName: "cursor/fix-issue-1019",
+      repo: "AuraHQ-ai/aura",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe(
+      "https://github.com/AuraHQ-ai/aura/tree/cursor/fix-issue-1019",
+    );
+  });
+
+  it("falls back gracefully when GitHub PR lookup throws", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("github down");
+    });
+
+    const result = await resolveCursorAgentPrUrl({
+      branchName: "cursor/fix-issue-1019",
+      repo: "AuraHQ-ai/aura",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("");
+  });
+});

--- a/apps/api/src/lib/cursor-agent.ts
+++ b/apps/api/src/lib/cursor-agent.ts
@@ -46,6 +46,52 @@ export interface CursorAgentStatus {
   finishedAt?: string;
 }
 
+export interface ResolveCursorAgentPrUrlParams {
+  prUrl?: string;
+  branchName?: string;
+  repo: string;
+  githubToken?: string | null;
+  fetchImpl?: typeof fetch;
+}
+
+export async function resolveCursorAgentPrUrl({
+  prUrl,
+  branchName,
+  repo,
+  githubToken,
+  fetchImpl = fetch,
+}: ResolveCursorAgentPrUrlParams): Promise<string> {
+  if (prUrl) return prUrl;
+  if (!branchName) return "";
+
+  try {
+    const owner = repo.split("/")[0];
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github.v3+json",
+    };
+    if (githubToken) headers.Authorization = `token ${githubToken}`;
+
+    const lookupUrl = new URL(`https://api.github.com/repos/${repo}/pulls`);
+    lookupUrl.searchParams.set("head", `${owner}:${branchName}`);
+    lookupUrl.searchParams.set("state", "open");
+
+    const ghRes = await fetchImpl(lookupUrl.toString(), { headers });
+    if (!ghRes.ok) return "";
+
+    const pulls = (await ghRes.json()) as unknown;
+    if (Array.isArray(pulls)) {
+      const firstPrUrl = pulls[0]?.html_url;
+      if (typeof firstPrUrl === "string" && firstPrUrl) {
+        return firstPrUrl;
+      }
+    }
+
+    return `https://github.com/${repo}/tree/${branchName}`;
+  } catch {
+    return "";
+  }
+}
+
 export async function launchCursorAgent(
   params: LaunchCursorAgentParams,
 ): Promise<CursorAgentResponse> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Resolve missing Cursor finished webhook PR URLs by looking up open PRs from the finished branch via GitHub
- Fall back to a clickable branch tree link when the lookup succeeds but finds no PR
- Preserve current graceful behavior when GitHub lookup fails

## Tests
- `pnpm --filter aura-api exec vitest run src/lib/cursor-agent.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
- `pnpm --filter aura-api test`

Fixes #1019
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5719508-1078-48d9-8777-51ad53910b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5719508-1078-48d9-8777-51ad53910b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

