### PR TITLE
docs(credentials): remove stale 'shared sandbox' warning

### DIFF
--- a/content/docs/tools/credentials.mdx
+++ b/content/docs/tools/credentials.mdx
@@ -83,11 +83,9 @@ When Aura executes a sandbox command tool (`run_command`, `run_command_detached`
 - Each credential has a `sandbox_env_name` (e.g. `GITHUB_TOKEN`, `DATABASE_URL`)
 - At sandbox creation and per-command execution, `getSandboxEnvs(userId)` resolves which credentials the current user can access
 - The resolved values are injected as environment variables
-- This means different users get different environment variables in the same sandbox
+- This means different users get different environment variables in the user's own sandbox
 
-<Warning>
-The sandbox is currently a single shared instance, not per-user. While credential injection is user-specific per command, the filesystem and process state is shared. Per-user sandboxes are planned.
-</Warning>
+Each user gets their own sandbox instance (see [Sandbox](/tools/sandbox)) -- filesystem and process state are isolated per user, and credential injection runs per-command against the calling user's grants.
 
 ## Making Authenticated Requests
 


### PR DESCRIPTION
## Why

`content/docs/tools/credentials.mdx` still carried a `<Warning>` block claiming the sandbox is "a single shared instance, not per-user" and that "per-user sandboxes are planned."

This contradicts the current state of the docs: `content/docs/tools/sandbox.mdx` was updated in #990 to document the per-user sandbox lifecycle (shipped in #569 / merged via #956 on May 20). Two pages saying opposite things about the same subsystem.

## What

- Drop the `<Warning>` block.
- Tighten the bullet above it: env vars are injected into the **user's own** sandbox.
- Replace the warning with a one-line note that filesystem/process state is per-user, linking to the Sandbox docs page for lifecycle details.

No behavior change; documentation only.

## Verification

- Cross-checked against `apps/api/src/lib/sandbox.ts` (per-user instances + `autoPause`) and `apps/api/src/lib/sandbox-envs.ts` (per-user credential resolution).
- `tsc` clean.
- Companion follow-up to #990; no overlap with the still-open #1021 / #1022 supervisor docs train.