### PR TITLE
Memory v3 atomic: entity/recent-tail prefilter

### DIFF
--- a/apps/api/bench/src/eval-retrieval.ts
+++ b/apps/api/bench/src/eval-retrieval.ts
@@ -73,6 +73,7 @@ export async function evaluateRetrieval(
       limit: k,
       workspaceId,
       adminMode: true,
+      prefilter: true,
       onUsage,
       asOf,
     });

--- a/apps/api/src/memory/extract.ts
+++ b/apps/api/src/memory/extract.ts
@@ -663,9 +663,12 @@ async function extractWithReconciliation(
     retrieveMemories({
       query: context.userMessage,
       currentUserId: context.userId,
+      channelId: context.channelId,
+      channelType: context.channelType,
       limit: 20,
       workspaceId,
       adminMode: true,
+      prefilter: true,
     }).then((mems) => { existingMemories = mems; }).catch((err) => {
       logger.warn("Memory retrieval failed during reconciliation — proceeding with empty existing memories", {
         error: String(err?.message ?? err).slice(0, 200),
@@ -706,9 +709,12 @@ async function extractWithReconciliationFromTranscript(
     existingMemories = await retrieveMemories({
       query: context.userMessage,
       currentUserId: context.userId,
+      channelId: context.channelId,
+      channelType: context.channelType,
       limit: 20,
       workspaceId,
       adminMode: true,
+      prefilter: true,
     });
   } catch (err) {
     logger.warn("Memory retrieval failed during transcript reconciliation — proceeding with empty existing memories", {

--- a/apps/api/src/memory/retrieve.test.ts
+++ b/apps/api/src/memory/retrieve.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+const aiMocks = vi.hoisted(() => ({
+  generateObject: vi.fn(),
+  rerank: vi.fn(),
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: dbMocks.execute,
+  },
+}));
+
+vi.mock("../lib/embeddings.js", () => ({
+  embedText: vi.fn(async () => Array.from({ length: 1536 }, () => 0.001)),
+}));
+
+vi.mock("../lib/ai.js", () => ({
+  getFastModel: vi.fn(async () => ({ id: "fast-test-model" })),
+  getRerankingModel: vi.fn(async () => null),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("ai", () => ({
+  generateObject: aiMocks.generateObject,
+  rerank: aiMocks.rerank,
+}));
+
+import {
+  retrieveMemories,
+  decideEntityPrefilter,
+} from "./retrieve.js";
+
+interface RenderedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+function renderSql(query: any): RenderedQuery {
+  if (!query?.toQuery) return { sql: String(query), params: [] };
+  const rendered = query.toQuery({
+    escapeName: (name: string) => `"${name}"`,
+    escapeParam: (index: number) => `$${index + 1}`,
+    escapeString: (value: string) => `'${value.replace(/'/g, "''")}'`,
+  });
+  return { sql: rendered.sql, params: rendered.params };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}
+
+function memoryRow(id: string) {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    id,
+    workspace_id: "W123",
+    content: `memory ${id}`,
+    type: "fact",
+    source_message_id: null,
+    source_channel_type: "public_channel",
+    source_thread_ts: null,
+    source_channel_id: "C123",
+    related_user_ids: [],
+    embedding: null,
+    relevance_score: 0.8,
+    shareable: 0,
+    search_vector: null,
+    status: "current",
+    confidence: 0.8,
+    valid_from: null,
+    valid_until: null,
+    supersedes_memory_id: null,
+    superseded_at: null,
+    superseded_by_memory_id: null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function setupDb(options: { resolveEntity?: boolean; entityMemoryCount?: number } = {}) {
+  const executed: RenderedQuery[] = [];
+  const resolveEntity = options.resolveEntity ?? false;
+  const entityMemoryCount = options.entityMemoryCount ?? 0;
+
+  dbMocks.execute.mockImplementation(async (query: any) => {
+    const rendered = renderSql(query);
+    executed.push(rendered);
+    const compact = normalizeSql(rendered.sql);
+
+    if (compact.includes("FROM unnest(to_tsvector")) {
+      return { rows: [] };
+    }
+
+    if (
+      resolveEntity &&
+      compact.includes("FROM entities") &&
+      compact.includes("lower(canonical_name)") &&
+      compact.includes("LIMIT 1")
+    ) {
+      return {
+        rows: [{ id: "entity-vadim", canonical_name: "Vadim", type: "person" }],
+      };
+    }
+
+    if (compact.includes("SELECT DISTINCT m.*") && compact.includes("JOIN memory_entities me")) {
+      return {
+        rows: Array.from({ length: entityMemoryCount }, (_, index) =>
+          memoryRow(`entity-memory-${index}`),
+        ),
+      };
+    }
+
+    if (compact.includes("SELECT me.memory_id, me.entity_id")) {
+      return {
+        rows: Array.from({ length: entityMemoryCount }, (_, index) => ({
+          memory_id: `entity-memory-${index}`,
+          entity_id: "entity-vadim",
+        })),
+      };
+    }
+
+    if (compact.startsWith("WITH ")) {
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  });
+
+  return executed;
+}
+
+function hybridQuery(executed: RenderedQuery[]): RenderedQuery {
+  const query = executed.find((entry) => normalizeSql(entry.sql).startsWith("WITH "));
+  expect(query).toBeDefined();
+  return query!;
+}
+
+describe("retrieveMemories prefilter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    aiMocks.generateObject.mockResolvedValue({ object: { entities: [] } });
+  });
+
+  it("restricts scored candidates to resolved entity memories plus the recent tail", async () => {
+    aiMocks.generateObject.mockResolvedValue({
+      object: { entities: [{ name: "Vadim", type: "person" }] },
+    });
+    const executed = setupDb({ resolveEntity: true, entityMemoryCount: 15 });
+
+    await retrieveMemories({
+      query: "What did Vadim decide?",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const rendered = hybridQuery(executed);
+    const compact = normalizeSql(rendered.sql);
+    expect(compact).toContain("candidate_pool AS");
+    expect(compact).toContain("global_cosine_candidates AS");
+    expect(compact).toContain("FROM memory_entities me JOIN memories m ON m.id = me.memory_id");
+    expect(compact).toContain("WHERE me.entity_id IN");
+    expect(compact).toContain("ORDER BY created_at DESC");
+    expect(compact).toContain("id IN (SELECT id FROM candidate_pool)");
+    expect(rendered.params).toContain("entity-vadim");
+    expect(rendered.params).toContain(50);
+  });
+
+  it("keeps the legacy global candidate pool when no entity resolves", async () => {
+    const executed = setupDb({ resolveEntity: false });
+
+    await retrieveMemories({
+      query: "what was decided recently",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const compact = normalizeSql(hybridQuery(executed).sql);
+    expect(compact).not.toContain("candidate_pool AS");
+    expect(compact).not.toContain("id IN (SELECT id FROM candidate_pool)");
+  });
+
+  it("falls back to the global pool when resolved entities return too few memories", async () => {
+    aiMocks.generateObject.mockResolvedValue({
+      object: { entities: [{ name: "Vadim", type: "person" }] },
+    });
+    const executed = setupDb({ resolveEntity: true, entityMemoryCount: 1 });
+
+    await retrieveMemories({
+      query: "What did Vadim decide?",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const compact = normalizeSql(hybridQuery(executed).sql);
+    expect(compact).not.toContain("candidate_pool AS");
+    expect(compact).not.toContain("id IN (SELECT id FROM candidate_pool)");
+  });
+
+  it("guards DM-private memories to the current DM channel", async () => {
+    const executed = setupDb({ resolveEntity: false });
+
+    await retrieveMemories({
+      query: "what do you remember",
+      currentUserId: "U_B",
+      channelId: "D2",
+      channelType: "dm",
+      workspaceId: "W123",
+      limit: 15,
+    });
+
+    const rendered = hybridQuery(executed);
+    const compact = normalizeSql(rendered.sql);
+    expect(compact).toContain("source_channel_type != 'dm'");
+    expect(compact).toContain("source_channel_type = 'dm' AND source_channel_id =");
+    expect(compact).toContain("related_user_ids @> ARRAY");
+    expect(rendered.params).toContain("D2");
+    expect(rendered.params).toContain("U_B");
+    expect(rendered.params).not.toContain("D1");
+    expect(rendered.params).not.toContain("U_A");
+  });
+
+  it("does not add the entity candidate pool when prefilter is disabled", async () => {
+    aiMocks.generateObject.mockResolvedValue({
+      object: { entities: [{ name: "Vadim", type: "person" }] },
+    });
+    const executed = setupDb({ resolveEntity: true, entityMemoryCount: 15 });
+
+    await retrieveMemories({
+      query: "What did Vadim decide?",
+      currentUserId: "U123",
+      channelId: "C123",
+      channelType: "public_channel",
+      workspaceId: "W123",
+      prefilter: false,
+      limit: 15,
+    });
+
+    const compact = normalizeSql(hybridQuery(executed).sql);
+    expect(compact).not.toContain("candidate_pool AS");
+    expect(compact).not.toContain("id IN (SELECT id FROM candidate_pool)");
+  });
+});
+
+describe("decideEntityPrefilter", () => {
+  it("requires high-confidence, top-k-sized entity candidates", () => {
+    expect(
+      decideEntityPrefilter({
+        enabled: true,
+        resolvedEntityCount: 0,
+        entityMemoryCount: 0,
+        usedHeuristic: false,
+        resolutionConfidences: [],
+        limit: 15,
+      }),
+    ).toMatchObject({ apply: false, reason: "no-resolved-entities" });
+
+    expect(
+      decideEntityPrefilter({
+        enabled: true,
+        resolvedEntityCount: 1,
+        entityMemoryCount: 50,
+        usedHeuristic: false,
+        resolutionConfidences: ["fuzzy"],
+        limit: 15,
+      }),
+    ).toMatchObject({ apply: false, reason: "low-confidence-resolution" });
+
+    expect(
+      decideEntityPrefilter({
+        enabled: true,
+        resolvedEntityCount: 1,
+        entityMemoryCount: 14,
+        usedHeuristic: false,
+        resolutionConfidences: ["exact"],
+        limit: 15,
+      }),
+    ).toMatchObject({ apply: false, reason: "sparse-entity-candidates" });
+
+    expect(
+      decideEntityPrefilter({
+        enabled: true,
+        resolvedEntityCount: 1,
+        entityMemoryCount: 15,
+        usedHeuristic: false,
+        resolutionConfidences: ["alias"],
+        limit: 15,
+      }),
+    ).toMatchObject({ apply: true, reason: "applied" });
+  });
+});

--- a/apps/api/src/memory/retrieve.ts
+++ b/apps/api/src/memory/retrieve.ts
@@ -2,11 +2,11 @@ import { sql } from "drizzle-orm";
 import { generateObject, rerank } from "ai";
 import { z } from "zod";
 import { db } from "../db/client.js";
-import { memories, messages, type Memory } from "@aura/db/schema";
+import { messages, type Memory } from "@aura/db/schema";
 import type { EntityType } from "@aura/db/schema";
 import { embedText } from "../lib/embeddings.js";
 import { getFastModel, getRerankingModel } from "../lib/ai.js";
-import { resolveEntityReadOnly } from "./entity-resolution.js";
+import { resolveEntityReadOnly, type ResolvedEntity } from "./entity-resolution.js";
 import { logger } from "../lib/logger.js";
 
 interface RetrievalOptions {
@@ -16,6 +16,10 @@ interface RetrievalOptions {
   queryEmbedding?: number[];
   /** The Slack user ID of the person asking */
   currentUserId: string;
+  /** Slack channel/conversation where the query is happening, used for DM privacy and channel weighting */
+  channelId?: string;
+  /** Slack channel type for the current query context */
+  channelType?: string;
   /** Maximum number of memories to return */
   limit?: number;
   /** Minimum relevance score threshold */
@@ -48,10 +52,17 @@ interface RetrievalOptions {
       totalTokens?: number;
     },
   ) => void;
+  /** Restrict cosine/full-text candidates to resolved entities + a recent tail. Defaults on. */
+  prefilter?: boolean;
 }
 
 const MAX_FULLTEXT_LEXEMES = 8;
 const PER_TERM_FULLTEXT_LIMIT = 25;
+const ENTITY_PREFILTER_RECENT_TAIL_LIMIT = 50;
+const HIGH_CONFIDENCE_ENTITY_RESOLUTIONS = new Set<ResolvedEntity["confidence"]>([
+  "exact",
+  "alias",
+]);
 
 async function extractLexemes(
   query: string,
@@ -166,6 +177,123 @@ interface EntityMemoryResult {
   memoryEntityMap: Map<string, Set<string>>;
   /** Total number of distinct entities resolved */
   resolvedEntityCount: number;
+  /** Distinct resolved entity IDs, used to pre-filter the hybrid candidate pool */
+  resolvedEntityIds: string[];
+  /** True when query entities came from the heuristic fallback, not the LLM extractor. */
+  usedHeuristic: boolean;
+  /** Best read-only resolution confidence per distinct resolved entity. */
+  resolutionConfidences: ResolvedEntity["confidence"][];
+}
+
+export interface EntityPrefilterDecision {
+  apply: boolean;
+  reason:
+    | "disabled"
+    | "no-resolved-entities"
+    | "heuristic-resolution"
+    | "low-confidence-resolution"
+    | "sparse-entity-candidates"
+    | "applied";
+  minEntityMemories: number;
+}
+
+export function decideEntityPrefilter(
+  params: {
+    enabled: boolean;
+    resolvedEntityCount: number;
+    entityMemoryCount: number;
+    usedHeuristic: boolean;
+    resolutionConfidences: ResolvedEntity["confidence"][];
+    limit: number;
+  },
+): EntityPrefilterDecision {
+  const minEntityMemories = Math.max(1, params.limit);
+  if (!params.enabled) {
+    return { apply: false, reason: "disabled", minEntityMemories };
+  }
+  if (params.resolvedEntityCount === 0) {
+    return { apply: false, reason: "no-resolved-entities", minEntityMemories };
+  }
+  if (params.usedHeuristic) {
+    return { apply: false, reason: "heuristic-resolution", minEntityMemories };
+  }
+  if (
+    params.resolutionConfidences.length === 0 ||
+    params.resolutionConfidences.some((confidence) => !HIGH_CONFIDENCE_ENTITY_RESOLUTIONS.has(confidence))
+  ) {
+    return { apply: false, reason: "low-confidence-resolution", minEntityMemories };
+  }
+  if (params.entityMemoryCount < minEntityMemories) {
+    return { apply: false, reason: "sparse-entity-candidates", minEntityMemories };
+  }
+  return { apply: true, reason: "applied", minEntityMemories };
+}
+
+interface MemoryVisibilityOptions {
+  adminMode: boolean;
+  currentUserId: string;
+  channelId?: string;
+}
+
+function memoryColumn(columnName: string, tableAlias?: string) {
+  return sql.raw(tableAlias ? `${tableAlias}.${columnName}` : columnName);
+}
+
+function buildMemoryVisibilityFilter(
+  options: MemoryVisibilityOptions,
+  tableAlias?: string,
+) {
+  if (options.adminMode) return sql`TRUE`;
+
+  const sourceChannelType = memoryColumn("source_channel_type", tableAlias);
+  const sourceChannelId = memoryColumn("source_channel_id", tableAlias);
+  const shareable = memoryColumn("shareable", tableAlias);
+  const relatedUserIds = memoryColumn("related_user_ids", tableAlias);
+  const sameDmPrivateMemory = options.channelId
+    ? sql`(
+        ${sourceChannelType} = 'dm'
+        AND ${sourceChannelId} = ${options.channelId}
+        AND ${relatedUserIds} @> ARRAY[${options.currentUserId}]::text[]
+      )`
+    : sql`FALSE`;
+
+  return sql`(
+    ${sourceChannelType} != 'dm'
+    OR ${shareable} = 1
+    OR ${sameDmPrivateMemory}
+  )`;
+}
+
+function buildMemoryBaseFilter(
+  minRelevanceScore: number,
+  workspaceId?: string,
+  tableAlias?: string,
+  requireEmbedding = true,
+  asOf?: Date,
+) {
+  const embedding = memoryColumn("embedding", tableAlias);
+  const relevanceScore = memoryColumn("relevance_score", tableAlias);
+  const status = memoryColumn("status", tableAlias);
+  const validFrom = memoryColumn("valid_from", tableAlias);
+  const validUntil = memoryColumn("valid_until", tableAlias);
+  const workspace = memoryColumn("workspace_id", tableAlias);
+  const workspaceFilter = workspaceId
+    ? sql`${workspace} = ${workspaceId}`
+    : sql`TRUE`;
+
+  const embeddingFilter = requireEmbedding ? sql`${embedding} IS NOT NULL` : sql`TRUE`;
+
+  // As-of (bench): temporal validity replaces the live status filter so a
+  // question sees the exact memory state at its instant on the timeline.
+  // Production (no asOf) keeps the live status filter.
+  const lifecycleFilter = asOf
+    ? sql`${validFrom} <= ${asOf} AND (${validUntil} IS NULL OR ${validUntil} > ${asOf})`
+    : sql`${status} IN ('current', 'disputed')`;
+
+  return sql`${embeddingFilter}
+    AND ${relevanceScore} >= ${minRelevanceScore}
+    AND ${lifecycleFilter}
+    AND ${workspaceFilter}`;
 }
 
 /**
@@ -175,12 +303,19 @@ interface EntityMemoryResult {
 async function fetchEntityMatchedMemories(
   query: string,
   minRelevanceScore: number,
-  currentUserId?: string,
+  visibility: MemoryVisibilityOptions,
   workspaceId?: string,
   onUsage?: RetrievalOptions["onUsage"],
   asOf?: Date,
 ): Promise<EntityMemoryResult> {
-  const emptyResult: EntityMemoryResult = { memories: [], memoryEntityMap: new Map(), resolvedEntityCount: 0 };
+  const emptyResult: EntityMemoryResult = {
+    memories: [],
+    memoryEntityMap: new Map(),
+    resolvedEntityCount: 0,
+    resolvedEntityIds: [],
+    usedHeuristic: false,
+    resolutionConfidences: [],
+  };
 
   try {
     // Step 1: Extract entities via LLM
@@ -201,7 +336,9 @@ async function fetchEntityMatchedMemories(
     const resolutions = await Promise.all(
       extractedEntities.map(async (entity) => {
         const resolved = await resolveEntityReadOnly(entity.name, entity.type, workspaceId);
-        return resolved ? { entityId: resolved.entityId, name: entity.name } : null;
+        return resolved
+          ? { entityId: resolved.entityId, name: entity.name, confidence: resolved.confidence }
+          : null;
       }),
     );
     const resolvedByEntity = resolutions.filter((r): r is NonNullable<typeof r> => r !== null);
@@ -212,39 +349,50 @@ async function fetchEntityMatchedMemories(
       const heuristicResolutions = await Promise.all(
         heuristicNames.map(async (name) => {
           const resolved = await resolveEntityReadOnly(name, "company" as EntityType, workspaceId);
-          return resolved ? { entityId: resolved.entityId, name } : null;
+          return resolved
+            ? { entityId: resolved.entityId, name, confidence: resolved.confidence }
+            : null;
         }),
       );
-      resolvedByEntity.push(...heuristicResolutions.filter((r): r is NonNullable<typeof r> => r !== null));
+      const heuristicResolved = heuristicResolutions.filter((r): r is NonNullable<typeof r> => r !== null);
+      if (heuristicResolved.length > 0) usedHeuristic = true;
+      resolvedByEntity.push(...heuristicResolved);
     }
 
     if (resolvedByEntity.length === 0) return emptyResult;
 
     const entityIds = [...new Set(resolvedByEntity.map((r) => r.entityId))];
+    const confidenceRank: Record<ResolvedEntity["confidence"], number> = {
+      exact: 0,
+      alias: 1,
+      fuzzy: 2,
+      new: 3,
+    };
+    const confidenceByEntityId = new Map<string, ResolvedEntity["confidence"]>();
+    for (const resolution of resolvedByEntity) {
+      const existing = confidenceByEntityId.get(resolution.entityId);
+      if (
+        !existing ||
+        confidenceRank[resolution.confidence] < confidenceRank[existing]
+      ) {
+        confidenceByEntityId.set(resolution.entityId, resolution.confidence);
+      }
+    }
+    const resolutionConfidences = entityIds.map(
+      (id) => confidenceByEntityId.get(id) ?? "fuzzy",
+    );
 
     logger.debug("Entity resolution for retrieval", {
       extracted: extractedEntities.length,
       resolved: entityIds.length,
       usedHeuristic,
+      resolutionConfidences,
       query: query.substring(0, 100),
     });
 
     // Step 4: Fetch memories linked to resolved entities, tracking which entity each memory came from
-    const privacyFilter = currentUserId
-      ? sql`AND (
-          m.source_channel_type != 'dm'
-          OR m.shareable = 1
-          OR m.related_user_ids @> ARRAY[${currentUserId}]::text[]
-        )`
-      : sql``;
-
-    const workspaceMemoryFilter = sql`AND m.workspace_id = ${workspaceId}`;
-
-    // As-of (bench): temporal validity replaces the live status filter so a
-    // question sees the exact memory state at its instant on the timeline.
-    const lifecycleFilter = asOf
-      ? sql`AND m.valid_from <= ${asOf} AND (m.valid_until IS NULL OR m.valid_until > ${asOf})`
-      : sql`AND m.status IN ('current', 'disputed')`;
+    const visibilityFilter = buildMemoryVisibilityFilter(visibility, "m");
+    const memoryBaseFilter = buildMemoryBaseFilter(minRelevanceScore, workspaceId, "m", false, asOf);
 
     const entityIdList = sql.join(entityIds.map(id => sql`${id}`), sql`, `);
 
@@ -253,10 +401,8 @@ async function fetchEntityMatchedMemories(
       FROM memories m
       JOIN memory_entities me ON m.id = me.memory_id
       WHERE me.entity_id IN (${entityIdList})
-        AND m.relevance_score >= ${minRelevanceScore}
-        ${lifecycleFilter}
-        ${privacyFilter}
-        ${workspaceMemoryFilter}
+        AND ${memoryBaseFilter}
+        AND ${visibilityFilter}
       ORDER BY m.relevance_score DESC, m.created_at DESC
       LIMIT 50
     `);
@@ -315,6 +461,9 @@ async function fetchEntityMatchedMemories(
       memories: memoriesList,
       memoryEntityMap,
       resolvedEntityCount: entityIds.length,
+      resolvedEntityIds: entityIds,
+      usedHeuristic,
+      resolutionConfidences,
     };
   } catch (error) {
     logger.warn("Entity-first retrieval failed, falling back to hybrid search only", {
@@ -341,16 +490,37 @@ async function fetchEntityMatchedMemories(
 export async function retrieveMemories(
   options: RetrievalOptions,
 ): Promise<Memory[]> {
-  const { query, queryEmbedding: precomputed, currentUserId, limit = 20, minRelevanceScore = 0.1, adminMode = false, workspaceId, onUsage, asOf } = options;
+  const {
+    query,
+    queryEmbedding: precomputed,
+    currentUserId,
+    channelId,
+    channelType,
+    limit = 20,
+    minRelevanceScore = 0.1,
+    adminMode = false,
+    workspaceId,
+    prefilter = true,
+    onUsage,
+    asOf,
+  } = options;
   const start = Date.now();
+  const visibility = { adminMode, currentUserId, channelId };
 
   try {
     const [queryEmbedding, lexemes, entityResult] = await Promise.all([
       precomputed ? Promise.resolve(precomputed) : embedText(query),
       extractLexemes(query),
-      fetchEntityMatchedMemories(query, minRelevanceScore, adminMode ? undefined : currentUserId, workspaceId, onUsage, asOf),
+      fetchEntityMatchedMemories(query, minRelevanceScore, visibility, workspaceId, onUsage, asOf),
     ]);
-    const { memories: entityMemories, memoryEntityMap, resolvedEntityCount } = entityResult;
+    const {
+      memories: entityMemories,
+      memoryEntityMap,
+      resolvedEntityCount,
+      resolvedEntityIds,
+      usedHeuristic,
+      resolutionConfidences,
+    } = entityResult;
 
     const CANDIDATE_POOL_SIZE = Math.max(25, limit);
     // Embed vector as a raw SQL literal instead of a parameterized value.
@@ -359,32 +529,71 @@ export async function retrieveMemories(
     // values are finite numbers.
     const vectorSql = sql.raw(`'[${queryEmbedding.join(",")}]'::vector`);
 
-    const privacyFilter = adminMode
-      ? sql`TRUE`
-      : sql`(
-        ${memories.sourceChannelType} != 'dm'
-        OR ${memories.shareable} = 1
-        OR ${memories.relatedUserIds} @> ARRAY[${currentUserId}]::text[]
-      )`;
-
-    // As-of (bench): the hybrid lane keys on temporal validity instead of live
-    // status so it matches the entity lane and stays deterministic under
-    // concurrent extraction. Production (no asOf) keeps the live status filter.
-    const statusFilter = asOf
-      ? sql`${memories.validFrom} <= ${asOf} AND (${memories.validUntil} IS NULL OR ${memories.validUntil} > ${asOf})`
-      : sql`${memories.status} IN ('current', 'disputed')`;
-    // Multi-tenancy: scope the hybrid SQL lane to the workspace when one is
-    // supplied. Without this, the vector + full-text RRF query would see
-    // every workspace's memories. The entity-first lane already filters by
-    // workspace_id; this brings the hybrid lane in line.
-    const workspaceFilter = workspaceId
-      ? sql`${memories.workspaceId} = ${workspaceId}`
-      : sql`TRUE`;
-    const baseFilter = sql`${memories.embedding} IS NOT NULL AND ${memories.relevanceScore} >= ${minRelevanceScore} AND ${statusFilter} AND ${workspaceFilter}`;
+    const privacyFilter = buildMemoryVisibilityFilter(visibility);
+    const baseFilter = buildMemoryBaseFilter(minRelevanceScore, workspaceId, undefined, true, asOf);
+    const entityPrefilter = decideEntityPrefilter({
+      enabled: prefilter,
+      resolvedEntityCount,
+      entityMemoryCount: entityMemories.length,
+      usedHeuristic,
+      resolutionConfidences,
+      limit,
+    });
+    const shouldPrefilterByEntity = entityPrefilter.apply;
+    const entityPrefilterIds = shouldPrefilterByEntity
+      ? sql.join(resolvedEntityIds.map(id => sql`${id}`), sql`, `)
+      : sql``;
+    // Keep prefilter as a precision hint, not a hard recall cliff: only use it
+    // for high-yield exact/alias resolutions, and always union in global cosine
+    // top-k so semantic matches are still eligible for final scoring.
+    const candidatePoolCte = shouldPrefilterByEntity
+      ? sql`
+        global_cosine_candidates AS (
+          SELECT id
+          FROM memories
+          WHERE ${baseFilter} AND ${privacyFilter}
+          ORDER BY embedding <=> ${vectorSql}
+          LIMIT ${CANDIDATE_POOL_SIZE}
+        ),
+        candidate_pool AS (
+          SELECT DISTINCT me.memory_id AS id
+          FROM memory_entities me
+          JOIN memories m ON m.id = me.memory_id
+          WHERE me.entity_id IN (${entityPrefilterIds})
+            AND ${buildMemoryBaseFilter(minRelevanceScore, workspaceId, "m", true, asOf)}
+            AND ${buildMemoryVisibilityFilter(visibility, "m")}
+          UNION
+          SELECT id
+          FROM (
+            SELECT id
+            FROM memories
+            WHERE ${baseFilter} AND ${privacyFilter}
+            ORDER BY created_at DESC
+            LIMIT ${ENTITY_PREFILTER_RECENT_TAIL_LIMIT}
+          ) recent_global_memories
+          UNION
+          SELECT id
+          FROM global_cosine_candidates
+        ),
+      `
+      : sql``;
+    const candidatePoolFilter = shouldPrefilterByEntity
+      ? sql`AND id IN (SELECT id FROM candidate_pool)`
+      : sql``;
+    const channelBoostSql = channelId
+      ? sql`CASE WHEN m.source_channel_id = ${channelId} THEN 1.0 ELSE 0.0 END`
+      : sql`0.0`;
 
     logger.debug(`Extracted ${lexemes.length} lexemes for fulltext search`, {
       lexemes,
       query: query.substring(0, 100),
+      prefilter: shouldPrefilterByEntity,
+      prefilterReason: entityPrefilter.reason,
+      entityMemoryCount: entityMemories.length,
+      minEntityPrefilterMemories: entityPrefilter.minEntityMemories,
+      resolvedEntityCount,
+      resolutionConfidences,
+      channelType,
     });
 
     const fulltextSearchCte = lexemes.length === 0
@@ -406,6 +615,7 @@ export async function retrieveMemories(
               WHERE search_vector @@ to_tsquery('english', ${lexeme})
                 AND ${baseFilter}
                 AND ${privacyFilter}
+                ${candidatePoolFilter}
               ORDER BY ts_rank_cd(search_vector, to_tsquery('english', ${lexeme}), 4) DESC
               LIMIT ${PER_TERM_FULLTEXT_LIMIT}
             )
@@ -432,10 +642,11 @@ export async function retrieveMemories(
       })();
 
     const hybridQuery = sql`
-      WITH vector_search AS (
+      WITH ${candidatePoolCte}
+      vector_search AS (
         SELECT id, ROW_NUMBER() OVER (ORDER BY embedding <=> ${vectorSql}) AS rank
         FROM memories
-        WHERE ${baseFilter} AND ${privacyFilter}
+        WHERE ${baseFilter} AND ${privacyFilter} ${candidatePoolFilter}
         ORDER BY embedding <=> ${vectorSql}
         LIMIT ${CANDIDATE_POOL_SIZE}
       ),
@@ -443,7 +654,8 @@ export async function retrieveMemories(
       SELECT
         m.*,
         COALESCE(rrf_score(v.rank), 0.0) + COALESCE(rrf_score(f.rank), 0.0) AS rrf_score,
-        (1 - (m.embedding <=> ${vectorSql})) AS similarity
+        (1 - (m.embedding <=> ${vectorSql})) AS similarity,
+        ${channelBoostSql} AS channel_boost
       FROM (
         SELECT COALESCE(v.id, f.id) AS id, v.rank AS vector_rank, f.rank AS fulltext_rank
         FROM vector_search v
@@ -492,6 +704,7 @@ export async function retrieveMemories(
       } as Memory,
       similarity: Number(row.similarity ?? 0),
       rrfScore: Number(row.rrf_score ?? 0),
+      channelBoost: Number(row.channel_boost ?? 0),
     }));
 
     // Merge entity-matched memories; track entity boost as a separate signal
@@ -513,6 +726,7 @@ export async function retrieveMemories(
         similarity: 0,
         rrfScore: ENTITY_RRF_BOOST,
         entityBoost: entityBoostScore(m.id),
+        channelBoost: channelId && m.sourceChannelId === channelId ? 1 : 0,
       }));
 
     const results = hybridResults.map((r) => ({
@@ -524,6 +738,8 @@ export async function retrieveMemories(
     if (entityMemories.length > 0) {
       logger.debug(`Entity-first retrieval found ${entityMemories.length} memories, ${entityOnlyMemories.length} unique`, {
         resolvedEntities: resolvedEntityCount,
+        prefilter: shouldPrefilterByEntity,
+        prefilterReason: entityPrefilter.reason,
         query: query.substring(0, 100),
       });
     }
@@ -543,6 +759,7 @@ export async function retrieveMemories(
       });
 
       const ENTITY_WEIGHT = 0.1;
+      const CHANNEL_WEIGHT = channelId ? 0.05 : 0;
       const scored = ranking.map((item) => {
         const result = results[item.originalIndex];
         const memory = result.memory;
@@ -550,7 +767,11 @@ export async function retrieveMemories(
         const ageDays = ageMs / (1000 * 60 * 60 * 24);
         const recencyBoost = Math.max(0, 1 - ageDays / 365);
 
-        const score = item.score * (0.8 - ENTITY_WEIGHT / 2) + recencyBoost * (0.2 - ENTITY_WEIGHT / 2) + result.entityBoost * ENTITY_WEIGHT;
+        const score =
+          item.score * (0.8 - ENTITY_WEIGHT / 2 - CHANNEL_WEIGHT / 2) +
+          recencyBoost * (0.2 - ENTITY_WEIGHT / 2 - CHANNEL_WEIGHT / 2) +
+          result.entityBoost * ENTITY_WEIGHT +
+          result.channelBoost * CHANNEL_WEIGHT;
         return { memory, score, originalIndex: item.originalIndex, cohereScore: item.score };
       });
 
@@ -563,6 +784,9 @@ export async function retrieveMemories(
           query: query.substring(0, 100),
           totalCandidates: results.length,
           lexemeCount: lexemes.length,
+          prefilter: shouldPrefilterByEntity,
+          prefilterReason: entityPrefilter.reason,
+          channelId,
           method: "hybrid-rrf+cohere-rerank",
         },
       );
@@ -574,18 +798,20 @@ export async function retrieveMemories(
       const RRF_K = 60;
       const maxRrfScore = 2 / (1 + RRF_K);
 
-      const scored = results.map(({ memory, similarity, rrfScore, entityBoost }) => {
+      const CHANNEL_WEIGHT = channelId ? 0.1 : 0;
+      const scored = results.map(({ memory, similarity, rrfScore, entityBoost, channelBoost }) => {
         const ageMs = now - new Date(memory.createdAt).getTime();
         const ageDays = ageMs / (1000 * 60 * 60 * 24);
         const recencyBoost = Math.max(0, 1 - ageDays / 365);
 
         const normalizedRrf = maxRrfScore > 0 ? Math.min(rrfScore / maxRrfScore, 1) : 0;
         const score =
-          normalizedRrf * 0.4 +
+          normalizedRrf * (0.4 - CHANNEL_WEIGHT / 2) +
           similarity * 0.2 +
           memory.relevanceScore * 0.1 +
           recencyBoost * 0.1 +
-          entityBoost * 0.2;
+          entityBoost * (0.2 - CHANNEL_WEIGHT / 2) +
+          channelBoost * CHANNEL_WEIGHT;
 
         return { memory, score };
       });
@@ -599,6 +825,8 @@ export async function retrieveMemories(
           query: query.substring(0, 100),
           totalCandidates: results.length,
           lexemeCount: lexemes.length,
+          prefilter: shouldPrefilterByEntity,
+          channelId,
           method: "hybrid-rrf+legacy",
         },
       );

--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -38,6 +38,8 @@ export interface ChannelSession {
   isDirectMessage: boolean;
   /** Specific channel type — when omitted, derived from isDirectMessage (dm vs public_channel). */
   channelType?: ChannelType;
+  /** Workspace ID for tenant-scoped memory retrieval. */
+  workspaceId?: string;
   userTimezone?: string;
   /** Human-readable channel name (e.g. "#dev (C0BNVKS77)"). Falls back to conversationId. */
   channelDisplayName?: string;
@@ -296,6 +298,10 @@ export async function buildCorePrompt(
             query: session.messageText,
             queryEmbedding,
             currentUserId: session.userId,
+            channelId: session.conversationId,
+            channelType: session.channelType,
+            workspaceId: session.workspaceId ?? process.env.DEFAULT_WORKSPACE_ID ?? "default",
+            prefilter: true,
             limit: 15,
           }).catch(() => [] as Memory[])
         : Promise.resolve([] as Memory[]),
@@ -307,6 +313,7 @@ export async function buildCorePrompt(
             matchLimit: 15,
             minSimilarity: 0.35,
             excludeThreadTs: session.threadId,
+            workspaceId: session.workspaceId ?? process.env.DEFAULT_WORKSPACE_ID ?? "default",
           })
         : Promise.resolve([] as ConversationThread[]),
       session.userProfile !== undefined

--- a/apps/api/src/pipeline/prompt.ts
+++ b/apps/api/src/pipeline/prompt.ts
@@ -100,6 +100,7 @@ export async function assemblePrompt(
     conversationContext: threadContext,
     isDirectMessage: context.isDm,
     channelType: context.channelType === "slack_list_item" ? "public_channel" : context.channelType,
+    workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
     userTimezone,
     channelDisplayName,
     isChannelHistory,

--- a/apps/api/src/routes/dashboard/chat.ts
+++ b/apps/api/src/routes/dashboard/chat.ts
@@ -429,6 +429,8 @@ dashboardChatApp.openapi(postChatRoute, async (c) => {
       conversationId: "dashboard",
       messageText,
       isDirectMessage: true,
+      channelType: "dashboard",
+      workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
       modelIdOverride: modelId,
     });
 

--- a/apps/api/src/routes/dashboard/memories.ts
+++ b/apps/api/src/routes/dashboard/memories.ts
@@ -69,8 +69,12 @@ dashboardMemoriesApp.openapi(listMemoriesRoute, async (c) => {
         const results = await retrieveMemories({
           query: search,
           currentUserId: "dashboard",
+          channelId: "dashboard",
+          channelType: "dashboard",
+          workspaceId: process.env.DEFAULT_WORKSPACE_ID || "default",
           limit,
           adminMode: true,
+          prefilter: true,
         });
 
         let items = results.map(({ embedding, searchVector, workspaceId, ...rest }) => rest);


### PR DESCRIPTION
**Single change:** entity + recent-tail candidate prefilter before vector/full-text scoring (retrieve.ts). One of 5 atomic decompositions of #1059 for isolated benching.

**Base:** main. **Dependency:** standalone, no Phase 2 storage dependency.

**Bench:** memory-bench.yml fires automatically on this non-draft PR (medium, lme+locomo, replay=exchange). Compares to main baseline committed in apps/api/bench/history.jsonl.

**Expected effect:** narrows candidate set; should improve precision, possible recall risk on LoCoMo.