### PR TITLE
fix(voice): store transcript as message body (#1035)

### DIFF
--- a/apps/api/src/lib/files.test.ts
+++ b/apps/api/src/lib/files.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const audioMocks = vi.hoisted(() => ({
+  transcribeAudio: vi.fn(),
+}));
+
+vi.mock("./audio.js", () => ({
+  transcribeAudio: audioMocks.transcribeAudio,
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { downloadEventFiles } from "./files.js";
+
+function stubSlackDownload(data: Uint8Array = new Uint8Array([1, 2, 3])) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+    }),
+  );
+}
+
+describe("downloadEventFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubSlackDownload();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns audio transcripts separately from content parts", async () => {
+    audioMocks.transcribeAudio.mockResolvedValue("hello from a voice note");
+
+    const result = await downloadEventFiles(
+      {
+        files: [
+          {
+            url_private_download: "https://slack.test/voice.ogg",
+            mimetype: "audio/ogg",
+            name: "voice.ogg",
+            size: 123,
+          },
+        ],
+      },
+      "xoxb-token",
+    );
+
+    expect(result.parts).toEqual([]);
+    expect(result.transcripts).toEqual(["hello from a voice note"]);
+    expect(audioMocks.transcribeAudio).toHaveBeenCalledWith(
+      expect.any(Uint8Array),
+      "audio/ogg",
+      "voice.ogg",
+    );
+  });
+
+  it("returns a failure transcript when audio transcription fails", async () => {
+    audioMocks.transcribeAudio.mockRejectedValue(new Error("OPENAI_API_KEY is not set"));
+
+    const result = await downloadEventFiles(
+      {
+        files: [
+          {
+            url_private_download: "https://slack.test/voice.ogg",
+            mimetype: "audio/ogg",
+            name: "voice.ogg",
+            size: 123,
+          },
+        ],
+      },
+      "xoxb-token",
+    );
+
+    expect(result.parts).toEqual([]);
+    expect(result.transcripts).toEqual([
+      "[transcription failed: OPENAI_API_KEY is not set]",
+    ]);
+  });
+
+  it("keeps non-audio files as content parts without transcripts", async () => {
+    stubSlackDownload(new TextEncoder().encode("hello file"));
+
+    const result = await downloadEventFiles(
+      {
+        files: [
+          {
+            url_private_download: "https://slack.test/note.txt",
+            mimetype: "text/plain",
+            name: "note.txt",
+            size: 10,
+          },
+        ],
+      },
+      "xoxb-token",
+    );
+
+    expect(result.transcripts).toEqual([]);
+    expect(result.parts).toEqual([
+      { type: "text", text: "[File: note.txt]\nhello file" },
+    ]);
+  });
+});

--- a/apps/api/src/lib/files.ts
+++ b/apps/api/src/lib/files.ts
@@ -61,6 +61,11 @@ export type FileContentPart =
   | { type: "file"; data: Uint8Array; mediaType: string; filename: string }
   | { type: "text"; text: string };
 
