### PR TITLE
Implement memory retrieval prefilter

### DIFF
--- a/apps/api/bench/src/eval-retrieval.ts
+++ b/apps/api/bench/src/eval-retrieval.ts
@@ -55,6 +55,7 @@ export async function evaluateRetrieval(
       limit: k,
       workspaceId,
       adminMode: true,
+      prefilter: true,
     });
   } catch (error) {
     logger.warn("bench: retrieval failed", {

--- a/apps/api/src/memory/extract.ts
+++ b/apps/api/src/memory/extract.ts
@@ -604,9 +604,12 @@ async function extractWithReconciliation(
     retrieveMemories({
       query: context.userMessage,
       currentUserId: context.userId,
+      channelId: context.channelId,
+      channelType: context.channelType,
       limit: 20,
       workspaceId,
       adminMode: true,
+      prefilter: true,
     }).then((mems) => { existingMemories = mems; }).catch((err) => {
       logger.warn("Memory retrieval failed during reconciliation — proceeding with empty existing memories", {
         error: String(err?.message ?? err).slice(0, 200),
@@ -647,9 +650,12 @@ async function extractWithReconciliationFromTranscript(
     existingMemories = await retrieveMemories({
       query: context.userMessage,
       currentUserId: context.userId,
+      channelId: context.channelId,
+      channelType: context.channelType,
       limit: 20,
       workspaceId,
       adminMode: true,
+      prefilter: true,
     });
   } catch (err) {
     logger.warn("Memory retrieval failed during transcript reconciliation — proceeding with empty existing memories", {

--- a/apps/api/src/memory/retrieve.test.ts
+++ b/apps/api/src/memory/retrieve.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+const aiMocks = vi.hoisted(() => ({
+  generateObject: vi.fn(),
+  rerank: vi.fn(),
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: dbMocks.execute,
+  },
+}));
+
+vi.mock("../lib/embeddings.js", () => ({
+  embedText: vi.fn(async () => Array.from({ length: 1536 }, () => 0.001)),
+}));
+
+vi.mock("../lib/ai.js", () => ({
+  getFastModel: vi.fn(async () => ({ id: "fast-test-model" })),
+  getRerankingModel: vi.fn(async () => null),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("ai", () => ({
+  generateObject: aiMocks.generateObject,
+  rerank: aiMocks.rerank,
+}));
+
+import { retrieveMemories } from "./retrieve.js";
+
+interface RenderedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+function renderSql(query: any): RenderedQuery {
+  if (!query?.toQuery) return { sql: String(query), params: [] };
+  const rendered = query.toQuery({
+    escapeName: (name: string) => `"${name}"`,
+    escapeParam: (index: number) => `$${index + 1}`,
+    escapeString: (value: string) => `'${value.replace(/'/g, "''")}'`,
+  });
+  return { sql: rendered.sql, params: rendered.params };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}
+
+function setupDb(options: { resolveEntity?: boolean } = {}) {
+  const executed: RenderedQuery[] = [];
+  const resolveEntity = options.resolveEntity ?? false;
+
+  dbMocks.execute.mockImplementation(async (query: any) => {
+    const rendered = renderSql(query);
+    executed.push(rendered);
+    const compact = normalizeSql(rendered.sql);
+
+    if (compact.includes("FROM unnest(to_tsvector")) {
+      return { rows: [] };
+    }
+
+    if (
+      resolveEntity &&
+      compact.includes("FROM entities") &&
+      compact.includes("lower(canonical_name)") &&
+      compact.includes("LIMIT 1")
+    ) {
+      return {
+        rows: [{ id: "entity-vadim", canonical_name: "Vadim", type: "person" }],
+      };
+    }
+
+    if (compact.includes("SELECT DISTINCT m.*") && compact.includes("JOIN memory_entities me")) {
+      return { rows: [] };
+    }
+
+    if (compact.startsWith("WITH ")) {
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  });
+
+  return executed;
+}
+
+function hybridQuery(executed: RenderedQuery[]): RenderedQuery {
+  const query = executed.find((entry) => normalizeSql(entry.sql).startsWith("WITH "));
+  expect(query).toBeDefined();
+  return query!;
+}
+
+describe("retrieveMemories prefilter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    aiMocks.generateObject.mockResolvedValue({ object: { entities: [] } });
+  });
+
+  it("restricts scored candidates to resolved entity memories plus the recent tail", async () => {
+    aiMocks.generateObject.mockResolvedValue({
+      object: { entities: [{ name: "Vadim", type: "person" }] },
+    });
+    const executed = setupDb({ resolveEntity: true });
+
+    await retrieveMemories({
+      query: "What did Vadim decide?",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const rendered = hybridQuery(executed);
+    const compact = normalizeSql(rendered.sql);
+    expect(compact).toContain("candidate_pool AS");
+    expect(compact).toContain("FROM memory_entities me JOIN memories m ON m.id = me.memory_id");
+    expect(compact).toContain("WHERE me.entity_id IN");
+    expect(compact).toContain("ORDER BY created_at DESC");
+    expect(compact).toContain("id IN (SELECT id FROM candidate_pool)");
+    expect(rendered.params).toContain("entity-vadim");
+    expect(rendered.params).toContain(50);
+  });
+
+  it("keeps the legacy global candidate pool when no entity resolves", async () => {
+    const executed = setupDb({ resolveEntity: false });
+
+    await retrieveMemories({
+      query: "what was decided recently",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const compact = normalizeSql(hybridQuery(executed).sql);
+    expect(compact).not.toContain("candidate_pool AS");
+    expect(compact).not.toContain("id IN (SELECT id FROM candidate_pool)");
+  });
+
+  it("guards DM-private memories to the current DM channel", async () => {
+    const executed = setupDb({ resolveEntity: false });
+
+    await retrieveMemories({
+      query: "what do you remember",
+      currentUserId: "U_B",
+      channelId: "D2",
+      channelType: "dm",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const rendered = hybridQuery(executed);
+    const compact = normalizeSql(rendered.sql);
+    expect(compact).toContain("source_channel_type != 'dm'");
+    expect(compact).toContain("source_channel_type = 'dm' AND source_channel_id =");
+    expect(compact).toContain("related_user_ids @> ARRAY");
+    expect(rendered.params).toContain("D2");
+    expect(rendered.params).toContain("U_B");
+    expect(rendered.params).not.toContain("D1");
+    expect(rendered.params).not.toContain("U_A");
+  });
+
+  it("does not add the entity candidate pool when prefilter is disabled", async () => {
+    aiMocks.generateObject.mockResolvedValue({
+      object: { entities: [{ name: "Vadim", type: "person" }] },
+    });
+    const executed = setupDb({ resolveEntity: true });
+
+    await retrieveMemories({
+      query: "What did Vadim decide?",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      prefilter: false,
+      limit: 15,
+    });
+
+    const compact = normalizeSql(hybridQuery(executed).sql);
+    expect(compact).not.toContain("candidate_pool AS");
+    expect(compact).not.toContain("id IN (SELECT id FROM candidate_pool)");
+  });
+});

--- a/apps/api/src/memory/retrieve.ts
+++ b/apps/api/src/memory/retrieve.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import { generateObject, rerank } from "ai";
 import { z } from "zod";
 import { db } from "../db/client.js";
-import { memories, messages, type Memory } from "@aura/db/schema";
+import { messages, type Memory } from "@aura/db/schema";
 import type { EntityType } from "@aura/db/schema";
 import { embedText } from "../lib/embeddings.js";
 import { getFastModel, getRerankingModel } from "../lib/ai.js";
@@ -16,6 +16,10 @@ interface RetrievalOptions {
   queryEmbedding?: number[];
   /** The Slack user ID of the person asking */
   currentUserId: string;
+  /** Slack channel/conversation where the query is happening, used for DM privacy and channel weighting */
+  channelId?: string;
+  /** Slack channel type for the current query context */
+  channelType?: string;
   /** Maximum number of memories to return */
   limit?: number;
   /** Minimum relevance score threshold */
@@ -24,10 +28,13 @@ interface RetrievalOptions {
   adminMode?: boolean;
   /** Workspace ID for tenant isolation in entity queries */
   workspaceId?: string;
+  /** Restrict cosine/full-text candidates to resolved entities + a recent tail. Defaults on. */
+  prefilter?: boolean;
 }
 
 const MAX_FULLTEXT_LEXEMES = 8;
 const PER_TERM_FULLTEXT_LIMIT = 25;
+const ENTITY_PREFILTER_RECENT_TAIL_LIMIT = 50;
 
 async function extractLexemes(
   query: string,
@@ -138,6 +145,65 @@ interface EntityMemoryResult {
   memoryEntityMap: Map<string, Set<string>>;
   /** Total number of distinct entities resolved */
   resolvedEntityCount: number;
+  /** Distinct resolved entity IDs, used to pre-filter the hybrid candidate pool */
+  resolvedEntityIds: string[];
+}
+
+interface MemoryVisibilityOptions {
+  adminMode: boolean;
+  currentUserId: string;
+  channelId?: string;
+}
+
+function memoryColumn(columnName: string, tableAlias?: string) {
+  return sql.raw(tableAlias ? `${tableAlias}.${columnName}` : columnName);
+}
+
+function buildMemoryVisibilityFilter(
+  options: MemoryVisibilityOptions,
+  tableAlias?: string,
+) {
+  if (options.adminMode) return sql`TRUE`;
+
+  const sourceChannelType = memoryColumn("source_channel_type", tableAlias);
+  const sourceChannelId = memoryColumn("source_channel_id", tableAlias);
+  const shareable = memoryColumn("shareable", tableAlias);
+  const relatedUserIds = memoryColumn("related_user_ids", tableAlias);
+  const sameDmPrivateMemory = options.channelId
+    ? sql`(
+        ${sourceChannelType} = 'dm'
+        AND ${sourceChannelId} = ${options.channelId}
+        AND ${relatedUserIds} @> ARRAY[${options.currentUserId}]::text[]
+      )`
+    : sql`FALSE`;
+
+  return sql`(
+    ${sourceChannelType} != 'dm'
+    OR ${shareable} = 1
+    OR ${sameDmPrivateMemory}
+  )`;
+}
+
+function buildMemoryBaseFilter(
+  minRelevanceScore: number,
+  workspaceId?: string,
+  tableAlias?: string,
+  requireEmbedding = true,
+) {
+  const embedding = memoryColumn("embedding", tableAlias);
+  const relevanceScore = memoryColumn("relevance_score", tableAlias);
+  const status = memoryColumn("status", tableAlias);
+  const workspace = memoryColumn("workspace_id", tableAlias);
+  const workspaceFilter = workspaceId
+    ? sql`${workspace} = ${workspaceId}`
+    : sql`TRUE`;
+
+  const embeddingFilter = requireEmbedding ? sql`${embedding} IS NOT NULL` : sql`TRUE`;
+
+  return sql`${embeddingFilter}
+    AND ${relevanceScore} >= ${minRelevanceScore}
+    AND ${status} IN ('current', 'disputed')
+    AND ${workspaceFilter}`;
 }
 
 /**
@@ -147,10 +213,15 @@ interface EntityMemoryResult {
 async function fetchEntityMatchedMemories(
   query: string,
   minRelevanceScore: number,
-  currentUserId?: string,
+  visibility: MemoryVisibilityOptions,
   workspaceId?: string,
 ): Promise<EntityMemoryResult> {
-  const emptyResult: EntityMemoryResult = { memories: [], memoryEntityMap: new Map(), resolvedEntityCount: 0 };
+  const emptyResult: EntityMemoryResult = {
+    memories: [],
+    memoryEntityMap: new Map(),
+    resolvedEntityCount: 0,
+    resolvedEntityIds: [],
+  };
 
   try {
     // Step 1: Extract entities via LLM
@@ -200,15 +271,8 @@ async function fetchEntityMatchedMemories(
     });
 
     // Step 4: Fetch memories linked to resolved entities, tracking which entity each memory came from
-    const privacyFilter = currentUserId
-      ? sql`AND (
-          m.source_channel_type != 'dm'
-          OR m.shareable = 1
-          OR m.related_user_ids @> ARRAY[${currentUserId}]::text[]
-        )`
-      : sql``;
-
-    const workspaceMemoryFilter = sql`AND m.workspace_id = ${workspaceId}`;
+    const visibilityFilter = buildMemoryVisibilityFilter(visibility, "m");
+    const memoryBaseFilter = buildMemoryBaseFilter(minRelevanceScore, workspaceId, "m", false);
 
     const entityIdList = sql.join(entityIds.map(id => sql`${id}`), sql`, `);
 
@@ -217,10 +281,8 @@ async function fetchEntityMatchedMemories(
       FROM memories m
       JOIN memory_entities me ON m.id = me.memory_id
       WHERE me.entity_id IN (${entityIdList})
-        AND m.relevance_score >= ${minRelevanceScore}
-        AND m.status IN ('current', 'disputed')
-        ${privacyFilter}
-        ${workspaceMemoryFilter}
+        AND ${memoryBaseFilter}
+        AND ${visibilityFilter}
       ORDER BY m.relevance_score DESC, m.created_at DESC
       LIMIT 50
     `);
@@ -279,6 +341,7 @@ async function fetchEntityMatchedMemories(
       memories: memoriesList,
       memoryEntityMap,
       resolvedEntityCount: entityIds.length,
+      resolvedEntityIds: entityIds,
     };
   } catch (error) {
     logger.warn("Entity-first retrieval failed, falling back to hybrid search only", {
@@ -305,16 +368,28 @@ async function fetchEntityMatchedMemories(
 export async function retrieveMemories(
   options: RetrievalOptions,
 ): Promise<Memory[]> {
-  const { query, queryEmbedding: precomputed, currentUserId, limit = 20, minRelevanceScore = 0.1, adminMode = false, workspaceId } = options;
+  const {
+    query,
+    queryEmbedding: precomputed,
+    currentUserId,
+    channelId,
+    channelType,
+    limit = 20,
+    minRelevanceScore = 0.1,
+    adminMode = false,
+    workspaceId,
+    prefilter = true,
+  } = options;
   const start = Date.now();
+  const visibility = { adminMode, currentUserId, channelId };
 
   try {
     const [queryEmbedding, lexemes, entityResult] = await Promise.all([
       precomputed ? Promise.resolve(precomputed) : embedText(query),
       extractLexemes(query),
-      fetchEntityMatchedMemories(query, minRelevanceScore, adminMode ? undefined : currentUserId, workspaceId),
+      fetchEntityMatchedMemories(query, minRelevanceScore, visibility, workspaceId),
     ]);
-    const { memories: entityMemories, memoryEntityMap, resolvedEntityCount } = entityResult;
+    const { memories: entityMemories, memoryEntityMap, resolvedEntityCount, resolvedEntityIds } = entityResult;
 
     const CANDIDATE_POOL_SIZE = Math.max(25, limit);
     // Embed vector as a raw SQL literal instead of a parameterized value.
@@ -323,27 +398,46 @@ export async function retrieveMemories(
     // values are finite numbers.
     const vectorSql = sql.raw(`'[${queryEmbedding.join(",")}]'::vector`);
 
-    const privacyFilter = adminMode
-      ? sql`TRUE`
-      : sql`(
-        ${memories.sourceChannelType} != 'dm'
-        OR ${memories.shareable} = 1
-        OR ${memories.relatedUserIds} @> ARRAY[${currentUserId}]::text[]
-      )`;
-
-    const statusFilter = sql`${memories.status} IN ('current', 'disputed')`;
-    // Multi-tenancy: scope the hybrid SQL lane to the workspace when one is
-    // supplied. Without this, the vector + full-text RRF query would see
-    // every workspace's memories. The entity-first lane already filters by
-    // workspace_id; this brings the hybrid lane in line.
-    const workspaceFilter = workspaceId
-      ? sql`${memories.workspaceId} = ${workspaceId}`
-      : sql`TRUE`;
-    const baseFilter = sql`${memories.embedding} IS NOT NULL AND ${memories.relevanceScore} >= ${minRelevanceScore} AND ${statusFilter} AND ${workspaceFilter}`;
+    const privacyFilter = buildMemoryVisibilityFilter(visibility);
+    const baseFilter = buildMemoryBaseFilter(minRelevanceScore, workspaceId);
+    const shouldPrefilterByEntity = prefilter && resolvedEntityIds.length > 0;
+    const entityPrefilterIds = shouldPrefilterByEntity
+      ? sql.join(resolvedEntityIds.map(id => sql`${id}`), sql`, `)
+      : sql``;
+    const candidatePoolCte = shouldPrefilterByEntity
+      ? sql`
+        candidate_pool AS (
+          SELECT DISTINCT me.memory_id AS id
+          FROM memory_entities me
+          JOIN memories m ON m.id = me.memory_id
+          WHERE me.entity_id IN (${entityPrefilterIds})
+            AND ${buildMemoryBaseFilter(minRelevanceScore, workspaceId, "m")}
+            AND ${buildMemoryVisibilityFilter(visibility, "m")}
+          UNION
+          SELECT id
+          FROM (
+            SELECT id
+            FROM memories
+            WHERE ${baseFilter} AND ${privacyFilter}
+            ORDER BY created_at DESC
+            LIMIT ${ENTITY_PREFILTER_RECENT_TAIL_LIMIT}
+          ) recent_global_memories
+        ),
+      `
+      : sql``;
+    const candidatePoolFilter = shouldPrefilterByEntity
+      ? sql`AND id IN (SELECT id FROM candidate_pool)`
+      : sql``;
+    const channelBoostSql = channelId
+      ? sql`CASE WHEN m.source_channel_id = ${channelId} THEN 1.0 ELSE 0.0 END`
+      : sql`0.0`;
 
     logger.debug(`Extracted ${lexemes.length} lexemes for fulltext search`, {
       lexemes,
       query: query.substring(0, 100),
+      prefilter: shouldPrefilterByEntity,
+      resolvedEntityCount,
+      channelType,
     });
 
     const fulltextSearchCte = lexemes.length === 0
@@ -365,6 +459,7 @@ export async function retrieveMemories(
               WHERE search_vector @@ to_tsquery('english', ${lexeme})
                 AND ${baseFilter}
                 AND ${privacyFilter}
+                ${candidatePoolFilter}
               ORDER BY ts_rank_cd(search_vector, to_tsquery('english', ${lexeme}), 4) DESC
               LIMIT ${PER_TERM_FULLTEXT_LIMIT}
             )
@@ -391,10 +486,11 @@ export async function retrieveMemories(
       })();
 
     const hybridQuery = sql`
-      WITH vector_search AS (
+      WITH ${candidatePoolCte}
+      vector_search AS (
         SELECT id, ROW_NUMBER() OVER (ORDER BY embedding <=> ${vectorSql}) AS rank
         FROM memories
-        WHERE ${baseFilter} AND ${privacyFilter}
+        WHERE ${baseFilter} AND ${privacyFilter} ${candidatePoolFilter}
         ORDER BY embedding <=> ${vectorSql}
         LIMIT ${CANDIDATE_POOL_SIZE}
       ),
@@ -402,7 +498,8 @@ export async function retrieveMemories(
       SELECT
         m.*,
         COALESCE(rrf_score(v.rank), 0.0) + COALESCE(rrf_score(f.rank), 0.0) AS rrf_score,
-        (1 - (m.embedding <=> ${vectorSql})) AS similarity
+        (1 - (m.embedding <=> ${vectorSql})) AS similarity,
+        ${channelBoostSql} AS channel_boost
       FROM (
         SELECT COALESCE(v.id, f.id) AS id, v.rank AS vector_rank, f.rank AS fulltext_rank
         FROM vector_search v
@@ -451,6 +548,7 @@ export async function retrieveMemories(
       } as Memory,
       similarity: Number(row.similarity ?? 0),
       rrfScore: Number(row.rrf_score ?? 0),
+      channelBoost: Number(row.channel_boost ?? 0),
     }));
 
     // Merge entity-matched memories; track entity boost as a separate signal
@@ -472,6 +570,7 @@ export async function retrieveMemories(
         similarity: 0,
         rrfScore: ENTITY_RRF_BOOST,
         entityBoost: entityBoostScore(m.id),
+        channelBoost: channelId && m.sourceChannelId === channelId ? 1 : 0,
       }));
 
     const results = hybridResults.map((r) => ({
@@ -483,6 +582,7 @@ export async function retrieveMemories(
     if (entityMemories.length > 0) {
       logger.debug(`Entity-first retrieval found ${entityMemories.length} memories, ${entityOnlyMemories.length} unique`, {
         resolvedEntities: resolvedEntityCount,
+        prefilter: shouldPrefilterByEntity,
         query: query.substring(0, 100),
       });
     }
@@ -502,6 +602,7 @@ export async function retrieveMemories(
       });
 
       const ENTITY_WEIGHT = 0.1;
+      const CHANNEL_WEIGHT = channelId ? 0.05 : 0;
       const scored = ranking.map((item) => {
         const result = results[item.originalIndex];
         const memory = result.memory;
@@ -509,7 +610,11 @@ export async function retrieveMemories(
         const ageDays = ageMs / (1000 * 60 * 60 * 24);
         const recencyBoost = Math.max(0, 1 - ageDays / 365);
 
-        const score = item.score * (0.8 - ENTITY_WEIGHT / 2) + recencyBoost * (0.2 - ENTITY_WEIGHT / 2) + result.entityBoost * ENTITY_WEIGHT;
+        const score =
+          item.score * (0.8 - ENTITY_WEIGHT / 2 - CHANNEL_WEIGHT / 2) +
+          recencyBoost * (0.2 - ENTITY_WEIGHT / 2 - CHANNEL_WEIGHT / 2) +
+          result.entityBoost * ENTITY_WEIGHT +
+          result.channelBoost * CHANNEL_WEIGHT;
         return { memory, score, originalIndex: item.originalIndex, cohereScore: item.score };
       });
 
@@ -522,6 +627,8 @@ export async function retrieveMemories(
           query: query.substring(0, 100),
           totalCandidates: results.length,
           lexemeCount: lexemes.length,
+          prefilter: shouldPrefilterByEntity,
+          channelId,
           method: "hybrid-rrf+cohere-rerank",
         },
       );
@@ -533,18 +640,20 @@ export async function retrieveMemories(
       const RRF_K = 60;
       const maxRrfScore = 2 / (1 + RRF_K);
 
-      const scored = results.map(({ memory, similarity, rrfScore, entityBoost }) => {
+      const CHANNEL_WEIGHT = channelId ? 0.1 : 0;
+      const scored = results.map(({ memory, similarity, rrfScore, entityBoost, channelBoost }) => {
         const ageMs = now - new Date(memory.createdAt).getTime();
         const ageDays = ageMs / (1000 * 60 * 60 * 24);
         const recencyBoost = Math.max(0, 1 - ageDays / 365);
 
         const normalizedRrf = maxRrfScore > 0 ? Math.min(rrfScore / maxRrfScore, 1) : 0;
         const score =
-          normalizedRrf * 0.4 +
+          normalizedRrf * (0.4 - CHANNEL_WEIGHT / 2) +
           similarity * 0.2 +
           memory.relevanceScore * 0.1 +
           recencyBoost * 0.1 +
-          entityBoost * 0.2;
+          entityBoost * (0.2 - CHANNEL_WEIGHT / 2) +
+          channelBoost * CHANNEL_WEIGHT;
 
         return { memory, score };
       });
@@ -558,6 +667,8 @@ export async function retrieveMemories(
           query: query.substring(0, 100),
           totalCandidates: results.length,
           lexemeCount: lexemes.length,
+          prefilter: shouldPrefilterByEntity,
+          channelId,
           method: "hybrid-rrf+legacy",
         },
       );

--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -38,6 +38,8 @@ export interface ChannelSession {
   isDirectMessage: boolean;
   /** Specific channel type — when omitted, derived from isDirectMessage (dm vs public_channel). */
   channelType?: ChannelType;
+  /** Workspace ID for tenant-scoped memory retrieval. */
+  workspaceId?: string;
   userTimezone?: string;
   /** Human-readable channel name (e.g. "#dev (C0BNVKS77)"). Falls back to conversationId. */
   channelDisplayName?: string;
@@ -296,6 +298,10 @@ export async function buildCorePrompt(
             query: session.messageText,
             queryEmbedding,
             currentUserId: session.userId,
+            channelId: session.conversationId,
+            channelType: session.channelType,
+            workspaceId: session.workspaceId ?? process.env.DEFAULT_WORKSPACE_ID ?? "default",
+            prefilter: true,
             limit: 15,
           }).catch(() => [] as Memory[])
         : Promise.resolve([] as Memory[]),
@@ -307,6 +313,7 @@ export async function buildCorePrompt(
             matchLimit: 15,
             minSimilarity: 0.35,
             excludeThreadTs: session.threadId,
+            workspaceId: session.workspaceId ?? process.env.DEFAULT_WORKSPACE_ID ?? "default",
           })
         : Promise.resolve([] as ConversationThread[]),
       session.userProfile !== undefined

--- a/apps/api/src/pipeline/prompt.ts
+++ b/apps/api/src/pipeline/prompt.ts
@@ -100,6 +100,7 @@ export async function assemblePrompt(
     conversationContext: threadContext,
     isDirectMessage: context.isDm,
     channelType: context.channelType === "slack_list_item" ? "public_channel" : context.channelType,
+    workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
     userTimezone,
     channelDisplayName,
     isChannelHistory,

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -429,6 +429,8 @@ dashboardChatApp.openapi(postChatRoute, async (c) => {
       conversationId: "dashboard",
       messageText,
       isDirectMessage: true,
+      channelType: "dashboard",
+      workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
       modelIdOverride: modelId,
     });
 

--- a/apps/api/src/routes/dashboard/memories.ts
+++ b/apps/api/src/routes/dashboard/memories.ts
@@ -69,8 +69,12 @@ dashboardMemoriesApp.openapi(listMemoriesRoute, async (c) => {
         const results = await retrieveMemories({
           query: search,
           currentUserId: "dashboard",
+          channelId: "dashboard",
+          channelType: "dashboard",
+          workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
           limit,
           adminMode: true,
+          prefilter: true,
         });
 
         let items = results.map(({ embedding, searchVector, workspaceId, ...rest }) => rest);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add default-on memory retrieval prefiltering: when query entity resolution succeeds, hybrid vector/full-text scoring is limited to memories linked to resolved entities plus the 50 most recent visible memories.
- Thread channel/workspace context through memory retrieval call sites and add in-channel ranking boost.
- Tighten non-admin DM visibility so non-shareable DM memories only match in the same DM channel for the related user.
- Add focused unit tests for entity prefilter SQL, entity-less fallback, DM privacy guard, and `prefilter=false` escape hatch.

## Benchmark results

Requested command/subset: `pnpm bench:memory --subset=medium --dataset=both --log`.

Local bench runs could not reach scoring in this Cloud environment because the required root `.env.local` is absent and no `DATABASE_URL` / model credentials are present. I also checked the available Vercel/Neon MCP and Vercel CLI paths; they require authentication in this environment.

The GitHub memory-bench workflow did start for this PR (run `26607036061`) and created an ephemeral Neon branch, but it did not produce a sticky PR comment or `result.json`. It loaded 150 LoCoMo + 180 LongMemEval cases, then embeddings failed with `GatewayAuthenticationError: AI Gateway authentication failed: No authentication provided` because `AI_GATEWAY_API_KEY` was empty in the workflow environment. The job was cancelled at the 25-minute timeout during ingestion/scoring, so no per-category metrics are available from CI either.

### Baseline on main
- Commit: `0431705`
- Command attempted: `pnpm bench:memory --subset=medium --dataset=both --log --note="baseline before #1044 prefilter"`
- Result: blocked before scoring locally: `.env.local not found`

| Dataset | Category | QA accuracy | recall@15 |
|---|---|---:|---:|
| locomo | single_hop | unavailable | unavailable |
| locomo | multi_hop | unavailable | unavailable |
| longmemeval | single_hop | unavailable | unavailable |
| longmemeval | multi_hop | unavailable | unavailable |
| longmemeval | temporal | unavailable | unavailable |
| longmemeval | knowledge_update | unavailable | unavailable |
| longmemeval | abstention | unavailable | unavailable |

### Post-change
- Commit: `4170a29`
- Command attempted locally: `pnpm bench:memory --subset=medium --dataset=both --log --note="#1044 prefilter implementation"`
- Local result: blocked before scoring: `.env.local not found`
- CI result: memory-bench run `26607036061` cancelled at timeout after embedding failures from missing `AI_GATEWAY_API_KEY`; no `result.json`

| Dataset | Category | QA accuracy | recall@15 |
|---|---|---:|---:|
| locomo | single_hop | unavailable | unavailable |
| locomo | multi_hop | unavailable | unavailable |
| longmemeval | single_hop | unavailable | unavailable |
| longmemeval | multi_hop | unavailable | unavailable |
| longmemeval | temporal | unavailable | unavailable |
| longmemeval | knowledge_update | unavailable | unavailable |
| longmemeval | abstention | unavailable | unavailable |

### Delta
| Dataset | Category | QA accuracy delta | recall@15 delta |
|---|---|---:|---:|
| locomo | single_hop | unavailable | unavailable |
| locomo | multi_hop | unavailable | unavailable |
| longmemeval | single_hop | unavailable | unavailable |
| longmemeval | multi_hop | unavailable | unavailable |
| longmemeval | temporal | unavailable | unavailable |
| longmemeval | knowledge_update | unavailable | unavailable |
| longmemeval | abstention | unavailable | unavailable |

Verdict: benchmark delta is not measurable until the bench environment has AI Gateway credentials (or the embedding path has an Anthropic/direct fallback). No category regression can be confirmed or ruled out from this run.

## Verification
- `pnpm --filter aura-api test src/memory/retrieve.test.ts`
- `pnpm --filter aura-api typecheck`
- `pnpm typecheck`
- `pnpm --filter aura-api test`

Part of #1042. Closes #1044.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-230aff6a-8b10-4a68-9d2f-f0b68c088b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-230aff6a-8b10-4a68-9d2f-f0b68c088b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

