### PR TITLE
fix(http_request): accept pre-serialized string bodies without double-encoding (#1023)

### DIFF
--- a/apps/api/src/tools/http-request.test.ts
+++ b/apps/api/src/tools/http-request.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:dns/promises", () => ({
+  default: {
+    resolve4: vi.fn(async () => ["93.184.216.34"]),
+  },
+}));
+
+vi.mock("../lib/tool.js", () => ({
+  defineTool: (config: any) => config,
+}));
+
+vi.mock("../lib/api-credentials.js", () => ({
+  getApiCredentialWithType: vi.fn(),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { createHttpRequestTool } from "./http-request.js";
+
+function createResponse() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: vi.fn(async () => ({ ok: true })),
+    text: vi.fn(async () => ""),
+  };
+}
+
+describe("http_request body serialization", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => createResponse());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  function getLastFetchInit(): RequestInit {
+    const lastCall = fetchMock.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    return lastCall![1] as RequestInit;
+  }
+
+  function getTool() {
+    return createHttpRequestTool().http_request as any;
+  }
+
+  it("serializes object bodies once", async () => {
+    const tool = getTool();
+
+    await tool.execute({
+      method: "POST",
+      url: "https://example.com/api",
+      body: { hello: "world" },
+      timeout_ms: 30_000,
+    });
+
+    const init = getLastFetchInit();
+    expect(init.body).toBe('{"hello":"world"}');
+    expect(init.headers).toMatchObject({ "Content-Type": "application/json" });
+  });
+
+  it("sends string bodies verbatim", async () => {
+    const tool = getTool();
+
+    await tool.execute({
+      method: "POST",
+      url: "https://example.com/api",
+      body: '{"hello":"world"}',
+      timeout_ms: 30_000,
+    });
+
+    const init = getLastFetchInit();
+    expect(init.body).toBe('{"hello":"world"}');
+    expect(init.body).not.toBe(JSON.stringify('{"hello":"world"}'));
+    expect(init.headers).not.toHaveProperty("Content-Type");
+  });
+
+  it("omits the fetch body when no body is provided", async () => {
+    const tool = getTool();
+
+    await tool.execute({
+      method: "POST",
+      url: "https://example.com/api",
+      timeout_ms: 30_000,
+    });
+
+    const init = getLastFetchInit();
+    expect(init.body).toBeUndefined();
+  });
+});

--- a/apps/api/src/tools/http-request.ts
+++ b/apps/api/src/tools/http-request.ts
@@ -56,7 +56,13 @@ export function createHttpRequestTool(context?: ScheduleContext) {
             },
           )
           .describe("Additional headers (auth headers not allowed -- use credential_name)"),
-        body: z.unknown().optional().describe("Request body (will be JSON-serialized)"),
+        body: z
+          .unknown()
+          .optional()
+          .describe(
+            "Request body. Pass a JSON object/array -- it will be serialized automatically. " +
+              "If you pass a string it is sent verbatim (e.g. for form-encoded or pre-serialized payloads).",
+          ),
         timeout_ms: z
           .number()
           .default(30_000)
@@ -76,6 +82,13 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           }
 
           const headers: Record<string, string> = { ...input.headers };
+          let serializedBody: string | undefined;
+          if (input.body !== undefined && input.body !== null) {
+            serializedBody =
+              typeof input.body === "string"
+                ? input.body
+                : JSON.stringify(input.body);
+          }
 
           if (input.credential_name) {
             const owner = input.credential_owner ?? context?.userId;
@@ -106,7 +119,8 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           }
 
           if (
-            input.body &&
+            serializedBody !== undefined &&
+            typeof input.body !== "string" &&
             !Object.keys(headers).some(
               (k) => k.toLowerCase() === "content-type",
             )
@@ -123,7 +137,7 @@ export function createHttpRequestTool(context?: ScheduleContext) {
           const response = await fetch(input.url, {
             method: input.method,
             headers,
-            body: input.body ? JSON.stringify(input.body) : undefined,
+            body: serializedBody,
             redirect: "manual",
             signal: AbortSignal.timeout(input.timeout_ms),
           });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1023.

- Sends string `http_request` bodies verbatim instead of JSON-stringifying them again.
- Continues JSON-serializing object/array/number/boolean bodies automatically.
- Only defaults `Content-Type: application/json` for non-string bodies when the caller did not set a content type.
- Adds focused tests for object bodies, pre-serialized string bodies, and requests without bodies.

## Before / after wire examples

Before:

```ts
http_request({ method: "POST", url, body: '{"a":1}' })
```

sent this double-encoded body on the wire:

```json
"{\"a\":1}"
```

After:

```ts
http_request({ method: "POST", url, body: { a: 1 } })
http_request({ method: "POST", url, body: '{"a":1}' })
```

both send the same body on the wire:

```json
{"a":1}
```

## Verification

- `pnpm --filter aura-api test -- src/tools/http-request.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ff04f49-afd3-4b92-9f0b-66ee7ad889cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ff04f49-afd3-4b92-9f0b-66ee7ad889cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

