### PR TITLE
docs(dashboard): document Adoption page

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -61,6 +61,22 @@ Monitor scheduled and recurring jobs:
 - See execution history and logs
 - Check cron schedules and frequency limits
 
+### Adoption
+
+Track how Aura is being adopted across the workspace over a chosen date range (default: last 180 days, Europe/Amsterdam timezone):
+
+- Headline KPIs: workspace reach, DAU / WAU / MAU with week-over-week deltas, power users, new users (7d / 28d), DAU/MAU stickiness
+- Activity volume chart (DAU, rolling 7-day WAU, rolling 28-day MAU) with weekend markers
+- Stickiness chart with 20% / 30% / 50% reference lines
+- Penetration funnel from workspace members through ever-talked, MAU, WAU, DAU, and power users -- with drop-off at each stage
+- Depth of engagement: P50 / P90 / P99 messages per active user and a histogram of message-count buckets
+- Weekly cohort retention table by first-message week, color-coded by return rate
+- Week-1 retention, returning-MAU rate, and DM vs mention share (28d)
+- Team adoption table (team comes from `users.known_facts.team`): per-team DAU/WAU/MAU, MAU%, dormant users, top user
+- Top active users (last 7 days) and dormant users (previously active, now silent)
+
+The date range is reflected in the URL so specific windows can be bookmarked and shared.
+
 ### Credentials
 
 Manage the encrypted credential store:


### PR DESCRIPTION
Adds an **Adoption** section to `content/docs/dashboard.mdx` reflecting the new `/adoption` route shipped in 2e58b07 (`feat(dashboard): add Adoption traction KPIs`).

The Adoption page is already live in the sidebar nav (`apps/dashboard/src/components/sidebar.tsx`) and backed by `apps/api/src/routes/dashboard/adoption.ts`, but had zero docs coverage.

The new section documents:
- Headline KPIs (reach, DAU/WAU/MAU + WoW deltas, power users, new users, stickiness)
- Activity volume + stickiness charts with reference lines
- Penetration funnel and depth-of-engagement histogram (P50/P90/P99)
- Weekly cohort retention heatmap (by first-message week)
- Week-1 retention, returning-MAU rate, DM vs mention share
- Team adoption table (sourced from `users.known_facts.team`)
- Top active and dormant user lists

One file changed, +16/-0. Found and filed by the daily docs-maintenance job.