### PR TITLE
feat(sandbox): detached commands as suspend points with webhook-driven resume (#987)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Slack event → Vercel serverless function → embed query → pgvector similari
 
 **Memory:** Every exchange triggers a fast-model LLM call that extracts structured memories (facts, decisions, relationships, open threads). Each memory is a 1536-dimensional pgvector embedding. Top ~10 most similar memories are retrieved on each response. DM-sourced memories are private by default.
 
-**Sandbox:** Persistent E2B VM attached to each user. Survives across conversations within a session. Has git, psql, gcloud, the GitHub CLI, `mongosh`, the `mongodb` node driver, and more. Build the custom template with `node sandbox/build-tsx.ts`.
+**Sandbox:** Persistent E2B VM attached to each user. Survives across conversations within a session. Has git, psql, gcloud, the GitHub CLI, `mongosh`, the `mongodb` node driver, and more. `run_command_detached` is a suspend point when webhook callbacks are configured: the active Slack turn ends after dispatch, and `/api/webhook/sandbox-command` resumes the same thread with a synthetic `<detached-command-result>` user turn when the process exits. Build the custom template with `node sandbox/build-tsx.ts`.
 
 **Scratch storage:** When `MONGODB_ATLAS_URI` is set, Aura uses MongoDB Atlas as a schema-less scratch layer for arbitrary per-task collections (cross-session job state, dumps, staging). Postgres stays mission-critical and schema-managed; Mongo is the ad-hoc workspace. See `content/docs/tools/sandbox.mdx`.
 

--- a/apps/api/src/lib/tool.test.ts
+++ b/apps/api/src/lib/tool.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const dbMocks = vi.hoisted(() => ({
+  returning: vi.fn(),
+  updateWhere: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  tool: (config: any) => config,
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: dbMocks.returning,
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: dbMocks.updateWhere,
+      })),
+    })),
+  },
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  defineTool,
+  executionContext,
+  markTurnSuspendedByDetachedCommand,
+  registerToolNames,
+  TOOL_CALL_AFTER_DETACHED_SUSPEND_ERROR,
+} from "./tool.js";
+
+describe("tool detached suspend enforcement", () => {
+  it("returns a hard error for tool calls after a detached command suspends the turn", async () => {
+    dbMocks.returning.mockResolvedValue([{ id: "log-1" }]);
+    dbMocks.updateWhere.mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const tools = registerToolNames({
+      read_note: defineTool({
+        description: "read a note",
+        inputSchema: z.object({}),
+        execute,
+      }),
+    });
+
+    const result = await executionContext.run(
+      {
+        triggeredBy: "U123",
+        triggerType: "user_message",
+        channelId: "C123",
+        threadTs: "1710000000.000000",
+      },
+      async () => {
+        markTurnSuspendedByDetachedCommand("abcdef12");
+        return (tools.read_note as any).execute({});
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: TOOL_CALL_AFTER_DETACHED_SUSPEND_ERROR,
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/tool.ts
+++ b/apps/api/src/lib/tool.ts
@@ -16,9 +16,25 @@ export interface ExecutionContext {
   channelId?: string;
   threadTs?: string;
   workspaceId?: string;
+  detachedCommandSuspended?: {
+    commandId: string;
+  };
 }
 
 export const executionContext = new AsyncLocalStorage<ExecutionContext>();
+
+export const TOOL_CALL_AFTER_DETACHED_SUSPEND_ERROR =
+  "tool_call_after_suspend: this turn already dispatched a detached command and is suspended; the conversation will resume when the webhook fires";
+
+export function markTurnSuspendedByDetachedCommand(commandId: string): void {
+  const ctx = executionContext.getStore();
+  if (!ctx) return;
+  ctx.detachedCommandSuspended = { commandId };
+}
+
+export function getDetachedCommandSuspendState(): { commandId: string } | undefined {
+  return executionContext.getStore()?.detachedCommandSuspended;
+}
 
 // ── Slack Card Metadata ──────────────────────────────────────────────────────
 // Co-located with tool definitions via defineTool() so that Slack card behavior
@@ -119,6 +135,19 @@ export function defineTool<TInput, TOutput>(config: {
     let logId: string | undefined;
 
     try {
+      if (ctx.detachedCommandSuspended) {
+        logger.warn("Tool call refused after detached command suspend point", {
+          toolName,
+          commandId: ctx.detachedCommandSuspended.commandId,
+          channelId: ctx.channelId,
+          threadTs: ctx.threadTs,
+        });
+        return {
+          ok: false,
+          error: TOOL_CALL_AFTER_DETACHED_SUSPEND_ERROR,
+        } as TOutput;
+      }
+
       try {
         const [logEntry] = await db
           .insert(actionLog)

--- a/apps/api/src/personality/system-prompt.ts
+++ b/apps/api/src/personality/system-prompt.ts
@@ -192,6 +192,7 @@ You have tools for Slack, email, calendar, BigQuery, notes, jobs, web, sandbox, 
 - When someone asks you to DO something ("post in #general", "DM Joan", "check #engineering"), use the appropriate tool.
 - When someone just wants a text answer, don't use tools -- just respond.
 - If a tool fails, explain what went wrong plainly. Don't retry silently.
+- run_command_detached is a suspend point when webhook callbacks are configured: after it starts a command, stop using tools and send a short final note that you'll continue when the command finishes. The webhook will wake you with a <detached-command-result> user turn. If the tool says webhook env is missing, use check_command polling instead.
 
 **Channel access:**
 - You must join a channel before reading or posting. Use join_channel first.
@@ -474,7 +475,7 @@ const CAPABILITY_DOMAINS: Array<{
     label: "E2B Sandboxes",
     envNames: ["E2B_API_KEY", "E2B_PAT"],
     wrappers: ["run_command", "run_command_detached", "check_command", "dispatch_headless", "run_subagent"],
-    guidance: "use run_command for short inline work, run_command_detached for long sandbox work, and check_command to poll it; do not call E2B APIs directly",
+    guidance: "use run_command for short inline work; use run_command_detached for long work as a suspend point that resumes via webhook, falling back to check_command polling only when webhook env is missing; do not call E2B APIs directly",
   },
 ];
 

--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -3,6 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const agentMocks = vi.hoisted(() => ({
   createInteractiveAgent: vi.fn(),
 }));
+const toolStateMocks = vi.hoisted(() => ({
+  detachedSuspendState: undefined as { commandId: string } | undefined,
+}));
 
 vi.mock("ai", () => ({
   streamText: vi.fn(),
@@ -19,6 +22,7 @@ vi.mock("../lib/ai.js", () => ({
 
 vi.mock("../lib/tool.js", () => ({
   getSlackMeta: (tool: any) => tool?.slack,
+  getDetachedCommandSuspendState: () => toolStateMocks.detachedSuspendState,
 }));
 
 vi.mock("../lib/settings.js", () => ({
@@ -149,6 +153,7 @@ function baseOptions(slackClient: any) {
 describe("generateResponse Slack stream handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    toolStateMocks.detachedSuspendState = undefined;
   });
 
   afterEach(() => {
@@ -602,6 +607,50 @@ describe("generateResponse Slack stream handling", () => {
         finishReason: "stop",
         relaunchCount: 1,
       },
+    });
+  });
+
+  it("does not relaunch after run_command_detached suspends the turn", async () => {
+    toolStateMocks.detachedSuspendState = { commandId: "abcdef12" };
+    const stream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+    const streamMock = mockAgentStreams([
+      createAgentStreamResult((async function* () {
+        yield {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "run_command_detached",
+          input: { command: "pnpm test" },
+        };
+        yield {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "run_command_detached",
+          output: { id: "abcdef12", pid: 4321, started_at: "2026-05-28T08:00:00.000Z" },
+        };
+      })()),
+    ]);
+
+    await expect(generateResponse(baseOptions(slackClient))).resolves.toMatchObject({
+      raw: "Started the detached command. I'll continue when it finishes.",
+      alreadyPosted: true,
+    });
+
+    expect(streamMock).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "empty_completion_relaunched",
+    )).toBe(false);
+    expect(vi.mocked(logError).mock.calls.some(
+      ([entry]) => entry.errorCode === "empty_completion_after_tools",
+    )).toBe(false);
+    expect(stream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "markdown_text",
+        text: "Started the detached command. I'll continue when it finishes.",
+      })],
     });
   });
 

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -14,7 +14,7 @@ import {
   isInvalidChunks,
   isMsgTooLong,
 } from "../lib/slack-messaging.js";
-import { getSlackMeta } from "../lib/tool.js";
+import { getDetachedCommandSuspendState, getSlackMeta } from "../lib/tool.js";
 import { createInteractiveAgent } from "../lib/agents.js";
 import { getMainModel, buildCachedSystemMessages } from "../lib/ai.js";
 import { InvocationSupersededError } from "./prepare-step.js";
@@ -689,6 +689,7 @@ export async function generateResponse(
   let lineCarry = "";
   let emptyCompletionDetected = false;
   let emptyCompletionRelaunchCount = 0;
+  let turnSuspendedByDetachedCommand = false;
   let latestResult: Awaited<ReturnType<typeof agent.stream>> | null = null;
   const stepsPromises: Array<PromiseLike<any[]>> = [];
   const aggregateUsage: DetailedTokenUsage = {
@@ -1251,6 +1252,13 @@ export async function generateResponse(
             is_error: !!isError,
             rawOutput: output,
           });
+          if (
+            chunk.toolName === "run_command_detached" &&
+            !isError &&
+            getDetachedCommandSuspendState()
+          ) {
+            turnSuspendedByDetachedCommand = true;
+          }
           pendingToolInputs.delete(chunk.toolCallId);
           optimisticToolCards.delete(chunk.toolCallId);
 
@@ -1368,6 +1376,7 @@ export async function generateResponse(
         const hasUsefulToolResults = toolCallRecords.some((record) => !record.is_error);
         const canRelaunch =
           hasUsefulToolResults &&
+          !turnSuspendedByDetachedCommand &&
           finishReason !== "tool-calls" &&
           emptyCompletionRelaunchCount < 1;
 
@@ -1389,29 +1398,39 @@ export async function generateResponse(
           continue;
         }
 
-        logError({
-          errorName: "EmptyCompletion",
-          errorMessage: "Stream completed without usable output after tool calls",
-          errorCode: "empty_completion_after_tools",
-          channelId,
-          context: {
+        if (turnSuspendedByDetachedCommand) {
+          const suspendFallbackText =
+            "Started the detached command. I'll continue when it finishes.";
+          logger.warn("Detached command suspend turn completed without text; adding fallback", {
+            channelId,
             toolCallCount: toolCallRecords.length,
-            toolErrorCount,
-            finishReason,
-            relaunchCount: emptyCompletionRelaunchCount,
-          },
-        });
+          });
+          await appendTextDelta(suspendFallbackText);
+        } else {
+          logError({
+            errorName: "EmptyCompletion",
+            errorMessage: "Stream completed without usable output after tool calls",
+            errorCode: "empty_completion_after_tools",
+            channelId,
+            context: {
+              toolCallCount: toolCallRecords.length,
+              toolErrorCount,
+              finishReason,
+              relaunchCount: emptyCompletionRelaunchCount,
+            },
+          });
 
-        streamingFailed = true;
-        emptyCompletionDetected = true;
+          streamingFailed = true;
+          emptyCompletionDetected = true;
 
-        if (streamer) {
-          try {
-            await streamer.stop({
-              chunks: [toChunkMarkdownText("\n\n_...(no output generated — see Aura logs)_")],
-            });
-          } catch {
-            // Stream may already be unrecoverable.
+          if (streamer) {
+            try {
+              await streamer.stop({
+                chunks: [toChunkMarkdownText("\n\n_...(no output generated — see Aura logs)_")],
+              });
+            } catch {
+              // Stream may already be unrecoverable.
+            }
           }
         }
       }

--- a/apps/api/src/tools/sandbox.test.ts
+++ b/apps/api/src/tools/sandbox.test.ts
@@ -28,6 +28,10 @@ const dbMocks = vi.hoisted(() => ({
   updateWhere: vi.fn(),
 }));
 
+const toolMocks = vi.hoisted(() => ({
+  markTurnSuspendedByDetachedCommand: vi.fn(),
+}));
+
 vi.mock("../lib/sandbox.js", () => ({
   getOrCreateSandbox: sandboxMocks.getOrCreateSandbox,
   getSandboxEnvs: sandboxMocks.getSandboxEnvs,
@@ -41,6 +45,7 @@ vi.mock("../lib/logger.js", () => ({
 
 vi.mock("../lib/tool.js", () => ({
   defineTool: (config: any) => config,
+  markTurnSuspendedByDetachedCommand: toolMocks.markTurnSuspendedByDetachedCommand,
 }));
 
 vi.mock("../db/client.js", () => ({
@@ -202,7 +207,11 @@ describe("sandbox command tools", () => {
   });
 
   it("starts detached commands and returns id, pid, and started_at", async () => {
-    const tool = createSandboxTools({ userId: "U123" } as any).run_command_detached as any;
+    const tool = createSandboxTools({
+      userId: "U123",
+      channelId: "C123",
+      threadTs: "1710000000.000000",
+    } as any).run_command_detached as any;
 
     const result = await tool.execute(
       tool.inputSchema.parse({
@@ -236,6 +245,7 @@ describe("sandbox command tools", () => {
       requestedBy: "U123",
       workspaceId: "default",
     }));
+    expect(toolMocks.markTurnSuspendedByDetachedCommand).toHaveBeenCalledWith(result.id);
   });
 
   it("warns once when detached command webhook env vars are missing", async () => {
@@ -248,6 +258,7 @@ describe("sandbox command tools", () => {
     await tool.execute(tool.inputSchema.parse({ command: "sleep 300" }));
     await tool.execute(tool.inputSchema.parse({ command: "sleep 301" }));
 
+    expect(toolMocks.markTurnSuspendedByDetachedCommand).not.toHaveBeenCalled();
     expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
     expect(loggerMocks.warn).toHaveBeenCalledWith(
       "run_command_detached: webhook callback disabled, env vars missing",

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -7,7 +7,7 @@ import {
   ensureUserHome,
 } from "../lib/sandbox.js";
 import { logger } from "../lib/logger.js";
-import { defineTool } from "../lib/tool.js";
+import { defineTool, markTurnSuspendedByDetachedCommand } from "../lib/tool.js";
 import { detachedCommands, type DetachedCommand, type ScheduleContext } from "@aura/db/schema";
 import { eq } from "drizzle-orm";
 
@@ -54,12 +54,25 @@ function getPublicUrl(): string {
   return DEFAULT_PUBLIC_URL;
 }
 
-function warnIfWebhookEnvMissing() {
-  if (warnedAboutWebhookEnv) return;
-
+function getMissingWebhookEnvVars(): string[] {
   const missing: string[] = [];
   if (!process.env.AURA_PUBLIC_URL) missing.push("AURA_PUBLIC_URL");
   if (!process.env.SANDBOX_WEBHOOK_SECRET) missing.push("SANDBOX_WEBHOOK_SECRET");
+  return missing;
+}
+
+function isDetachedCommandWebhookConfigured(): boolean {
+  return getMissingWebhookEnvVars().length === 0;
+}
+
+function canSuspendForDetachedCommand(context?: ScheduleContext): boolean {
+  return isDetachedCommandWebhookConfigured() && !!context?.channelId && !!context.threadTs;
+}
+
+function warnIfWebhookEnvMissing() {
+  if (warnedAboutWebhookEnv) return;
+
+  const missing = getMissingWebhookEnvVars();
   if (missing.length === 0) return;
 
   warnedAboutWebhookEnv = true;
@@ -625,7 +638,7 @@ export function createSandboxTools(context?: ScheduleContext) {
     }),
     run_command_detached: defineTool({
       description:
-        "Start a long-running shell command in the sandbox and return immediately with { id, pid, started_at }. Use this instead of run_command when work may exceed about 120s, has uncertain duration, or should keep running while you continue the conversation. The command writes stdout/stderr/status under /tmp/aura-bg/<id>.*. Poll progress with check_command({ id }); stop it with run_command({ command: 'kill <pid>' }) if needed.",
+        "Start a long-running shell command in the sandbox and return immediately with { id, pid, started_at }. Use this instead of run_command when work may exceed about 120s or has uncertain duration. When webhook env is configured (AURA_PUBLIC_URL and SANDBOX_WEBHOOK_SECRET) and this turn has a Slack thread to resume, this is a suspend point: after a successful dispatch, do not call any more tools in this turn; send a short final message like 'started <id>, I'll continue when it finishes.' The completion webhook will resume the conversation with the command result. If webhook env is missing, the turn does not suspend because no resume can arrive; poll progress with check_command({ id }) as before. The command writes stdout/stderr/status under /tmp/aura-bg/<id>.*. Stop it with run_command({ command: 'kill <pid>' }) if needed.",
       requiredCredentials: ["e2b_api_key"],
       inputSchema: z.object({
         command: z
@@ -688,6 +701,10 @@ export function createSandboxTools(context?: ScheduleContext) {
             id: detached.id,
             pid: detached.pid,
           });
+
+          if (canSuspendForDetachedCommand(context)) {
+            markTurnSuspendedByDetachedCommand(detached.id);
+          }
 
           return detached;
         } catch (error: any) {

--- a/apps/api/src/webhook/sandbox-command.test.ts
+++ b/apps/api/src/webhook/sandbox-command.test.ts
@@ -1,15 +1,13 @@
 import crypto from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const safePostMessageMock = vi.hoisted(() => vi.fn());
 const recordErrorMock = vi.hoisted(() => vi.fn());
+const runPipelineMock = vi.hoisted(() => vi.fn());
+const getConfigMock = vi.hoisted(() => vi.fn());
+const executionContextRunMock = vi.hoisted(() => vi.fn((_context, fn) => fn()));
 
 vi.mock("../db/client.js", () => ({
   db: {},
-}));
-
-vi.mock("../lib/slack-messaging.js", () => ({
-  safePostMessage: safePostMessageMock,
 }));
 
 vi.mock("../lib/logger.js", () => ({
@@ -25,7 +23,22 @@ vi.mock("../lib/metrics.js", () => ({
   recordError: recordErrorMock,
 }));
 
+vi.mock("../lib/settings.js", () => ({
+  getConfig: getConfigMock,
+}));
+
+vi.mock("../lib/tool.js", () => ({
+  executionContext: {
+    run: executionContextRunMock,
+  },
+}));
+
+vi.mock("../pipeline/index.js", () => ({
+  runPipeline: runPipelineMock,
+}));
+
 import {
+  buildDetachedCommandResultMessage,
   createSandboxCommandWebhookApp,
   verifySandboxWebhookSignature,
 } from "./sandbox-command.js";
@@ -59,7 +72,9 @@ describe("sandbox command webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.SANDBOX_WEBHOOK_SECRET = "sandbox-secret";
-    safePostMessageMock.mockResolvedValue({ ok: true });
+    runPipelineMock.mockResolvedValue(undefined);
+    getConfigMock.mockResolvedValue("U_AURA");
+    executionContextRunMock.mockImplementation((_context, fn) => fn());
   });
 
   it("verifies HMAC signatures", () => {
@@ -86,7 +101,39 @@ describe("sandbox command webhook", () => {
     expect(response.status).toBe(401);
   });
 
-  it("updates the detached command row and posts a Slack notification", async () => {
+  it("formats detached command results as a synthetic user turn payload", () => {
+    const startedAt = new Date("2026-05-28T08:00:00Z");
+    const completedAt = new Date("2026-05-28T08:00:42Z");
+    const message = buildDetachedCommandResultMessage(
+      {
+        id: "abcdef12",
+        workspaceId: "default",
+        pid: 4321,
+        command: "pnpm test",
+        status: "completed",
+        exitCode: 0,
+        requestedBy: "U123",
+        channelId: "C123",
+        threadTs: "1710000000.000000",
+        startedAt,
+        completedAt,
+        stdoutTail: null,
+        stderrTail: null,
+      },
+      0,
+      "last stdout",
+      "",
+      completedAt,
+    );
+
+    expect(message).toContain('<detached-command-result id="abcdef12" exit_code=0 runtime_s=42>');
+    expect(message).toContain("_Command:_ `pnpm test`");
+    expect(message).toContain("*stdout tail:*");
+    expect(message).toContain("last stdout");
+    expect(message).toContain("</detached-command-result>");
+  });
+
+  it("updates the detached command row and enqueues a synthetic resume", async () => {
     const startedAt = new Date(Date.now() - 2_000);
     const row = {
       id: "abcdef12",
@@ -104,7 +151,12 @@ describe("sandbox command webhook", () => {
       stderrTail: null,
     };
     const { database, calls } = createDatabaseMock(row);
-    const app = createSandboxCommandWebhookApp({ chat: { postMessage: vi.fn() } } as any, database);
+    const resumeConversation = vi.fn().mockResolvedValue(undefined);
+    const enqueued: Promise<void>[] = [];
+    const app = createSandboxCommandWebhookApp({ chat: { postMessage: vi.fn() } } as any, database, {
+      resumeConversation,
+      enqueueResume: (promise) => enqueued.push(promise),
+    });
     const body = JSON.stringify({
       id: "abcdef12",
       exit_code: 1,
@@ -122,21 +174,97 @@ describe("sandbox command webhook", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ ok: true, notified: true });
+    expect(await response.json()).toEqual({ ok: true, resumed: true });
     expect(calls.set).toHaveBeenCalledWith(expect.objectContaining({
       status: "failed",
       exitCode: 1,
       stdoutTail: "last stdout",
       stderrTail: "last stderr",
     }));
-    expect(safePostMessageMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-      channel: "C123",
-      thread_ts: "1710000000.000000",
-      text: expect.stringContaining("Detached command `abcdef12` failed with exit code 1"),
+    expect(resumeConversation).toHaveBeenCalledWith(expect.objectContaining({
+      row: expect.objectContaining({
+        id: "abcdef12",
+        channelId: "C123",
+        threadTs: "1710000000.000000",
+      }),
+      exitCode: 1,
+      stdoutTail: "last stdout",
+      stderrTail: "last stderr",
+      slackClient: expect.anything(),
     }));
+    expect(enqueued).toHaveLength(1);
   });
 
-  it("skips duplicate Slack notifications for curl retry payloads", async () => {
+  it("routes the default synthetic resume through runPipeline with the command result", async () => {
+    const startedAt = new Date(Date.now() - 1_000);
+    const row = {
+      id: "abcdef12",
+      workspaceId: "default",
+      pid: 4321,
+      command: "pnpm test",
+      status: "running",
+      exitCode: null,
+      requestedBy: "U123",
+      channelId: "C123",
+      threadTs: "1710000000.000000",
+      startedAt,
+      completedAt: null,
+      stdoutTail: null,
+      stderrTail: null,
+    };
+    const { database } = createDatabaseMock(row);
+    const enqueued: Promise<void>[] = [];
+    const slackClient = { chat: { postMessage: vi.fn() } } as any;
+    const app = createSandboxCommandWebhookApp(slackClient, database, {
+      enqueueResume: (promise) => enqueued.push(promise),
+    });
+    const body = JSON.stringify({
+      id: "abcdef12",
+      exit_code: 0,
+      stdout_tail: "ok",
+      stderr_tail: "",
+    });
+
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": sign(body, "sandbox-secret"),
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, resumed: true });
+    expect(enqueued).toHaveLength(1);
+    await enqueued[0];
+
+    expect(executionContextRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggeredBy: "U123",
+        channelId: "C123",
+        threadTs: "1710000000.000000",
+        workspaceId: "default",
+      }),
+      expect.any(Function),
+    );
+    expect(runPipelineMock).toHaveBeenCalledWith(expect.objectContaining({
+      event: expect.objectContaining({
+        type: "app_mention",
+        channel: "C123",
+        thread_ts: "1710000000.000000",
+        user: "U123",
+        text: expect.stringContaining("<detached-command-result"),
+      }),
+      client: slackClient,
+      botUserId: "U_AURA",
+    }));
+    expect(runPipelineMock.mock.calls[0]?.[0].event.text).toContain("_Command:_ `pnpm test`");
+    expect(runPipelineMock.mock.calls[0]?.[0].event.text).toContain("*stdout tail:*");
+    expect(runPipelineMock.mock.calls[0]?.[0].event.text).toContain("ok");
+  });
+
+  it("skips duplicate synthetic resumes for curl retry payloads", async () => {
     const row = {
       id: "abcdef12",
       workspaceId: "default",
@@ -153,7 +281,11 @@ describe("sandbox command webhook", () => {
       stderrTail: null,
     };
     const { database } = createDatabaseMock(row);
-    const app = createSandboxCommandWebhookApp({ chat: { postMessage: vi.fn() } } as any, database);
+    const resumeConversation = vi.fn().mockResolvedValue(undefined);
+    const app = createSandboxCommandWebhookApp({ chat: { postMessage: vi.fn() } } as any, database, {
+      resumeConversation,
+      enqueueResume: () => undefined,
+    });
     const body = JSON.stringify({
       id: "abcdef12",
       exit_code: 0,
@@ -177,13 +309,56 @@ describe("sandbox command webhook", () => {
     });
 
     expect(first.status).toBe(200);
-    expect(await first.json()).toEqual({ ok: true, notified: true });
+    expect(await first.json()).toEqual({ ok: true, resumed: true });
     expect(second.status).toBe(200);
     expect(await second.json()).toEqual({
       ok: true,
-      notified: false,
+      resumed: false,
       reason: "already_notified",
     });
-    expect(safePostMessageMock).toHaveBeenCalledTimes(1);
+    expect(resumeConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and no-ops when the origin thread is missing", async () => {
+    const row = {
+      id: "abcdef12",
+      workspaceId: "default",
+      pid: 4321,
+      command: "sleep 1",
+      status: "running",
+      exitCode: null,
+      requestedBy: "U123",
+      channelId: null,
+      threadTs: null,
+      startedAt: new Date(Date.now() - 1_000),
+      completedAt: null,
+      stdoutTail: null,
+      stderrTail: null,
+    };
+    const { database } = createDatabaseMock(row);
+    const resumeConversation = vi.fn().mockResolvedValue(undefined);
+    const app = createSandboxCommandWebhookApp({ chat: { postMessage: vi.fn() } } as any, database, {
+      resumeConversation,
+      enqueueResume: () => undefined,
+    });
+    const body = JSON.stringify({
+      id: "abcdef12",
+      exit_code: 0,
+      stdout_tail: "done",
+      stderr_tail: "",
+    });
+
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": sign(body, "sandbox-secret"),
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, resumed: false });
+    expect(resumeConversation).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/webhook/sandbox-command.ts
+++ b/apps/api/src/webhook/sandbox-command.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { WebClient } from "@slack/web-api";
+import { waitUntil } from "@vercel/functions";
 import crypto from "node:crypto";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
@@ -7,10 +8,12 @@ import { db } from "../db/client.js";
 import { detachedCommands, type DetachedCommand } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
 import { recordError } from "../lib/metrics.js";
-import { safePostMessage } from "../lib/slack-messaging.js";
+import { getConfig } from "../lib/settings.js";
+import { executionContext, type ExecutionContext } from "../lib/tool.js";
+import { runPipeline } from "../pipeline/index.js";
 
 const MAX_TAIL_CHARS = 16 * 1024;
-const SLACK_TAIL_CHARS = 4_000;
+const RESULT_TAIL_CHARS = 4_000;
 
 const payloadSchema = z.object({
   id: z.string().regex(/^[a-f0-9]{8}$/),
@@ -57,36 +60,113 @@ function runtimeSeconds(row: DetachedCommand, completedAt: Date): number {
 }
 
 function formatTailBlock(label: string, value: string): string {
-  const tail = truncateTail(value.trim(), SLACK_TAIL_CHARS);
+  const tail = truncateTail(value.trim(), RESULT_TAIL_CHARS);
   if (!tail) return "";
   return `\n\n*${label}:*\n\`\`\`\n${sanitizeCodeBlock(tail)}\n\`\`\``;
 }
 
-export function buildSandboxCommandNotification(
+export function buildDetachedCommandResultMessage(
   row: DetachedCommand,
   exitCode: number,
   stdoutTail: string,
   stderrTail: string,
   completedAt = new Date(),
 ): string {
-  const status = exitCode === 0 ? "completed" : "failed";
   const command = formatInlineCode(row.command);
   const runtime = runtimeSeconds(row, completedAt);
-  const header =
-    `:gear: Detached command \`${row.id}\` ${status} with exit code ${exitCode}.`;
-  const commandLine = command ? `\n_Command:_ \`${command.slice(0, 180)}\`` : "";
-  const runtimeLine = `\n_Runtime:_ ${runtime}s`;
+  const commandLine = command ? `\n_Command:_ \`${command}\`` : "";
   const stdoutBlock = formatTailBlock("stdout tail", stdoutTail);
   const stderrBlock = formatTailBlock("stderr tail", stderrTail);
 
-  return `${header}${commandLine}${runtimeLine}${stdoutBlock}${stderrBlock}`;
+  return `<detached-command-result id="${row.id}" exit_code=${exitCode} runtime_s=${runtime}>${commandLine}${stdoutBlock}${stderrBlock}\n</detached-command-result>`;
+}
+
+type ResumeDetachedCommandInput = {
+  row: DetachedCommand;
+  exitCode: number;
+  stdoutTail: string;
+  stderrTail: string;
+  completedAt: Date;
+  slackClient: WebClient;
+};
+
+type SandboxCommandWebhookOptions = {
+  resumeConversation?: (input: ResumeDetachedCommandInput) => Promise<void>;
+  enqueueResume?: (promise: Promise<void>) => void;
+};
+
+function makeSyntheticSlackTs(): string {
+  const nowMs = Date.now();
+  const seconds = Math.floor(nowMs / 1000);
+  const micros = (nowMs % 1000) * 1000 + crypto.randomInt(0, 1000);
+  return `${seconds}.${String(micros).padStart(6, "0")}`;
+}
+
+function inferSyntheticChannelType(channelId: string): string {
+  if (channelId.startsWith("D")) return "im";
+  if (channelId.startsWith("G")) return "group";
+  return "channel";
+}
+
+async function getBotUserId(): Promise<string> {
+  return await getConfig("aura_bot_user_id");
+}
+
+async function resumeDetachedCommandConversation(input: ResumeDetachedCommandInput): Promise<void> {
+  const { row, exitCode, stdoutTail, stderrTail, completedAt, slackClient } = input;
+
+  if (!row.channelId || !row.threadTs) {
+    logger.warn("Sandbox command webhook cannot resume without origin thread", {
+      id: row.id,
+      channelId: row.channelId,
+      threadTs: row.threadTs,
+    });
+    return;
+  }
+
+  const botUserId = await getBotUserId();
+  const syntheticMessage = buildDetachedCommandResultMessage(
+    row,
+    exitCode,
+    stdoutTail,
+    stderrTail,
+    completedAt,
+  );
+  const syntheticEvent = {
+    type: "app_mention" as const,
+    channel: row.channelId,
+    ts: makeSyntheticSlackTs(),
+    thread_ts: row.threadTs,
+    channel_type: inferSyntheticChannelType(row.channelId),
+    user: row.requestedBy,
+    text: `<@${botUserId}> ${syntheticMessage}`,
+  };
+  const resumeContext: ExecutionContext = {
+    triggeredBy: row.requestedBy,
+    triggerType: "user_message",
+    callingUserId: row.requestedBy,
+    channelId: row.channelId,
+    threadTs: row.threadTs,
+    workspaceId: row.workspaceId,
+  };
+
+  await executionContext.run(resumeContext, async () =>
+    runPipeline({
+      event: syntheticEvent,
+      client: slackClient,
+      botUserId,
+    })
+  );
 }
 
 export function createSandboxCommandWebhookApp(
   slackClient: WebClient,
   database: any = db,
+  options: SandboxCommandWebhookOptions = {},
 ) {
   const app = new Hono();
+  const resumeConversation = options.resumeConversation ?? resumeDetachedCommandConversation;
+  const enqueueResume = options.enqueueResume ?? ((promise: Promise<void>) => waitUntil(promise));
 
   app.post("/", async (c) => {
     const rawBody = await c.req.text();
@@ -132,10 +212,10 @@ export function createSandboxCommandWebhookApp(
         logger.warn("Sandbox command webhook received for unknown command", {
           id: payload.id,
         });
-        return c.json({ ok: true, notified: false });
+        return c.json({ ok: true, resumed: false });
       }
 
-      const shouldNotify = existing.status === "running";
+      const shouldResume = existing.status === "running";
       const updatedRows = await database
         .update(detachedCommands)
         .set({
@@ -156,48 +236,55 @@ export function createSandboxCommandWebhookApp(
         stderrTail,
       };
 
-      let notified = false;
-      if (!shouldNotify) {
-        logger.info("Sandbox command webhook already notified, skipping Slack post", {
+      let resumed = false;
+      if (!shouldResume) {
+        logger.info("Sandbox command webhook already resumed, skipping synthetic turn", {
           id: payload.id,
           previousStatus: existing.status,
           status,
         });
-        return c.json({ ok: true, notified: false, reason: "already_notified" });
+        return c.json({ ok: true, resumed: false, reason: "already_notified" });
       }
 
-      if (updated.channelId) {
-        try {
-          await safePostMessage(slackClient, {
-            channel: updated.channelId,
-            thread_ts: updated.threadTs || undefined,
-            text: buildSandboxCommandNotification(
-              updated,
-              payload.exit_code,
-              stdoutTail,
-              stderrTail,
-              completedAt,
-            ),
-            unfurl_links: false,
-            unfurl_media: false,
-          });
-          notified = true;
-        } catch (error) {
-          recordError("sandbox_command_webhook_slack_notify", error, {
+      if (updated.channelId && updated.threadTs) {
+        const resumePromise = resumeConversation({
+          row: updated,
+          exitCode: payload.exit_code,
+          stdoutTail,
+          stderrTail,
+          completedAt,
+          slackClient,
+        }).catch((error) => {
+          logger.warn("Sandbox command webhook synthetic resume failed", {
             id: payload.id,
             channelId: updated.channelId,
+            threadTs: updated.threadTs,
+            error: error instanceof Error ? error.message : String(error),
           });
-        }
+          recordError("sandbox_command_webhook_resume", error, {
+            id: payload.id,
+            channelId: updated.channelId,
+            threadTs: updated.threadTs,
+          });
+        });
+        enqueueResume(resumePromise);
+        resumed = true;
+      } else {
+        logger.warn("Sandbox command webhook cannot resume missing origin thread", {
+          id: payload.id,
+          channelId: updated.channelId,
+          threadTs: updated.threadTs,
+        });
       }
 
       logger.info("Sandbox command webhook processed", {
         id: payload.id,
         status,
         exitCode: payload.exit_code,
-        notified,
+        resumed,
       });
 
-      return c.json({ ok: true, notified });
+      return c.json({ ok: true, resumed });
     } catch (error) {
       recordError("sandbox_command_webhook", error, { id: payload.id });
       return c.json({ error: "Webhook processing failed" }, 500);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat successful `run_command_detached` dispatches as hard suspend points when webhook resume is available.
- Refuse subsequent tool calls in the same turn with `tool_call_after_suspend` and avoid empty-completion relaunches for suspended turns.
- Replace sandbox-command webhook Slack top-level posts with synthetic user-turn resumes through the existing Slack pipeline.
- Update tool/system/docs guidance and tests for resume, dedupe, missing-origin, env-missing fallback, and runtime enforcement.

Fixes #987

## Verification
- `pnpm --filter aura-api test`
- `pnpm typecheck`
- `npx tsc --noEmit` (from `apps/api`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c80d219-83e8-4700-98e6-1d072f26e1c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c80d219-83e8-4700-98e6-1d072f26e1c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

