### PR TITLE
Memory v3 atomic: last-message weighted query embeddings

### DIFF
--- a/apps/api/bench/scripts/topic-pivot-probe.ts
+++ b/apps/api/bench/scripts/topic-pivot-probe.ts
@@ -1,0 +1,161 @@
+/**
+ * Topic-pivot probe for #1038 (last-message weighting).
+ *
+ * The standard LongMemEval / LoCoMo harness feeds the retriever a single
+ * question string, so it never exercises the last-5-message join that causes
+ * topic-pivot dilution in production (eval-retrieval.ts passes
+ * `benchCase.question` verbatim). This probe reproduces the production seam: a
+ * multi-turn query whose prior context is about topic A and whose LAST turn
+ * pivots to topic B. It then compares retrieval quality between:
+ *
+ *   - plain   : embed(full last-5 join)                 — the old behaviour
+ *   - weighted: embedWeightedQuery(latest, full join)   — #1038
+ *
+ * Acceptance (epic #1): the weighted query returns >= 2 on-topic (topic B)
+ * memories in the top-15.
+ *
+ * Run it on demand (needs DB + embedding gateway):
+ *   pnpm --filter aura-api exec tsx bench/scripts/topic-pivot-probe.ts
+ *
+ * It seeds an isolated, idempotent bench workspace and wipes its memories
+ * before each run, so it never touches production data.
+ */
+
+import { db } from "../../src/db/client.js";
+import { sql } from "drizzle-orm";
+import { memories, type NewMemory } from "@aura/db/schema";
+import { embedText, embedWeightedQuery } from "../../src/lib/embeddings.js";
+import { retrieveMemories } from "../../src/memory/retrieve.js";
+import {
+  localBenchWorkspaceId,
+  ensureBenchWorkspace,
+  wipeBenchMemories,
+} from "../src/workspace.js";
+
+const TOPIC_A = "office-kitchen";
+const TOPIC_B = "q3-churn";
+
+// Topic B (the pivot target) — what the last turn actually asks about.
+const TOPIC_B_MEMORIES = [
+  "The team decided to prioritize reducing Q3 churn by shipping the renewal-reminder email sequence.",
+  "Q3 churn was driven mainly by enterprise accounts not renewing after their annual contract lapsed.",
+  "We agreed to offer a 15% loyalty discount to at-risk accounts to curb Q3 churn renewals.",
+  "Renewal owners must reach out 60 days before contract end to lower Q3 churn.",
+  "The churn dashboard now tracks renewal rate week-over-week for the Q3 cohort.",
+];
+
+// Topic A (the prior-context distractor) — must NOT crowd out topic B.
+const TOPIC_A_MEMORIES = [
+  "The office kitchen is restocked with oat milk every Monday morning.",
+  "We switched the coffee supplier to a local roaster for the office kitchen.",
+  "Someone keeps leaving dirty mugs in the office kitchen sink.",
+  "The office kitchen now has a new espresso machine on the counter.",
+  "Snack budget for the office kitchen was increased this quarter.",
+];
+
+// Prior conversation context is all about topic A; the LAST turn pivots to B.
+const PRIOR_CONTEXT = [
+  "Did we ever sort out the oat milk situation in the kitchen?",
+  "Yeah, it's restocked Mondays now. And the new espresso machine is great.",
+  "Nice. Someone still leaves mugs in the sink though.",
+];
+const LATEST_TURN =
+  "Anyway — what did we actually decide about Q3 churn renewals?";
+
+function topicMemoryRows(workspaceId: string): NewMemory[] {
+  const mk = (content: string, topic: string): NewMemory => ({
+    workspaceId,
+    content,
+    type: "decision",
+    category: "semantic",
+    sourceChannelType: "public_channel",
+    sourceChannelId: `probe-${topic}`,
+    relatedUserIds: [],
+    searchVector: content,
+    relevanceScore: 1,
+    shareable: 1,
+  });
+  return [
+    ...TOPIC_B_MEMORIES.map((c) => mk(c, TOPIC_B)),
+    ...TOPIC_A_MEMORIES.map((c) => mk(c, TOPIC_A)),
+  ];
+}
+
+function isTopicB(content: string): boolean {
+  return /churn|renewal|q3/i.test(content);
+}
+
+async function seed(workspaceId: string, rows: NewMemory[]): Promise<void> {
+  // Embed all contents in one batch, then insert with embeddings.
+  const withEmbeddings = await Promise.all(
+    rows.map(async (r) => ({
+      ...r,
+      embedding: await embedText(r.content),
+    })),
+  );
+  await db.insert(memories).values(withEmbeddings);
+}
+
+async function countTopicBInTopK(
+  workspaceId: string,
+  queryText: string,
+  queryEmbedding: number[],
+  k = 15,
+): Promise<{ topicB: number; total: number; preview: string[] }> {
+  const results = await retrieveMemories({
+    query: queryText,
+    queryEmbedding,
+    currentUserId: "probe:user",
+    limit: k,
+    workspaceId,
+    adminMode: true,
+  });
+  const topicB = results.filter((m) => isTopicB(m.content)).length;
+  return {
+    topicB,
+    total: results.length,
+    preview: results.slice(0, 8).map((m) => `${isTopicB(m.content) ? "B" : "A"}  ${m.content.slice(0, 70)}`),
+  };
+}
+
+async function main(): Promise<void> {
+  const workspaceId = localBenchWorkspaceId("topic-pivot");
+  await ensureBenchWorkspace(workspaceId);
+  await wipeBenchMemories(workspaceId);
+  await seed(workspaceId, topicMemoryRows(workspaceId));
+
+  const fullJoin = [...PRIOR_CONTEXT, LATEST_TURN].join("\n");
+  const [plainEmb, weightedEmb] = await Promise.all([
+    embedText(fullJoin),
+    embedWeightedQuery(LATEST_TURN, fullJoin),
+  ]);
+
+  const plain = await countTopicBInTopK(workspaceId, fullJoin, plainEmb);
+  const weighted = await countTopicBInTopK(workspaceId, fullJoin, weightedEmb);
+
+  console.log("\n=== Topic-pivot probe (#1038) ===");
+  console.log(`workspace: ${workspaceId}`);
+  console.log(`\nquery (last-5 join):\n${fullJoin}\n`);
+  console.log(`PLAIN    embed(full join)        → topic-B in top-${plain.total}: ${plain.topicB}`);
+  for (const line of plain.preview) console.log(`   ${line}`);
+  console.log(`\nWEIGHTED embedWeightedQuery(...) → topic-B in top-${weighted.total}: ${weighted.topicB}`);
+  for (const line of weighted.preview) console.log(`   ${line}`);
+
+  await wipeBenchMemories(workspaceId);
+
+  const pass = weighted.topicB >= 2 && weighted.topicB >= plain.topicB;
+  console.log(
+    `\n${pass ? "PASS" : "FAIL"}: weighted topic-B=${weighted.topicB} (>=2 required), plain topic-B=${plain.topicB}`,
+  );
+  if (!pass) process.exitCode = 1;
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.execute(sql`SELECT 1`).catch(() => {});
+    process.exit(process.exitCode ?? 0);
+  });

