### PR TITLE
Self-heal reasoning model thinking capabilities

### DIFF
--- a/apps/api/src/lib/ai.test.ts
+++ b/apps/api/src/lib/ai.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  gatewayAuthIsInstance: vi.fn(),
+  getDefaultModelId: vi.fn(),
+  getModelCapabilities: vi.fn(),
+  updateModelCapabilities: vi.fn(),
+  wrapLanguageModel: vi.fn(({ model, middleware }: any) => ({
+    ...model,
+    doGenerate: (params: any) =>
+      middleware.wrapGenerate({
+        doGenerate: () => model.doGenerate(params),
+        params,
+      }),
+    doStream: (params: any) =>
+      middleware.wrapStream({
+        doStream: () => model.doStream(params),
+        params,
+      }),
+  })),
+}));
+
+vi.mock("ai", () => ({
+  pruneMessages: ({ messages }: any) => messages,
+  wrapLanguageModel: mocks.wrapLanguageModel,
+}));
+
+vi.mock("@ai-sdk/gateway", () => ({
+  gateway: vi.fn(),
+  GatewayAuthenticationError: {
+    isInstance: mocks.gatewayAuthIsInstance,
+  },
+}));
+
+vi.mock("./settings.js", () => ({
+  getSetting: vi.fn(),
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  getDefaultModelId: mocks.getDefaultModelId,
+  getModelCapabilities: mocks.getModelCapabilities,
+  updateModelCapabilities: mocks.updateModelCapabilities,
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("./invocation-lock.js", () => ({
+  isInvocationCurrent: vi.fn(),
+}));
+
+import { withAnthropicFallback } from "./ai.js";
+
+describe("withAnthropicFallback thinking self-heal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.gatewayAuthIsInstance.mockReturnValue(false);
+    mocks.updateModelCapabilities.mockResolvedValue(true);
+  });
+
+  it("persists adaptive Anthropic capabilities and retries stream with corrected options", async () => {
+    const streamResult = { stream: "ok" };
+    const gatewayModel = {
+      doGenerate: vi.fn(),
+      doStream: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error("\"thinking.type.enabled\" is not supported for this model"),
+        )
+        .mockResolvedValueOnce(streamResult),
+    };
+    mocks.getModelCapabilities.mockResolvedValue({
+      found: true,
+      supportsThinking: true,
+      tags: ["reasoning"],
+      capabilities: { provider: "anthropic", thinkingMode: "adaptive" },
+    });
+
+    const wrapped = withAnthropicFallback(
+      gatewayModel as any,
+      "anthropic/claude-opus-4.7",
+    ) as any;
+
+    await expect(
+      wrapped.doStream({
+        providerOptions: {
+          anthropic: {
+            thinking: { type: "enabled", budgetTokens: 4096 },
+            cacheControl: { type: "ephemeral" },
+          },
+        },
+      }),
+    ).resolves.toBe(streamResult);
+
+    expect(mocks.updateModelCapabilities).toHaveBeenCalledWith(
+      "anthropic/claude-opus-4.7",
+      { provider: "anthropic", thinkingMode: "adaptive" },
+    );
+    expect(gatewayModel.doStream).toHaveBeenCalledTimes(2);
+    expect(gatewayModel.doStream).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        providerOptions: {
+          anthropic: {
+            thinking: { type: "adaptive" },
+            cacheControl: { type: "ephemeral" },
+          },
+        },
+      }),
+    );
+  });
+});

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -7,8 +7,13 @@ import {
 /** The model type that wrapLanguageModel accepts (LanguageModelV3, not re-exported by "ai"). */
 export type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 import { getSetting } from "./settings.js";
-import { getDefaultModelId } from "./model-catalog.js";
+import { getDefaultModelId, updateModelCapabilities } from "./model-catalog.js";
 import { logger } from "./logger.js";
+import {
+  getProviderThinkingOptions,
+  resolveProviderThinkingOptions,
+} from "../pipeline/prepare-step.js";
+import type { ModelCapabilities } from "@aura/db/schema";
 
 /**
  * All LLM and embedding calls go through Vercel AI Gateway.
@@ -73,8 +78,122 @@ async function getDirectAnthropicModel(modelId: string) {
   return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(modelId);
 }
 
+const ENABLED_THINKING_UNSUPPORTED =
+  "\"thinking.type.enabled\" is not supported for this model";
+const ADAPTIVE_THINKING_UNSUPPORTED =
+  "adaptive thinking is not supported on this model";
+
+function errorIncludes(error: unknown, needle: string): boolean {
+  if (error instanceof Error) {
+    if (error.message.includes(needle) || String(error).includes(needle)) {
+      return true;
+    }
+
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause && errorIncludes(cause, needle)) {
+      return true;
+    }
+
+    const nested = (error as { errors?: unknown }).errors;
+    if (Array.isArray(nested)) {
+      return nested.some((item) => errorIncludes(item, needle));
+    }
+
+    return false;
+  }
+
+  return String(error).includes(needle);
+}
+
+function getSelfHealedAnthropicCapabilities(
+  error: unknown,
+): ModelCapabilities | null {
+  if (errorIncludes(error, ENABLED_THINKING_UNSUPPORTED)) {
+    return { provider: "anthropic", thinkingMode: "adaptive" };
+  }
+  if (errorIncludes(error, ADAPTIVE_THINKING_UNSUPPORTED)) {
+    return { provider: "anthropic", thinkingMode: "enabled" };
+  }
+  return null;
+}
+
+function getBudgetTokensFromParams(params: unknown): number {
+  const thinking = (params as any)?.providerOptions?.anthropic?.thinking;
+  return typeof thinking?.budgetTokens === "number" ? thinking.budgetTokens : 8000;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeProviderOptions(
+  existing: unknown,
+  corrected: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = isRecord(existing) ? { ...existing } : {};
+
+  for (const [provider, options] of Object.entries(corrected)) {
+    const existingProviderOptions = merged[provider];
+    merged[provider] = {
+      ...(isRecord(existingProviderOptions) ? existingProviderOptions : {}),
+      ...(isRecord(options) ? options : {}),
+    };
+  }
+
+  return merged;
+}
+
+type SelfHealRetryResult<T> =
+  | { healed: false }
+  | { healed: true; result: T };
+
+async function retryWithSelfHealedThinking<T>(opts: {
+  error: unknown;
+  gatewayId: string;
+  params: unknown;
+  retry: (params: any) => PromiseLike<T>;
+}): Promise<SelfHealRetryResult<T>> {
+  const capabilities = getSelfHealedAnthropicCapabilities(opts.error);
+  if (!capabilities) return { healed: false };
+
+  const wrote = await updateModelCapabilities(opts.gatewayId, capabilities);
+  logger.info("Self-healed Anthropic thinking capabilities", {
+    modelId: opts.gatewayId,
+    capabilities,
+    persisted: wrote,
+  });
+
+  const budgetTokens = getBudgetTokensFromParams(opts.params);
+  let correctedProviderOptions = await getProviderThinkingOptions(
+    opts.gatewayId,
+    budgetTokens,
+  ).catch(() =>
+    resolveProviderThinkingOptions(opts.gatewayId, capabilities, budgetTokens),
+  );
+
+  if (Object.keys(correctedProviderOptions).length === 0) {
+    correctedProviderOptions = resolveProviderThinkingOptions(
+      opts.gatewayId,
+      capabilities,
+      budgetTokens,
+    );
+  }
+
+  const retryParams = {
+    ...(isRecord(opts.params) ? opts.params : {}),
+    providerOptions: mergeProviderOptions(
+      (opts.params as any)?.providerOptions,
+      correctedProviderOptions as Record<string, unknown>,
+    ),
+  };
+
+  return { healed: true, result: await opts.retry(retryParams) };
+}
+
 function gatewayFallbackMiddleware(
   directModelId: string,
+  gatewayId: string,
+  gatewayModel: WrappableModel,
 ): LanguageModelMiddleware {
   return {
     specificationVersion: "v3" as const,
@@ -82,6 +201,17 @@ function gatewayFallbackMiddleware(
       try {
         return await doGenerate();
       } catch (error) {
+        const healed = await retryWithSelfHealedThinking<
+          Awaited<ReturnType<typeof doGenerate>>
+        >({
+          error,
+          gatewayId,
+          params,
+          retry: (retryParams) =>
+            gatewayModel.doGenerate(retryParams) as ReturnType<typeof doGenerate>,
+        });
+        if (healed.healed) return healed.result;
+
         if (GatewayAuthenticationError.isInstance(error)) {
           logger.warn(
             "Gateway auth failed, falling back to direct Anthropic API",
@@ -97,6 +227,17 @@ function gatewayFallbackMiddleware(
       try {
         return await doStream();
       } catch (error) {
+        const healed = await retryWithSelfHealedThinking<
+          Awaited<ReturnType<typeof doStream>>
+        >({
+          error,
+          gatewayId,
+          params,
+          retry: (retryParams) =>
+            gatewayModel.doStream(retryParams) as ReturnType<typeof doStream>,
+        });
+        if (healed.healed) return healed.result;
+
         if (GatewayAuthenticationError.isInstance(error)) {
           logger.warn(
             "Gateway auth failed (stream), falling back to direct Anthropic API",
@@ -124,7 +265,7 @@ export function withAnthropicFallback(gatewayModel: WrappableModel, gatewayId: s
 
   return wrapLanguageModel({
     model: gatewayModel,
-    middleware: gatewayFallbackMiddleware(directId),
+    middleware: gatewayFallbackMiddleware(directId, gatewayId, gatewayModel),
   });
 }
 
@@ -150,13 +291,6 @@ export async function getFastModelId(): Promise<string> {
 export async function getEmbeddingModel() {
   const gatewayId = await resolveModelId("model_embedding", "embedding");
   return gateway.embedding(gatewayId);
-}
-
-/**
- * Check if a model is Anthropic (used to decide where provider options apply).
- */
-export function isAnthropicModel(modelId: string): boolean {
-  return modelId.startsWith("anthropic/") || modelId.startsWith("claude");
 }
 
 /**

--- a/apps/api/src/lib/model-capabilities-schema.test.ts
+++ b/apps/api/src/lib/model-capabilities-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { ModelCapabilities } from "@aura/db/schema";
+
+describe("ModelCapabilities schema", () => {
+  it("accepts valid provider-specific capability shapes", () => {
+    expect(
+      ModelCapabilities.safeParse({
+        provider: "anthropic",
+        thinkingMode: "adaptive",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      ModelCapabilities.safeParse({
+        provider: "google",
+        thinkingBudget: "dynamic",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects malformed provider-specific capability shapes", () => {
+    expect(
+      ModelCapabilities.safeParse({
+        provider: "anthropic",
+        reasoningEffort: "high",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ModelCapabilities.safeParse({
+        provider: "openai",
+        reasoningEffort: "extreme",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ModelCapabilities.safeParse({
+        provider: "google",
+        thinkingBudget: true,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ModelCapabilities.safeParse({
+        thinkingMode: "enabled",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -7,6 +7,8 @@ import {
   sql,
 } from "drizzle-orm";
 import {
+  ModelCapabilities as ModelCapabilitiesSchema,
+  type ModelCapabilities as StoredModelCapabilities,
   modelCatalog,
   modelCatalogSelections,
   modelPricing,
@@ -71,6 +73,141 @@ const DEFAULT_WORKSPACE_ID = "default";
 
 function providerFromModelId(modelId: string): string {
   return modelId.split("/")[0] ?? "unknown";
+}
+
+function getGatewayModelTags(model: GatewayModel): string[] {
+  return Array.isArray(model.tags)
+    ? model.tags.filter((tag): tag is string => typeof tag === "string")
+    : [];
+}
+
+function hasReasoningTag(tags: string[]): boolean {
+  return tags.includes("reasoning");
+}
+
+function errorIncludes(error: unknown, needle: string): boolean {
+  if (error instanceof Error) {
+    if (error.message.includes(needle) || String(error).includes(needle)) {
+      return true;
+    }
+
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause && errorIncludes(cause, needle)) {
+      return true;
+    }
+
+    const nested = (error as { errors?: unknown }).errors;
+    if (Array.isArray(nested)) {
+      return nested.some((item) => errorIncludes(item, needle));
+    }
+
+    return false;
+  }
+
+  return String(error).includes(needle);
+}
+
+function inferStaticModelCapabilities(
+  gatewayModel: GatewayModel,
+): StoredModelCapabilities | null {
+  const tags = getGatewayModelTags(gatewayModel);
+  if (!hasReasoningTag(tags)) return null;
+
+  switch (providerFromModelId(gatewayModel.id)) {
+    case "openai":
+      return { provider: "openai", reasoningEffort: "medium" };
+    case "google":
+      return { provider: "google", thinkingBudget: "dynamic" };
+    case "xai":
+      return { provider: "xai", reasoningEffort: "low" };
+    default:
+      return null;
+  }
+}
+
+async function probeAnthropicThinkingMode(
+  modelId: string,
+): Promise<StoredModelCapabilities | null> {
+  const [{ generateText }, { gateway }] = await Promise.all([
+    import("ai"),
+    import("@ai-sdk/gateway"),
+  ]);
+
+  try {
+    await generateText({
+      model: gateway(modelId),
+      prompt: "ok",
+      providerOptions: {
+        anthropic: {
+          thinking: { type: "enabled", budgetTokens: 1024 },
+        },
+      },
+      maxOutputTokens: 10,
+    });
+    return { provider: "anthropic", thinkingMode: "enabled" };
+  } catch (error) {
+    if (errorIncludes(error, "\"thinking.type.enabled\" is not supported")) {
+      return { provider: "anthropic", thinkingMode: "adaptive" };
+    }
+    if (errorIncludes(error, "adaptive thinking is not supported on this model")) {
+      return { provider: "anthropic", thinkingMode: "enabled" };
+    }
+
+    logger.warn("Anthropic thinking-mode probe failed", {
+      modelId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+async function seedModelCapabilitiesForSyncedModels(
+  gatewayModels: GatewayModel[],
+  workspaceId: string,
+): Promise<void> {
+  const modelIds = gatewayModels.map((model) => model.id);
+  if (modelIds.length === 0) return;
+
+  const gatewayModelById = new Map(
+    gatewayModels.map((model) => [model.id, model]),
+  );
+  const rows = await db
+    .select({
+      modelId: modelCatalog.modelId,
+      capabilities: modelCatalog.capabilities,
+    })
+    .from(modelCatalog)
+    .where(
+      and(
+        eq(modelCatalog.workspaceId, workspaceId),
+        inArray(modelCatalog.modelId, modelIds),
+        isNull(modelCatalog.capabilities),
+      ),
+    );
+
+  for (const row of rows) {
+    const gatewayModel = gatewayModelById.get(row.modelId);
+    if (!gatewayModel) continue;
+
+    const tags = getGatewayModelTags(gatewayModel);
+    if (!hasReasoningTag(tags)) continue;
+
+    let capabilities: StoredModelCapabilities | null = null;
+    if (providerFromModelId(row.modelId) === "anthropic") {
+      capabilities = await probeAnthropicThinkingMode(row.modelId);
+    } else {
+      capabilities = inferStaticModelCapabilities(gatewayModel);
+    }
+
+    if (!capabilities) continue;
+
+    await updateModelCapabilities(row.modelId, capabilities, workspaceId);
+    logger.info("Seeded model capabilities from catalog refresh", {
+      workspaceId,
+      modelId: row.modelId,
+      capabilities,
+    });
+  }
 }
 
 function normalizePricingKey(key: string): string {
@@ -142,11 +279,8 @@ export async function syncModelCatalogFromGateway(
             typeof gatewayModel.max_tokens === "number"
               ? gatewayModel.max_tokens
               : null,
-          tags: Array.isArray(gatewayModel.tags)
-            ? gatewayModel.tags.filter(
-                (tag): tag is string => typeof tag === "string",
-              )
-            : null,
+          tags: getGatewayModelTags(gatewayModel),
+          capabilities: inferStaticModelCapabilities(gatewayModel),
           rawPricing: gatewayModel.pricing ?? null,
           rawPayload: gatewayModel,
           lastSyncedAt: syncedAt,
@@ -170,6 +304,11 @@ export async function syncModelCatalogFromGateway(
         },
       });
   }
+
+  for (const modelId of gatewayModels.map((model) => model.id)) {
+    capabilityCache.delete(`${workspaceId}::${modelId}`);
+  }
+  await seedModelCapabilitiesForSyncedModels(gatewayModels, workspaceId);
 
   const modelIds = gatewayModels.map((model) => model.id);
   const activeRows = modelIds.length
@@ -367,31 +506,41 @@ export async function getDefaultModelId(
   return catalog.defaults[category] ?? null;
 }
 
-// ── Model capabilities (from gateway tags) ───────────────────────────────────
+// ── Model capabilities (from gateway tags + persisted provider config) ───────
 // The Vercel AI Gateway returns a `tags` array per model. We treat the
 // presence of `"reasoning"` as the signal that a model supports thinking —
 // this is the same source of truth used across repos (mako/mono). No model
 // ID parsing.
 
-export interface ModelCapabilities {
+export interface ModelCatalogCapabilities {
+  found: boolean;
   supportsThinking: boolean;
   tags: string[];
+  capabilities: StoredModelCapabilities | null;
 }
 
 const CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
-const capabilityCache = new Map<string, { value: ModelCapabilities; expiresAt: number }>();
-const MISSING_CAPABILITIES: ModelCapabilities = { supportsThinking: false, tags: [] };
+const capabilityCache = new Map<string, { value: ModelCatalogCapabilities; expiresAt: number }>();
+const MISSING_CAPABILITIES: ModelCatalogCapabilities = {
+  found: false,
+  supportsThinking: false,
+  tags: [],
+  capabilities: null,
+};
 
 export async function getModelCapabilities(
   modelId: string,
   workspaceId = DEFAULT_WORKSPACE_ID,
-): Promise<ModelCapabilities> {
+): Promise<ModelCatalogCapabilities> {
   const cacheKey = `${workspaceId}::${modelId}`;
   const cached = capabilityCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) return cached.value;
 
   const [row] = await db
-    .select({ tags: modelCatalog.tags })
+    .select({
+      tags: modelCatalog.tags,
+      capabilities: modelCatalog.capabilities,
+    })
     .from(modelCatalog)
     .where(
       and(
@@ -402,9 +551,25 @@ export async function getModelCapabilities(
     .limit(1);
 
   const tags = Array.isArray(row?.tags) ? row!.tags : [];
-  const value: ModelCapabilities = {
+  let capabilities: StoredModelCapabilities | null = null;
+  if (row?.capabilities != null) {
+    const parsed = ModelCapabilitiesSchema.safeParse(row.capabilities);
+    if (parsed.success) {
+      capabilities = parsed.data;
+    } else {
+      logger.warn("getModelCapabilities: invalid persisted capabilities", {
+        modelId,
+        workspaceId,
+        issues: parsed.error.issues,
+      });
+    }
+  }
+
+  const value: ModelCatalogCapabilities = {
+    found: Boolean(row),
     supportsThinking: tags.includes("reasoning"),
     tags,
+    capabilities,
   };
 
   if (!row) {
@@ -424,5 +589,39 @@ export async function getModelCapabilities(
     expiresAt: Date.now() + CAPABILITY_CACHE_TTL_MS,
   });
   return value;
+}
+
+export async function updateModelCapabilities(
+  modelId: string,
+  capabilities: StoredModelCapabilities,
+  workspaceId = DEFAULT_WORKSPACE_ID,
+): Promise<boolean> {
+  const parsed = ModelCapabilitiesSchema.parse(capabilities);
+  const [updated] = await db
+    .update(modelCatalog)
+    .set({
+      capabilities: parsed,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(modelCatalog.workspaceId, workspaceId),
+        eq(modelCatalog.modelId, modelId),
+      ),
+    )
+    .returning({ modelId: modelCatalog.modelId });
+
+  capabilityCache.delete(`${workspaceId}::${modelId}`);
+
+  if (!updated) {
+    logger.warn("updateModelCapabilities: model not in catalog", {
+      modelId,
+      workspaceId,
+      capabilities: parsed,
+    });
+    return false;
+  }
+
+  return true;
 }
 

--- a/apps/api/src/pipeline/prepare-step.test.ts
+++ b/apps/api/src/pipeline/prepare-step.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCapabilities } from "@aura/db/schema";
+
+const catalogMocks = vi.hoisted(() => ({
+  getModelCapabilities: vi.fn(),
+}));
+
+vi.mock("../lib/model-catalog.js", () => ({
+  getModelCapabilities: catalogMocks.getModelCapabilities,
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/invocation-lock.js", () => ({
+  isInvocationCurrent: vi.fn(),
+}));
+
+import {
+  getProviderThinkingOptions,
+  resolveProviderThinkingOptions,
+} from "./prepare-step.js";
+
+function catalogRow(capabilities: ModelCapabilities | null, supportsThinking = true) {
+  return {
+    found: true,
+    supportsThinking,
+    tags: supportsThinking ? ["reasoning"] : [],
+    capabilities,
+  };
+}
+
+describe("getProviderThinkingOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves Anthropic adaptive thinking", async () => {
+    catalogMocks.getModelCapabilities.mockResolvedValue(
+      catalogRow({ provider: "anthropic", thinkingMode: "adaptive" }),
+    );
+
+    await expect(getProviderThinkingOptions("anthropic/claude-opus-4.7", 8000))
+      .resolves.toEqual({
+        anthropic: { thinking: { type: "adaptive" } },
+      });
+  });
+
+  it("resolves Anthropic enabled thinking with the requested budget", async () => {
+    catalogMocks.getModelCapabilities.mockResolvedValue(
+      catalogRow({ provider: "anthropic", thinkingMode: "enabled" }),
+    );
+
+    await expect(getProviderThinkingOptions("anthropic/claude-opus-4.6", 12000))
+      .resolves.toEqual({
+        anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } },
+      });
+  });
+
+  it("resolves OpenAI reasoning effort", async () => {
+    catalogMocks.getModelCapabilities.mockResolvedValue(
+      catalogRow({ provider: "openai", reasoningEffort: "medium" }),
+    );
+
+    await expect(getProviderThinkingOptions("openai/gpt-5.1", 8000))
+      .resolves.toEqual({
+        openai: { reasoningEffort: "medium" },
+      });
+  });
+
+  it("resolves Google dynamic thinking budget to provider dynamic mode", async () => {
+    catalogMocks.getModelCapabilities.mockResolvedValue(
+      catalogRow({ provider: "google", thinkingBudget: "dynamic" }),
+    );
+
+    await expect(getProviderThinkingOptions("google/gemini-2.5-pro", 8000))
+      .resolves.toEqual({
+        google: { thinkingConfig: { thinkingBudget: -1 } },
+      });
+  });
+
+  it("resolves xAI reasoning effort", async () => {
+    catalogMocks.getModelCapabilities.mockResolvedValue(
+      catalogRow({ provider: "xai", reasoningEffort: "low" }),
+    );
+
+    await expect(getProviderThinkingOptions("xai/grok-4-fast-reasoning", 8000))
+      .resolves.toEqual({
+        xai: { reasoningEffort: "low" },
+      });
+  });
+
+  it("falls back to enabled thinking for reasoning Anthropic models with null capabilities", () => {
+    expect(
+      resolveProviderThinkingOptions(
+        "anthropic/claude-opus-4.9",
+        null,
+        8000,
+        { found: true, supportsThinking: true },
+      ),
+    ).toEqual({
+      anthropic: { thinking: { type: "enabled", budgetTokens: 8000 } },
+    });
+  });
+
+  it("returns no override for non-reasoning null capabilities and unknown providers", () => {
+    expect(
+      resolveProviderThinkingOptions(
+        "anthropic/claude-haiku-4.5",
+        null,
+        8000,
+        { found: true, supportsThinking: false },
+      ),
+    ).toEqual({});
+
+    expect(
+      resolveProviderThinkingOptions(
+        "deepseek/deepseek-v3.2-thinking",
+        null,
+        8000,
+        { found: true, supportsThinking: true },
+      ),
+    ).toEqual({});
+  });
+});

--- a/apps/api/src/pipeline/prepare-step.ts
+++ b/apps/api/src/pipeline/prepare-step.ts
@@ -1,10 +1,10 @@
 import { pruneMessages } from "ai";
 import type { LanguageModel, ModelMessage } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
-import { isAnthropicModel } from "../lib/ai.js";
 import { getModelCapabilities } from "../lib/model-catalog.js";
 import { isInvocationCurrent } from "../lib/invocation-lock.js";
 import { logger } from "../lib/logger.js";
+import type { ModelCapabilities } from "@aura/db/schema";
 
 export class InvocationSupersededError extends Error {
   constructor(public readonly invocationId: string) {
@@ -55,29 +55,90 @@ type PrepareStepFn = (options: {
  * ignored — we rely on the model's own adaptive behavior.
  */
 
-/**
- * Some Anthropic models only support adaptive thinking (self-managed budget),
- * not the classic `{ type: "enabled", budgetTokens }` API. Opus 4.7 is the
- * first such model. Sending `enabled` to an adaptive-only model causes the
- * direct Anthropic API to reject the request, producing
- * `AI_NoOutputGeneratedError` with an empty stream.
- *
- * The gateway catalog only exposes a single `reasoning` tag and doesn't
- * distinguish the two thinking modes, so we keep a small allowlist of
- * adaptive-only gateway IDs. When more land, add them here.
- */
-const ADAPTIVE_ONLY_THINKING_MODELS = new Set<string>([
-  "anthropic/claude-opus-4.7",
-]);
+function isAnthropicGatewayModel(modelId: string): boolean {
+  return modelId.startsWith("anthropic/") || modelId.startsWith("claude");
+}
 
-function getAnthropicThinkingOptions(
+function hasProviderOptions(options: ProviderOptions): boolean {
+  return Object.keys(options).length > 0;
+}
+
+export function resolveProviderThinkingOptions(
+  modelId: string,
+  capabilities: ModelCapabilities | null,
+  budgetTokens: number,
+  catalogState?: { found: boolean; supportsThinking: boolean },
+): ProviderOptions {
+  if (!capabilities) {
+    // Preserve historical Anthropic behavior while allowing the catalog probe
+    // or runtime self-heal to write the more precise mode back later.
+    if (
+      isAnthropicGatewayModel(modelId) &&
+      (catalogState?.supportsThinking || catalogState?.found === false)
+    ) {
+      return {
+        anthropic: {
+          thinking: { type: "enabled", budgetTokens },
+        },
+      } as ProviderOptions;
+    }
+    return {};
+  }
+
+  switch (capabilities.provider) {
+    case "anthropic":
+      if (capabilities.thinkingMode === "none") return {};
+      return {
+        anthropic: {
+          thinking: capabilities.thinkingMode === "adaptive"
+            ? { type: "adaptive" }
+            : { type: "enabled", budgetTokens },
+        },
+      } as ProviderOptions;
+    case "openai":
+      if (capabilities.reasoningEffort === "none") return {};
+      return {
+        openai: {
+          reasoningEffort: capabilities.reasoningEffort,
+        },
+      } as ProviderOptions;
+    case "google":
+      if (capabilities.thinkingBudget === "none") return {};
+      return {
+        google: {
+          thinkingConfig: {
+            thinkingBudget: capabilities.thinkingBudget === "dynamic"
+              ? -1
+              : capabilities.thinkingBudget,
+          },
+        },
+      } as ProviderOptions;
+    case "xai":
+      if (capabilities.reasoningEffort === "none") return {};
+      return {
+        xai: {
+          reasoningEffort: capabilities.reasoningEffort,
+        },
+      } as ProviderOptions;
+    case "none":
+      return {};
+  }
+}
+
+export async function getProviderThinkingOptions(
   modelId: string,
   budgetTokens: number,
-): { type: "adaptive" } | { type: "enabled"; budgetTokens: number } {
-  if (ADAPTIVE_ONLY_THINKING_MODELS.has(modelId)) {
-    return { type: "adaptive" };
-  }
-  return { type: "enabled", budgetTokens };
+): Promise<ProviderOptions> {
+  const catalogCapabilities = await getModelCapabilities(modelId);
+  return resolveProviderThinkingOptions(
+    modelId,
+    catalogCapabilities.capabilities,
+    budgetTokens,
+    {
+      found: catalogCapabilities.found,
+      supportsThinking: catalogCapabilities.supportsThinking,
+    },
+  );
 }
 
 export function createPrepareStep(opts: {
@@ -101,26 +162,30 @@ export function createPrepareStep(opts: {
   let escalatedModel: { modelId: string; model: LanguageModel } | null = null;
   let failureCount = 0;
 
-  // Cache thinking support per model ID for this prepareStep instance.
-  // Catalog lookups are already in-memory-cached (5 min TTL), but we also
-  // memoize here so we don't hit the cache on every step.
-  const thinkingCache = new Map<string, boolean>();
-  async function modelSupportsThinking(modelId: string | undefined): Promise<boolean> {
-    if (!modelId) return false;
-    if (!isAnthropicModel(modelId)) return false;
-    const hit = thinkingCache.get(modelId);
-    if (hit !== undefined) return hit;
+  // Cache providerOptions per model/budget for this prepareStep instance.
+  // Catalog lookups are also in-memory cached, but this avoids repeated work
+  // while a long multi-step response is running.
+  const thinkingOptionsCache = new Map<string, ProviderOptions>();
+  async function getCachedProviderThinkingOptions(
+    modelId: string | undefined,
+    budgetTokens: number | undefined,
+  ): Promise<ProviderOptions | undefined> {
+    if (!modelId || !budgetTokens) return undefined;
+    const cacheKey = `${modelId}::${budgetTokens}`;
+    const hit = thinkingOptionsCache.get(cacheKey);
+    if (hit) return hasProviderOptions(hit) ? hit : undefined;
+
     try {
-      const caps = await getModelCapabilities(modelId);
-      thinkingCache.set(modelId, caps.supportsThinking);
-      return caps.supportsThinking;
+      const options = await getProviderThinkingOptions(modelId, budgetTokens);
+      thinkingOptionsCache.set(cacheKey, options);
+      return hasProviderOptions(options) ? options : undefined;
     } catch (err: any) {
       logger.warn("prepareStep: capability lookup failed", {
         modelId,
         error: err?.message,
       });
-      thinkingCache.set(modelId, false);
-      return false;
+      thinkingOptionsCache.set(cacheKey, {});
+      return undefined;
     }
   }
 
@@ -191,16 +256,7 @@ export function createPrepareStep(opts: {
     // support via the gateway-sourced catalog (tags.includes("reasoning")).
     const effectiveModelId = (hasEscalatedModel && escalatedModel) ? escalatedModel.modelId : opts.modelId;
     opts.recordStepModelId?.(stepNumber, effectiveModelId);
-    const thinkingEnabled = await modelSupportsThinking(effectiveModelId);
-
-    // --- Build Anthropic provider options ---
-    if (thinkingEnabled && opts.thinkingBudget && effectiveModelId) {
-      providerOptions = {
-        anthropic: {
-          thinking: getAnthropicThinkingOptions(effectiveModelId, opts.thinkingBudget),
-        },
-      };
-    }
+    providerOptions = await getCachedProviderThinkingOptions(effectiveModelId, opts.thinkingBudget);
 
     // --- Step limit warning ---
     // Concatenates all layers into a single string override. This breaks

--- a/packages/db/drizzle/0070_model_capabilities.sql
+++ b/packages/db/drizzle/0070_model_capabilities.sql
@@ -1,0 +1,46 @@
+ALTER TABLE "model_catalog" ADD COLUMN IF NOT EXISTS "capabilities" jsonb DEFAULT NULL;--> statement-breakpoint
+
+UPDATE "model_catalog"
+SET
+  "capabilities" = jsonb_build_object('provider', 'anthropic', 'thinkingMode', 'enabled'),
+  "updated_at" = now()
+WHERE (
+    "model_id" ~ '^anthropic/claude-opus-4\.[0-6]$'
+    OR "model_id" LIKE 'anthropic/claude-sonnet-%'
+  )
+  AND "capabilities" IS NULL;--> statement-breakpoint
+
+UPDATE "model_catalog"
+SET
+  "capabilities" = jsonb_build_object('provider', 'anthropic', 'thinkingMode', 'adaptive'),
+  "updated_at" = now()
+WHERE "model_id" IN ('anthropic/claude-opus-4.7', 'anthropic/claude-opus-4.8')
+  AND "capabilities" IS NULL;--> statement-breakpoint
+
+UPDATE "model_catalog"
+SET
+  "capabilities" = jsonb_build_object('provider', 'openai', 'reasoningEffort', 'medium'),
+  "updated_at" = now()
+WHERE (
+    "model_id" LIKE 'openai/gpt-5%'
+    OR "model_id" LIKE 'openai/o%'
+  )
+  AND "capabilities" IS NULL;--> statement-breakpoint
+
+UPDATE "model_catalog"
+SET
+  "capabilities" = jsonb_build_object('provider', 'google', 'thinkingBudget', 'dynamic'),
+  "updated_at" = now()
+WHERE "model_id" LIKE 'google/gemini-2.5%'
+  AND "capabilities" IS NULL;--> statement-breakpoint
+
+UPDATE "model_catalog"
+SET
+  "capabilities" = jsonb_build_object('provider', 'xai', 'reasoningEffort', 'low'),
+  "updated_at" = now()
+WHERE "model_id" LIKE 'xai/grok-%'
+  AND "capabilities" IS NULL
+  AND (
+    "tags" ? 'reasoning'
+    OR "model_id" LIKE '%reasoning%'
+  );

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1780012800000,
       "tag": "0069_bench_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1780042500000,
+      "tag": "0070_model_capabilities",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.0",
-    "drizzle-orm": "^0.44.0"
+    "drizzle-orm": "^0.44.0",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "drizzle-kit": "^0.31.9",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -20,6 +20,7 @@ import {
   numeric,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+import { z } from "zod";
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 
@@ -389,6 +390,28 @@ export const settings = pgTable(
 
 // ── Model Catalog ───────────────────────────────────────────────────────────
 
+export const ModelCapabilities = z.discriminatedUnion("provider", [
+  z.object({
+    provider: z.literal("anthropic"),
+    thinkingMode: z.enum(["adaptive", "enabled", "none"]),
+  }),
+  z.object({
+    provider: z.literal("openai"),
+    reasoningEffort: z.enum(["minimal", "low", "medium", "high", "none"]),
+  }),
+  z.object({
+    provider: z.literal("google"),
+    thinkingBudget: z.union([z.number(), z.literal("dynamic"), z.literal("none")]),
+  }),
+  z.object({
+    provider: z.literal("xai"),
+    reasoningEffort: z.enum(["low", "high", "none"]),
+  }),
+  z.object({ provider: z.literal("none") }),
+]);
+
+export type ModelCapabilities = z.infer<typeof ModelCapabilities>;
+
 export const modelCatalog = pgTable(
   "model_catalog",
   {
@@ -404,6 +427,7 @@ export const modelCatalog = pgTable(
     contextWindow: integer("context_window"),
     maxTokens: integer("max_tokens"),
     tags: jsonb("tags").$type<string[]>(),
+    capabilities: jsonb("capabilities").$type<ModelCapabilities | null>(),
     rawPricing: jsonb("raw_pricing").$type<Record<string, string | number | null>>(),
     rawPayload: jsonb("raw_payload").$type<Record<string, unknown>>(),
     lastSyncedAt: timestamptz("last_synced_at").notNull().defaultNow(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       drizzle-orm:
         specifier: ^0.44.0
         version: 0.44.7(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
     devDependencies:
       drizzle-kit:
         specifier: ^0.31.9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `model_catalog.capabilities` JSONB storage with a shared Zod discriminated union for provider-specific reasoning configuration.
- Replace the hardcoded Anthropic adaptive-only allowlist and Anthropic-only short-circuit with a provider-agnostic thinking resolver.
- Seed/probe capabilities during model catalog refresh and add runtime Anthropic self-heal retry for known thinking-mode mismatch errors.
- Add unit coverage for resolver arms, schema validation, and the self-heal retry path.

## Anthropic empirical matrix

| Model      | `type: enabled` | `type: adaptive` |
| ---------- | --------------- | ---------------- |
| opus-4.0   | ✅ works         | ❌ rejected       |
| opus-4.1   | ✅ works         | ❌ rejected       |
| opus-4.5   | ✅ works         | ❌ rejected       |
| opus-4.6   | ✅ works         | ✅ works          |
| opus-4.7   | ❌ rejected      | ✅ works          |
| opus-4.8   | ❌ rejected      | ✅ works          |

## Verification

- `pnpm --filter aura-api exec vitest run src/pipeline/prepare-step.test.ts src/lib/model-capabilities-schema.test.ts src/lib/ai.test.ts`
- `pnpm typecheck`
- `pnpm --filter aura-api test`
- `npx tsc --noEmit` in `apps/api`
- `npx tsc --noEmit` in `apps/dashboard`
- `pnpm --filter @aura/db build`
- `git diff --check`

Closes #1050
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd291c7b-f613-4576-8513-6946438f0a67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd291c7b-f613-4576-8513-6946438f0a67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

