### PR TITLE
docs(jobs): document supervisor pattern + orphan sweeps

### DIFF
--- a/content/docs/tools/jobs.mdx
+++ b/content/docs/tools/jobs.mdx
@@ -16,6 +16,32 @@ The **heartbeat** runs every 30 minutes and evaluates all pending jobs. Scheduli
 
 If a recurring job is left in `running` past the stale threshold and has already exhausted retries, the heartbeat does not leave it in `failed` forever. It resets the job to `pending`, clears `retries`, computes the next cron tick in the job timezone, and DMs the requester with the last error and next attempt time. One-shot jobs that exhaust stale retries stay `failed` and also send a DM.
 
+
+## Supervisor pattern
+
+After every job execution finishes (success, error, or interruption), the heartbeat writes a row to the `job_outcomes` table and fires a webhook to `POST /api/cron/supervisor`. The supervisor is a separately invoked endpoint that runs a fast-model LLM (`generateObject`) over the outcome plus recent job context and picks exactly one decision:
+
+| Decision | What it does |
+|----------|--------------|
+| `report_success` | DMs the requester that the job succeeded. No retry. |
+| `report_failure` | DMs the requester with the error. No retry. |
+| `retry_as_is` | Resets the job to `pending` with `retries=0`, sets `executeAt=now`, DMs the requester. |
+| `retry_with_fix` | Queues an immediate retry **and** opens a GitHub issue labelled `auto-supervisor-fix` on `AuraHQ-ai/aura`. |
+| `escalate` | DMs both the requester and the configured founder (`FOUNDER_USER_ID`) for human review. |
+| `disable_job` | Sets `enabled=0` on the job and DMs the requester with the reason. |
+
+Each outcome can be processed up to **3 times** (`MAX_SUPERVISOR_ATTEMPTS`). After that the outcome is marked `skipped` and the requester gets a fallback DM.
+
+### Orphan sweeps
+
+The heartbeat also reaps supervisor invocations that never completed:
+
+- `pending_review` outcomes older than 5 minutes are re-fired (webhook lost or never delivered).
+- `in_progress` outcomes older than 10 minutes with attempts left are reset to `pending_review`.
+- `in_progress` outcomes older than 10 minutes that have exhausted attempts are marked `skipped` and the requester is DM'd.
+- Jobs dequeued into `running` for which no execution row appears after 10 minutes get a `process_died_pre_execution` outcome written so the supervisor can still see and route them.
+
+
 ---
 
 ## `create_job`

--- a/content/docs/tools/jobs.mdx
+++ b/content/docs/tools/jobs.mdx
@@ -23,7 +23,8 @@ After every job execution finishes (success, error, or interruption), the heartb
 
 | Decision | What it does |
 |----------|--------------|
-| `report_success` | DMs the requester that the job succeeded. No retry. |
+| `silent_success` | Outcome succeeded cleanly; resolved with no DM. Default for routine recurring runs when `notify_on_success` is false. |
+| `report_success` | DMs the requester that the job succeeded. No retry. Used for noteworthy successes (recovery after failure, first run after a code change, or `notify_on_success=true`); one-shot jobs typically use this. |
 | `report_failure` | DMs the requester with the error. No retry. |
 | `retry_as_is` | Resets the job to `pending` with `retries=0`, sets `executeAt=now`, DMs the requester. |
 | `retry_with_fix` | Queues an immediate retry **and** opens a GitHub issue labelled `auto-supervisor-fix` on `AuraHQ-ai/aura`. |
@@ -60,6 +61,7 @@ Create a one-shot task, recurring job, or follow-up.
 | `priority` | enum | no | `high`, `normal` (default), or `low` |
 | `max_per_day` | number | no | Max executions per day (recurring jobs) |
 | `min_interval_hours` | number | no | Minimum hours between executions |
+| `notify_on_success` | boolean | no | If `true`, the supervisor reports successful runs via DM. Defaults to `false` -- routine recurring successes are silent. |
 | `script` | string | no | Shell command to run before/instead of LLM. See [execution modes](#execution-modes) below. |
 
 ---


### PR DESCRIPTION
After PRs #1016 / #1017 / #1018 landed the supervisor pattern, `content/docs/tools/jobs.mdx` had **zero** coverage of the new outcome-based execution flow.

### Changes
Adds two subsections under the heartbeat description in `jobs.mdx`:

- **Supervisor pattern** -- explains the `job_outcomes` write → `POST /api/cron/supervisor` webhook → `generateObject` decision flow, with a table of the six fixed decisions (`report_success`, `report_failure`, `retry_as_is`, `retry_with_fix`, `escalate`, `disable_job`) and the `MAX_SUPERVISOR_ATTEMPTS=3` cap.
- **Orphan sweeps** -- covers the heartbeat reaper: `pending_review` outcomes refired after 5m, `in_progress` outcomes reset/skipped after 10m, and the `process_died_pre_execution` outcome written for jobs dequeued into `running` that never produce an execution row after 10m.

### Verification
All claims cross-checked against:
- `apps/api/src/cron/supervisor.ts` (decision enum, attempts cap, route)
- `apps/api/src/cron/heartbeat.ts` (orphan thresholds: `PENDING_REVIEW_ORPHAN_THRESHOLD_MS=5min`, `IN_PROGRESS_ORPHAN_THRESHOLD_MS=10min`, `DEQUEUED_WITHOUT_EXECUTION_THRESHOLD_MS=10min`)
- `apps/api/src/cron/job-outcomes.ts` (outcome persistence + supervisor trigger)

### Follow-up not in this PR (kept to one PR per run)
`architecture.mdx` "Heartbeat & Cron" section still uses the legacy 5-step model and should mention the supervisor pattern -- queued for tomorrow's docs-maintenance run.