--- a/apps/api/src/lib/embeddings.ts
+++ b/apps/api/src/lib/embeddings.ts
@@ -1,6 +1,9 @@
 import { embed, embedMany } from "ai";
 import { getEmbeddingModel } from "./ai.js";
 import { logger } from "./logger.js";
+import { blendEmbeddings } from "./vector.js";
+
+export { blendEmbeddings } from "./vector.js";
 
 const EXPECTED_DIMENSIONS = 1536;
 
@@ -59,6 +62,35 @@ export async function embedText(text: string): Promise<number[]> {
     });
     throw error;
   }
+}
+
+/**
+ * Build a retrieval query embedding that weights the latest message more heavily
+ * than the surrounding thread context, mitigating topic-pivot dilution (#1038).
+ *
+ * `context` is the full joined thread text (which already contains `latest`); when
+ * it is empty or identical to `latest`, this degrades to a plain single embed.
+ * Otherwise both texts are embedded in ONE batched call (no extra request count)
+ * and blended `latestWeight` / `1 - latestWeight`.
+ */
+export async function embedWeightedQuery(
+  latest: string,
+  context?: string,
+  latestWeight = 0.65,
+): Promise<number[]> {
+  const trimmedLatest = latest.trim();
+  const trimmedContext = (context ?? "").trim();
+  if (!trimmedLatest || !trimmedContext || trimmedContext === trimmedLatest) {
+    return embedText(trimmedLatest || context || latest);
+  }
+  const [latestEmb, contextEmb] = await embedTexts([
+    trimmedLatest,
+    trimmedContext,
+  ]);
+  return blendEmbeddings(
+    [latestEmb, contextEmb],
+    [latestWeight, 1 - latestWeight],
+  );
 }
 
 /**

--- a/apps/api/src/lib/vector.test.ts
+++ b/apps/api/src/lib/vector.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { blendEmbeddings } from "./vector.js";
+
+/** Cosine similarity for test assertions. */
+function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+describe("blendEmbeddings (#1038 last-message weighting)", () => {
+  it("returns an L2-normalized vector", () => {
+    const out = blendEmbeddings(
+      [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+      ],
+      [0.65, 0.35],
+    );
+    const norm = Math.sqrt(out.reduce((s, v) => s + v * v, 0));
+    expect(norm).toBeCloseTo(1, 6);
+  });
+
+  it("leans toward the latest message when latestWeight > 0.5", () => {
+    // latest = topic B axis, context = topic A axis (orthogonal)
+    const latest = [0, 1, 0, 0];
+    const context = [1, 0, 0, 0];
+    const blended = blendEmbeddings([latest, context], [0.65, 0.35]);
+    // The blended query must be more similar to the pivoted (latest) topic
+    // than to the prior context — otherwise topic-pivot dilution persists.
+    expect(cosine(blended, latest)).toBeGreaterThan(cosine(blended, context));
+  });
+
+  it("equal weights produce a vector equidistant from both inputs", () => {
+    const a = [1, 0, 0, 0];
+    const b = [0, 1, 0, 0];
+    const blended = blendEmbeddings([a, b], [0.5, 0.5]);
+    expect(cosine(blended, a)).toBeCloseTo(cosine(blended, b), 6);
+  });
+
+  it("rejects mismatched vector/weight counts", () => {
+    expect(() => blendEmbeddings([[1, 0]], [0.5, 0.5])).toThrow();
+  });
+
+  it("falls back to the first vector when the weighted sum is degenerate", () => {
+    // Opposite vectors with equal weight cancel to the zero vector; we must
+    // not emit a zero (or NaN) embedding — pgvector cosine would be undefined.
+    const a = [1, 0, 0, 0];
+    const b = [-1, 0, 0, 0];
+    const blended = blendEmbeddings([a, b], [0.5, 0.5]);
+    expect(blended).toEqual(a);
+  });
+});