+export interface DownloadedEventFiles {
+  parts: FileContentPart[];
+  transcripts: string[];
+}
+
 /**
  * Extract downloadable files from a Slack event.
  * Accepts all file types, filtering only by size and presence of a download URL.
@@ -122,26 +127,6 @@ async function toContentPart(
     return { type: "image", image: data, mediaType: mimeType };
   }
 
-  if (AUDIO_MIME_TYPES.has(mimeType)) {
-    try {
-      const transcription = await transcribeAudio(data, mimeType, name);
-      return {
-        type: "text",
-        text: `[Voice message transcription]: ${transcription}`,
-      };
-    } catch (error: any) {
-      logger.error("Audio transcription failed", {
-        name,
-        mimeType,
-        error: error.message,
-      });
-      return {
-        type: "text",
-        text: `[Voice message]: Audio transcription failed — ${error.message}`,
-      };
-    }
-  }
-
   if (SPREADSHEET_MIME_TYPES.has(mimeType)) {
     if (mimeType === "text/csv" || mimeType === "application/csv") {
       const text = new TextDecoder().decode(data);
@@ -194,19 +179,44 @@ async function toContentPart(
 
 /**
  * Download all files from a Slack event and convert to AI SDK content parts.
+ * Audio files are transcribed into message-body text by the pipeline, not
+ * returned as content parts, so models do not see the same transcript twice.
  */
 export async function downloadEventFiles(
   event: any,
   botToken: string,
-): Promise<FileContentPart[]> {
+): Promise<DownloadedEventFiles> {
   const files = getEventFiles(event);
-  if (files.length === 0) return [];
+  if (files.length === 0) return { parts: [], transcripts: [] };
 
   const parts: FileContentPart[] = [];
+  const transcripts: string[] = [];
 
   for (const file of files) {
     try {
       const data = await downloadSlackFile(file.url, botToken);
+      if (AUDIO_MIME_TYPES.has(file.mimetype)) {
+        try {
+          const transcription = await transcribeAudio(data, file.mimetype, file.name);
+          transcripts.push(transcription);
+          logger.info("Downloaded and transcribed Slack audio file", {
+            name: file.name,
+            size: data.length,
+            mimeType: file.mimetype,
+            transcriptionLength: transcription.length,
+          });
+        } catch (error: any) {
+          const reason = error?.message || String(error);
+          logger.error("Audio transcription failed", {
+            name: file.name,
+            mimeType: file.mimetype,
+            error: reason,
+          });
+          transcripts.push(`[transcription failed: ${reason}]`);
+        }
+        continue;
+      }
+
       const part = await toContentPart(data, file.mimetype, file.name);
       parts.push(part);
       logger.info("Downloaded Slack file", {
@@ -216,6 +226,10 @@ export async function downloadEventFiles(
         partType: part.type,
       });
     } catch (error: any) {
+      if (AUDIO_MIME_TYPES.has(file.mimetype)) {
+        const reason = error?.message || String(error);
+        transcripts.push(`[transcription failed: ${reason}]`);
+      }
       logger.error("Failed to download Slack file", {
         name: file.name,
         url: file.url,
@@ -224,5 +238,5 @@ export async function downloadEventFiles(
     }
   }
 
-  return parts;
+  return { parts, transcripts };
 }

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -10,6 +10,7 @@ import {
 import { assemblePrompt } from "./prompt.js";
 import { generateResponse, type LLMResponse } from "./respond.js";
 import { InvocationSupersededError } from "./prepare-step.js";
+import { buildMessageText } from "./message-text.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import {
   fetchConversationContext,
@@ -296,15 +297,32 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       ],
     });
 
+    // 4b. Download files if the message has attachments. Voice notes produce
+    // transcripts for the canonical message body instead of file content parts.
+    const botToken = process.env.SLACK_BOT_TOKEN || "";
+    const downloadedFiles = hasFiles
+      ? await downloadEventFiles(event, botToken)
+      : { parts: [], transcripts: [] };
+    const fileParts = downloadedFiles.parts;
+    const voiceTranscripts = downloadedFiles.transcripts;
+    if (fileParts.length > 0) {
+      logger.info("Files ready for LLM", {
+        count: fileParts.length,
+        types: fileParts.map((p) => p.type),
+      });
+    }
+
     // ── Edge case: extremely long message ────────────────────────────────
-    let messageText = context.text || (hasFiles ? "What can you tell me about this file?" : "");
+    let messageText = buildMessageText(context.text, hasFiles, voiceTranscripts);
     if (messageText.length > MAX_MESSAGE_LENGTH) {
+      const originalLength = messageText.length;
       messageText = messageText.substring(0, MAX_MESSAGE_LENGTH);
       logger.warn("Truncated long message", {
-        originalLength: context.text.length,
+        originalLength,
         truncatedTo: MAX_MESSAGE_LENGTH,
       });
     }
+    context.text = messageText;
 
     // ── USLACKBOT list notification enrichment ───────────────────────────
     // Any USLACKBOT message in a tracked List channel is a list activity
@@ -368,16 +386,6 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
 
     capturedSystemPrompt = [stablePrefix, conversationContext, dynamicContext].filter(Boolean).join("\n\n");
     capturedUserPrompt = messageText;
-
-    // 4b. Download files if the message has attachments
-    const botToken = process.env.SLACK_BOT_TOKEN || "";
-    const fileParts = await downloadEventFiles(event, botToken);
-    if (fileParts.length > 0) {
-      logger.info("Files ready for LLM", {
-        count: fileParts.length,
-        types: fileParts.map((p) => p.type),
-      });
-    }
 
     // 5. Call LLM (streams response directly to Slack via chat.update)
     const llmStart = Date.now();

--- a/apps/api/src/pipeline/message-text.test.ts
+++ b/apps/api/src/pipeline/message-text.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMessageText } from "./message-text.js";
+
+describe("buildMessageText", () => {
+  it("uses the voice transcript as the message body for audio-only messages", () => {
+    expect(buildMessageText("", true, ["turn on the kitchen lights"])).toBe(
+      'Voice note: "turn on the kitchen lights"',
+    );
+  });
+
+  it("appends typed text after the voice note transcript", () => {
+    expect(buildMessageText("also make it brief", true, ["summarize this"])).toBe(
+      'Voice note: "summarize this"\n\nalso make it brief',
+    );
+  });
+
+  it("keeps the file fallback for non-audio file-only messages", () => {
+    expect(buildMessageText("", true, [])).toBe("What can you tell me about this file?");
+  });
+
+  it("formats transcription failures as voice-note text", () => {
+    expect(buildMessageText("", true, ["[transcription failed: OPENAI_API_KEY is not set]"])).toBe(
+      'Voice note: "[transcription failed: OPENAI_API_KEY is not set]"',
+    );
+  });
+});

--- a/apps/api/src/pipeline/message-text.ts
+++ b/apps/api/src/pipeline/message-text.ts
@@ -1,0 +1,15 @@
+const FILE_ATTACHMENT_FALLBACK = "What can you tell me about this file?";
+
+export function buildMessageText(
+  contextText: string,
+  hasFiles: boolean,
+  voiceTranscripts: string[],
+): string {
+  if (voiceTranscripts.length > 0) {
+    const voiceNoteText = `Voice note: "${voiceTranscripts.join("\n\n")}"`;
+    const userText = contextText.trim();
+    return userText ? `${voiceNoteText}\n\n${userText}` : voiceNoteText;
+  }
+
+  return contextText || (hasFiles ? FILE_ATTACHMENT_FALLBACK : "");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Store Slack voice-note transcripts as the canonical user message body using `Voice note: "..."`.
- Keep typed text alongside voice notes by appending it after the transcript on a new paragraph.
- Stop passing audio transcripts as redundant file content parts while preserving non-audio file handling.
- Preserve Whisper/download failure behavior as text: `Voice note: "[transcription failed: <reason>]"`.

## Before / after
Before, an audio-only voice note stored a placeholder in `messages.content`:

```text
What can you tell me about this file?
```

After, the same voice note stores the transcript directly:

```text
Voice note: "I will be five minutes late to the meeting."
```

With accompanying typed text:

```text
Voice note: "I will be five minutes late to the meeting."

Please let the team know.
```

## Validation
- `pnpm --filter aura-api test src/lib/files.test.ts src/pipeline/message-text.test.ts`
- `pnpm --filter aura-api test`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`

Closes #1035
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9be40780-d57a-44ad-980d-b82286b9edbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9be40780-d57a-44ad-980d-b82286b9edbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

