### PR TITLE
Fix dashboard session expiry handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ CRON_SECRET=your-cron-secret
 # ── Dashboard ────────────────────────────────────────────────────────────────
 DASHBOARD_API_SECRET=dev-secret-for-dashboard-chat
 DASHBOARD_SESSION_SECRET=your-session-secret
+# Optional. Defaults to 365d. Accepts jose duration strings like 30d, 365d, or 12h.
+# DASHBOARD_SESSION_TTL=365d
 
 # ── AI providers ─────────────────────────────────────────────────────────────
 ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/apps/api/src/routes/dashboard/auth.ts
+++ b/apps/api/src/routes/dashboard/auth.ts
@@ -16,10 +16,11 @@ function getSessionSecret(): Uint8Array {
 }
 
 export async function createSessionJwt(payload: { slackUserId: string; name: string; picture: string }): Promise<string> {
+  const sessionTtl = process.env.DASHBOARD_SESSION_TTL || "365d";
   return new SignJWT(payload)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
-    .setExpirationTime("7d")
+    .setExpirationTime(sessionTtl)
     .sign(getSessionSecret());
 }
 

--- a/apps/api/src/routes/dashboard/index.ts
+++ b/apps/api/src/routes/dashboard/index.ts
@@ -14,7 +14,7 @@ import { dashboardSettingsApp } from "./settings.js";
 import { dashboardModelsApp } from "./models.js";
 import { dashboardEntitiesApp } from "./entities.js";
 import { createDashboardApp } from "./schemas.js";
-import { jwtVerify } from "jose";
+import { errors, jwtVerify } from "jose";
 
 export const dashboardApp = createDashboardApp();
 
@@ -52,7 +52,10 @@ dashboardApp.use("*", async (c, next) => {
       c.set("userId" as never, payload.slackUserId as never);
       c.set("userName" as never, payload.name as never);
       return next();
-    } catch {
+    } catch (error) {
+      if (error instanceof errors.JWTExpired) {
+        return c.json({ error: "Unauthorized", reason: "token_expired" }, 401);
+      }
       // JWT verification failed — fall through to 401
     }
   }

--- a/apps/dashboard/src/components/auth-provider.tsx
+++ b/apps/dashboard/src/components/auth-provider.tsx
@@ -5,6 +5,7 @@ import {
   storeToken,
   clearToken,
   decodeToken,
+  redirectToSlackLogin,
   type Session,
 } from "@/lib/auth";
 
@@ -24,6 +25,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         : window.location.pathname;
       window.history.replaceState({}, "", cleanUrl);
       decodeToken(urlToken).then((s) => {
+        if (!s) {
+          clearToken();
+          redirectToSlackLogin("invalid_session");
+          return;
+        }
         setSession(s);
         setLoading(false);
       });
