### PR TITLE
fix(supervisor): silence routine recurring success DMs (#1024)

### DIFF
--- a/apps/api/src/cron/supervisor.test.ts
+++ b/apps/api/src/cron/supervisor.test.ts
@@ -143,6 +143,7 @@ function baseJob(overrides: Record<string, unknown> = {}) {
     playbook: null,
     script: null,
     cronSchedule: null,
+    notifyOnSuccess: false,
     frequencyConfig: null,
     channelId: null,
     threadTs: null,
@@ -183,6 +184,39 @@ function baseExecution(overrides: Record<string, unknown> = {}) {
     error: "model stream dropped",
     ...overrides,
   };
+}
+
+function promptContextFromGenerateCall() {
+  const prompt = String(generateObjectMock.mock.calls.at(-1)?.[0]?.prompt ?? "");
+  const contextJson = prompt.match(/Context:\n([\s\S]*)$/)?.[1];
+  if (!contextJson) throw new Error("Supervisor prompt did not include JSON context");
+  return JSON.parse(contextJson) as {
+    job: { cron_schedule: string | null; notify_on_success: boolean };
+    last_5_executions: Array<{ status: string; error: string | null }>;
+  };
+}
+
+function mockCleanSuccessDecisionPolicy() {
+  generateObjectMock.mockImplementation(async (args: { prompt: string }) => {
+    const contextJson = args.prompt.match(/Context:\n([\s\S]*)$/)?.[1];
+    if (!contextJson) throw new Error("Supervisor prompt did not include JSON context");
+    const context = JSON.parse(contextJson) as {
+      job: { cron_schedule: string | null; notify_on_success: boolean };
+      last_5_executions: Array<{ status: string; error: string | null }>;
+    };
+    const recoveredFromFailure = context.last_5_executions.some(
+      (execution) => execution.status === "failed" || execution.error,
+    );
+    const shouldReport =
+      context.job.notify_on_success || context.job.cron_schedule === null || recoveredFromFailure;
+
+    return {
+      object: {
+        decision: shouldReport ? "report_success" : "silent_success",
+        reasoning: shouldReport ? "Success should be reported." : "Routine recurring success.",
+      },
+    };
+  });
 }
 
 async function invokeSupervisor() {
@@ -282,6 +316,7 @@ describe("supervisor cron", () => {
   });
 
   it.each([
+    ["silent_success", { outcomeStatus: "succeeded", error: null }, { dmCount: 0 }],
     ["report_success", { outcomeStatus: "succeeded", error: null }, { dmCount: 1 }],
     ["report_failure", {}, { dmCount: 1 }],
     ["retry_as_is", {}, { dmCount: 1, jobUpdate: { status: "pending", retries: 0 } }],
@@ -339,6 +374,71 @@ describe("supervisor cron", () => {
       });
     },
   );
+
+  it.each([
+    {
+      name: "recurring clean success silently resolves",
+      job: baseJob({ cronSchedule: "50 8 * * 1-5", notifyOnSuccess: false }),
+      executions: [baseExecution({ status: "succeeded", error: null, summary: "No changes needed" })],
+      expectedDecision: "silent_success",
+      expectedDmCount: 0,
+    },
+    {
+      name: "one-shot clean success reports completion",
+      job: baseJob({ cronSchedule: null, notifyOnSuccess: false }),
+      executions: [baseExecution({ status: "succeeded", error: null, summary: "Task completed" })],
+      expectedDecision: "report_success",
+      expectedDmCount: 1,
+    },
+    {
+      name: "recurring clean success with notify_on_success reports completion",
+      job: baseJob({ cronSchedule: "0 9 * * *", notifyOnSuccess: true }),
+      executions: [baseExecution({ status: "succeeded", error: null, summary: "Task completed" })],
+      expectedDecision: "report_success",
+      expectedDmCount: 1,
+    },
+    {
+      name: "recovered clean success reports completion",
+      job: baseJob({ cronSchedule: "0 9 * * *", notifyOnSuccess: false }),
+      executions: [
+        baseExecution({ status: "succeeded", error: null, summary: "Recovered" }),
+        baseExecution({
+          id: "00000000-0000-4000-8000-000000000021",
+          status: "failed",
+          error: "Previous run failed",
+        }),
+      ],
+      expectedDecision: "report_success",
+      expectedDmCount: 1,
+    },
+  ])("$name", async ({ job, executions, expectedDecision, expectedDmCount }) => {
+    mockCleanSuccessDecisionPolicy();
+    queueDbResults(
+      [baseOutcome({ outcomeStatus: "succeeded", error: null })],
+      [job],
+      executions,
+    );
+
+    const response = await invokeSupervisor();
+    const body = await response.json();
+    const prompt = String(generateObjectMock.mock.calls[0][0].prompt);
+    const promptContext = promptContextFromGenerateCall();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ ok: true, decision: expectedDecision });
+    expect(prompt).toContain("silent_success");
+    expect(prompt).toContain("default for routine recurring runs");
+    expect(prompt).toContain("notify_on_success is true");
+    expect(promptContext.job).toMatchObject({
+      cron_schedule: job.cronSchedule,
+      notify_on_success: job.notifyOnSuccess,
+    });
+    expect(sendJobFailureDmMock).toHaveBeenCalledTimes(expectedDmCount);
+    expect(finalOutcomeUpdate()).toMatchObject({
+      supervisorStatus: "resolved",
+      supervisorDecision: expectedDecision,
+    });
+  });
 
   it("returns errored outcomes to pending_review when the LLM fails", async () => {
     generateObjectMock.mockRejectedValue(new Error("gateway unavailable"));

--- a/apps/api/src/cron/supervisor.ts
+++ b/apps/api/src/cron/supervisor.ts
@@ -23,6 +23,7 @@ const supervisorDecisionSchema = z.object({
   decision: z.enum([
     "retry_as_is",
     "retry_with_fix",
+    "silent_success",
     "report_success",
     "report_failure",
     "escalate",
@@ -143,7 +144,8 @@ async function runSupervisorLlm(context: SupervisorContext): Promise<SupervisorD
       prompt: truncateForPrompt(`Review this completed job outcome and decide the next action.
 
 Decision meanings:
-- report_success: outcome succeeded and the requester should be told.
+- silent_success: outcome succeeded cleanly and should be resolved with no DM. This is the default for routine recurring runs when cron_schedule is set and notify_on_success is false.
+- report_success: outcome succeeded and the requester should be told. Reserve this for noteworthy success: a job that had been failing recovered, the first successful run after a code change, or notify_on_success is true. One-shot jobs with no cron_schedule should usually report success.
 - report_failure: outcome failed in a way the requester should know about; do not retry.
 - retry_as_is: transient failure or likely timeout; retry immediately without changing the job.
 - retry_with_fix: likely Aura code/config bug; retry now and create an engineering issue.
@@ -171,6 +173,7 @@ ${jsonForPrompt({
     enabled: context.job.enabled,
     requested_by: context.job.requestedBy,
     cron_schedule: context.job.cronSchedule,
+    notify_on_success: context.job.notifyOnSuccess,
     frequency_config: context.job.frequencyConfig,
     last_result: context.job.lastResult,
   },
@@ -290,6 +293,10 @@ async function applySupervisorDecision(
   const link = jobLink(context.job.id);
 
   switch (decision.decision) {
+    case "silent_success": {
+      return;
+    }
+
     case "report_success": {
       await sendSupervisorDm(
         context.job,

--- a/packages/db/drizzle/0068_supervisor_silent_success.sql
+++ b/packages/db/drizzle/0068_supervisor_silent_success.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "jobs" ADD COLUMN "notify_on_success" boolean NOT NULL DEFAULT false;--> statement-breakpoint
+UPDATE "jobs" SET "notify_on_success" = true WHERE "cron_schedule" IS NULL;--> statement-breakpoint
+ALTER TABLE "job_outcomes" DROP CONSTRAINT IF EXISTS "job_outcomes_supervisor_decision_check";--> statement-breakpoint
+ALTER TABLE "job_outcomes" ADD CONSTRAINT "job_outcomes_supervisor_decision_check" CHECK ("supervisor_decision" IS NULL OR "supervisor_decision" IN ('retry_as_is', 'retry_with_fix', 'silent_success', 'report_success', 'report_failure', 'escalate', 'disable_job'));--> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1779440400000,
       "tag": "0067_process_died_pre_execution_outcome",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1779701400000,
+      "tag": "0068_supervisor_silent_success",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -535,6 +535,7 @@ export const jobs = pgTable(
     playbook: text("playbook"),
     script: text("script"),
     cronSchedule: text("cron_schedule"),
+    notifyOnSuccess: boolean("notify_on_success").notNull().default(false),
     frequencyConfig: jsonb("frequency_config").$type<FrequencyConfig>(),
     channelId: text("channel_id"),
     threadTs: text("thread_ts"),
@@ -598,6 +599,7 @@ export type JobOutcomeSupervisorStatus = "pending_review" | "in_progress" | "res
 export type JobOutcomeSupervisorDecision =
   | "retry_as_is"
   | "retry_with_fix"
+  | "silent_success"
   | "report_success"
   | "report_failure"
   | "escalate"
@@ -649,7 +651,7 @@ export const jobOutcomes = pgTable(
     ),
     check(
       "job_outcomes_supervisor_decision_check",
-      sql`${table.supervisorDecision} IS NULL OR ${table.supervisorDecision} IN ('retry_as_is', 'retry_with_fix', 'report_success', 'report_failure', 'escalate', 'disable_job')`,
+      sql`${table.supervisorDecision} IS NULL OR ${table.supervisorDecision} IN ('retry_as_is', 'retry_with_fix', 'silent_success', 'report_success', 'report_failure', 'escalate', 'disable_job')`,
     ),
   ],
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `silent_success` supervisor decision for clean recurring successes with no DM.
- Add `jobs.notify_on_success` with migration/backfill for one-shot jobs.
- Pass success-notification context into the supervisor prompt and cover the new decision policy in tests.

Fixes #1024

## Verification
- `pnpm typecheck`
- `pnpm --filter aura-api test`
- `npx tsc --noEmit` from `apps/api`

Note: `pnpm test` at the monorepo root exits non-zero without output because the root package has no `test` script.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebd84f73-ea7d-4757-b952-f3e09d62e67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebd84f73-ea7d-4757-b952-f3e09d62e67c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