--- a/apps/api/src/lib/vector.ts
+++ b/apps/api/src/lib/vector.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure vector math helpers — intentionally free of any DB / AI-client imports so
+ * they can be unit-tested without a live `DATABASE_URL` or embedding gateway.
+ */
+
+/**
+ * Blend several embedding vectors into one via a weighted sum, then L2-normalize.
+ * Used to build a query embedding that leans toward the most recent message while
+ * still carrying prior thread context (cosine search is scale-invariant, so the
+ * re-normalization keeps the blended vector well-formed).
+ */
+export function blendEmbeddings(
+  vectors: number[][],
+  weights: number[],
+): number[] {
+  if (vectors.length === 0) {
+    throw new Error("blendEmbeddings: no vectors provided");
+  }
+  if (vectors.length !== weights.length) {
+    throw new Error(
+      `blendEmbeddings: ${vectors.length} vectors but ${weights.length} weights`,
+    );
+  }
+  const dims = vectors[0].length;
+  const acc = new Array<number>(dims).fill(0);
+  for (let v = 0; v < vectors.length; v++) {
+    const vec = vectors[v];
+    const w = weights[v];
+    if (vec.length !== dims) {
+      throw new Error(
+        `blendEmbeddings: dimension mismatch (${vec.length} vs ${dims})`,
+      );
+    }
+    for (let i = 0; i < dims; i++) acc[i] += vec[i] * w;
+  }
+  let norm = 0;
+  for (let i = 0; i < dims; i++) norm += acc[i] * acc[i];
+  norm = Math.sqrt(norm);
+  if (norm === 0 || !Number.isFinite(norm)) return vectors[0];
+  for (let i = 0; i < dims; i++) acc[i] /= norm;
+  return acc;
+}

--- a/apps/api/src/pipeline/core-prompt.ts
+++ b/apps/api/src/pipeline/core-prompt.ts
@@ -9,7 +9,7 @@ import {
   retrieveConversations,
   type ConversationThread,
 } from "../memory/retrieve.js";
-import { embedText } from "../lib/embeddings.js";
+import { embedWeightedQuery } from "../lib/embeddings.js";
 import { getProfile } from "../users/profiles.js";
 import { getMainModelId } from "../lib/ai.js";
 import { getSandboxEnvNames } from "../lib/sandbox.js";
@@ -33,6 +33,13 @@ export interface ChannelSession {
   conversationId: string;
   threadId?: string;
   messageText: string;
+  /**
+   * The single latest user turn (without prior thread context). When provided
+   * and distinct from `messageText`, the retrieval query embedding is weighted
+   * toward this message to avoid topic-pivot dilution (#1038). Falls back to
+   * `messageText` when omitted.
+   */
+  latestMessageText?: string;
   /** Pre-formatted recent messages — each connector provides its own format. */
   conversationContext?: string;
   isDirectMessage: boolean;
@@ -278,7 +285,10 @@ export async function buildCorePrompt(
 
   let queryEmbedding: number[] | undefined;
   try {
-    queryEmbedding = await embedText(session.messageText);
+    queryEmbedding = await embedWeightedQuery(
+      session.latestMessageText ?? session.messageText,
+      session.messageText,
+    );
   } catch (error) {
     logger.error("Embedding failed, proceeding without memory context", {
       error: String(error),

--- a/apps/api/src/pipeline/prompt.ts
+++ b/apps/api/src/pipeline/prompt.ts
@@ -97,6 +97,7 @@ export async function assemblePrompt(
     conversationId: context.channelId,
     threadId: context.threadTs,
     messageText: queryText,
+    latestMessageText: context.text,
     conversationContext: threadContext,
     isDirectMessage: context.isDm,
     channelType: context.channelType === "slack_list_item" ? "public_channel" : context.channelType,


### PR DESCRIPTION
**Single change:** weighted latest-message query embeddings in core-prompt retrieval (core-prompt.ts + vector.ts embedWeightedQuery helper). One of 5 atomic decompositions of #1059.

**Base:** main. **Dependency:** standalone.

**Bench:** auto-fires on non-draft PR (medium, lme+locomo).

**Expected effect:** biases retrieval toward the most recent turn; should help multi-turn follow-up QA.