@@ -33,6 +39,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const token = getStoredToken();
     if (token) {
       decodeToken(token).then((s) => {
+        if (!s) {
+          clearToken();
+          setSession(null);
+          setLoading(false);
+          return;
+        }
         setSession(s);
         setLoading(false);
       });
@@ -44,6 +56,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = useCallback((token: string) => {
     storeToken(token);
     decodeToken(token).then((s) => {
+      if (!s) {
+        clearToken();
+        setSession(null);
+        return;
+      }
       setSession(s);
     });
   }, []);

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1,4 +1,5 @@
 import createClient from "openapi-fetch";
+import { redirectToSlackLogin, type AuthRedirectReason } from "./auth";
 import type { paths } from "./api-types";
 
 function getAuthToken(): string | null {
@@ -26,6 +27,15 @@ function buildQueryString(searchParams?: Record<string, string | undefined>): st
   return s ? `?${s}` : "";
 }
 
+function getUnauthorizedReason(text: string): AuthRedirectReason {
+  try {
+    const payload = JSON.parse(text) as { reason?: unknown };
+    return payload.reason === "token_expired" ? "token_expired" : "unauthorized";
+  } catch {
+    return "unauthorized";
+  }
+}
+
 async function apiFetch<T>(method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`/api/dashboard${path}`, {
     method,
@@ -34,6 +44,9 @@ async function apiFetch<T>(method: string, path: string, body?: unknown): Promis
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "Unknown error");
+    if (res.status === 401) {
+      redirectToSlackLogin(getUnauthorizedReason(text));
+    }
     throw new Error(`API ${method} ${path} failed (${res.status}): ${text}`);
   }
   return res.json();

--- a/apps/dashboard/src/lib/auth.ts
+++ b/apps/dashboard/src/lib/auth.ts
@@ -26,6 +26,8 @@ export function useAuth() {
 
 const SESSION_KEY = "aura_session";
 
+export type AuthRedirectReason = "token_expired" | "unauthorized" | "invalid_session";
+
 export function getStoredToken(): string | null {
   return localStorage.getItem(SESSION_KEY);
 }
@@ -38,12 +40,51 @@ export function clearToken() {
   localStorage.removeItem(SESSION_KEY);
 }
 
+function getCurrentReturnTo(): string {
+  const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  return window.location.pathname === "/login" ? "/" : path;
+}
+
+export function getSlackLoginUrl(returnTo = getCurrentReturnTo()): string {
+  const params = new URLSearchParams({
+    returnTo,
+    origin: window.location.origin,
+  });
+  return `/api/dashboard/auth/login?${params.toString()}`;
+}
+
+export function redirectToSlackLogin(reason: AuthRedirectReason = "unauthorized") {
+  clearToken();
+  const returnTo = getCurrentReturnTo();
+  const params = new URLSearchParams({
+    reason,
+    returnTo,
+  });
+
+  window.location.href = `/login?${params.toString()}`;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const payload = parts[1]!;
+  const normalized = payload
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(payload.length / 4) * 4, "=");
+
+  return JSON.parse(atob(normalized)) as Record<string, unknown>;
+}
+
 export async function decodeToken(token: string): Promise<Session | null> {
   try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const payload = JSON.parse(atob(parts[1]!));
+    const payload = decodeJwtPayload(token);
+    if (!payload) return null;
     if (payload.purpose) return null;
+    if (typeof payload.exp === "number" && payload.exp * 1000 <= Date.now()) {
+      return null;
+    }
     return {
       slackUserId: payload.slackUserId as string,
       name: (payload.name as string) || "User",

--- a/apps/dashboard/src/routes/login.tsx
+++ b/apps/dashboard/src/routes/login.tsx
@@ -1,12 +1,24 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getSlackLoginUrl } from "@/lib/auth";
+
+function getSafeReturnTo(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//") || value.startsWith("/api/")) {
+    return "/";
+  }
+  return value;
+}
 
 function LoginPage() {
-  const returnTo = window.location.pathname === "/login" ? "/" : window.location.pathname;
-  const origin = window.location.origin;
+  const params = new URLSearchParams(window.location.search);
+  const returnTo = getSafeReturnTo(params.get("returnTo"));
+  const reason = params.get("reason");
 
-  const loginUrl = `/api/dashboard/auth/login?returnTo=${encodeURIComponent(returnTo)}&origin=${encodeURIComponent(origin)}`;
+  const loginUrl = getSlackLoginUrl(returnTo);
+  const message = reason === "token_expired"
+    ? "Your dashboard session expired. Sign in with Slack to continue."
+    : "Sign in with your Slack account to continue.";
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">
@@ -14,7 +26,7 @@ function LoginPage() {
         <CardHeader className="text-center">
           <CardTitle className="text-xl">Aura Dashboard</CardTitle>
           <p className="text-sm text-muted-foreground">
-            Sign in with your Slack account to continue.
+            {message}
           </p>
         </CardHeader>
         <CardContent>

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -113,7 +113,7 @@ The dashboard uses Slack OAuth for login. Access requires at least the `power_us
 
 Authentication is handled directly by the Hono API via Slack's OpenID Connect flow. The API exposes `/login` and `/callback` routes that handle the full OAuth cycle -- no proxy or intermediate redirects needed.
 
-The callback issues a session JWT (HS256, 30-day expiry) stored as an HTTP-only cookie. For preview and branch deployments, an origin allowlist (restricted to trusted domain suffixes like `.aurahq.ai` and `localhost`) prevents token theft via crafted redirect URLs.
+The callback issues a session JWT (HS256, `DASHBOARD_SESSION_TTL` or `365d` by default) stored in the dashboard client. For preview and branch deployments, an origin allowlist (restricted to trusted domain suffixes like `.aurahq.ai` and `localhost`) prevents token theft via crafted redirect URLs.
 
 **Required env vars:** `DASHBOARD_SESSION_SECRET`, `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`.
 

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -26,6 +26,7 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `SLACK_USER_TOKEN` | Slack user token (`xoxp-...`) for message search |
 | `GITHUB_TOKEN` | GitHub PAT for reading source code and opening PRs |
 | `AURA_ADMIN_USER_IDS` | Comma-separated Slack user IDs with admin access. Fallback for users without a DB role — see [Permissions](/permissions) |
+| `DASHBOARD_SESSION_TTL` | Optional dashboard session JWT lifetime. Defaults to `365d`; accepts duration strings like `30d`, `365d`, or `12h`. |
 | `E2B_API_KEY` | E2B API key for sandbox access |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings and audio transcription |
 | `AURA_BOT_USER_ID` | Aura's own Slack bot user ID |


### PR DESCRIPTION
## Summary
- Extend dashboard session JWTs to a configurable `DASHBOARD_SESSION_TTL` with a `365d` default.
- Return a specific `token_expired` reason for expired dashboard JWTs and clear stale client sessions.
- Redirect dashboard API 401s through the Slack login flow with a friendly expired-session message.

## Test plan
- [x] `pnpm typecheck`
- [x] IDE lint diagnostics on edited source files


Made with [Cursor](https://cursor.com)