### PR TITLE
Memory v3 atomic: score fusion ranker (#1054)

### DIFF
--- a/apps/api/src/memory/extract.ts
+++ b/apps/api/src/memory/extract.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { getFastModel, withAnthropicFallback, type WrappableModel } from "../lib/ai.js";
 import { embedText, embedTexts } from "../lib/embeddings.js";
 import {
-  storeMemories, supersedeMemory, toDbChannelType, checkDuplicates,
+  storeMemories, supersedeMemory, toDbChannelType, checkDuplicates, updateLinkedMemoryIds,
   fetchThreadMessages, updateMemoryContent, archiveMemory,
   findContradictionCandidates,
 } from "./store.js";
@@ -840,6 +840,8 @@ async function runReconciliationCore(
         await db.delete(memoryEntities).where(eq(memoryEntities.memoryId, memoryId));
         const resolved = await resolveEntities(extractedEntities, workspaceId, model);
         await linkMemoryEntities(memoryId, resolved);
+        // Refresh graph links (#1054) now that this memory's entities changed.
+        await updateLinkedMemoryIds(workspaceId, [memoryId]);
       }
     } catch (entityError) {
       logger.warn("Failed to refresh entity links for updated memory", {
@@ -1082,6 +1084,10 @@ async function processCreateOperations(
       }
     }
   }
+
+  // #1054: materialize shared-entity graph links for the new batch so the
+  // retrieval ranker can apply a multi-hop graph-expansion boost.
+  await updateLinkedMemoryIds(workspaceId, memoryIds.filter(Boolean));
 
   logger.info(`${source === "reconciliation" ? "Reconciliation" : "Single-exchange extraction"} created ${newMemories.length} memories in ${Date.now() - start}ms`, {
     types: newMemories.map((m) => m.type),

--- a/apps/api/src/memory/retrieve.test.ts
+++ b/apps/api/src/memory/retrieve.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    execute: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/embeddings.js", () => ({
+  embedText: vi.fn(),
+}));
+
+vi.mock("../lib/ai.js", () => ({
+  getFastModel: vi.fn(),
+  getRerankingModel: vi.fn(),
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn(),
+  rerank: vi.fn(),
+}));
+
+import { fuseCandidates } from "./retrieve.js";
+import type { Memory } from "@aura/db/schema";
+
+describe("fuseCandidates (#1054 score fusion)", () => {
+  const NOW = Date.UTC(2026, 0, 1);
+
+  function mem(id: string, over: Partial<Memory> = {}): Memory {
+    return {
+      id,
+      content: `memory ${id}`,
+      relevanceScore: 0.5,
+      linkedMemoryIds: [],
+      createdAt: new Date(NOW),
+      sourceChannelId: null,
+      ...over,
+    } as unknown as Memory;
+  }
+
+  function candidate(
+    id: string,
+    signals: {
+      similarity?: number;
+      bm25?: number;
+      entityBoost?: number;
+      linkedMemoryIds?: string[];
+      createdAt?: Date;
+    },
+  ) {
+    return {
+      memory: mem(id, {
+        linkedMemoryIds: signals.linkedMemoryIds ?? [],
+        createdAt: signals.createdAt ?? new Date(NOW),
+      }),
+      similarity: signals.similarity ?? 0,
+      bm25: signals.bm25 ?? 0,
+      entityBoost: signals.entityBoost ?? 0,
+    };
+  }
+
+  it("ranks the strongest semantic + lexical candidate first", () => {
+    const out = fuseCandidates(
+      [
+        candidate("weak", { similarity: 0.1, bm25: 0 }),
+        candidate("strong", { similarity: 0.9, bm25: 0.3 }),
+        candidate("mid", { similarity: 0.5, bm25: 0.05 }),
+      ],
+      { now: NOW },
+    );
+    expect(out[0].memory.id).toBe("strong");
+    expect(out[out.length - 1].memory.id).toBe("weak");
+  });
+
+  it("applies a graph-expansion boost to memories linked from a top anchor", () => {
+    const ranked = fuseCandidates(
+      [
+        candidate("anchor", { similarity: 0.95, bm25: 0.3, linkedMemoryIds: ["operandB"] }),
+        candidate("operandB", { similarity: 0.05 }),
+        candidate("unrelated", { similarity: 0.05 }),
+      ],
+      { now: NOW },
+    );
+    const idx = (id: string) => ranked.findIndex((r) => r.memory.id === id);
+    expect(idx("operandB")).toBeLessThan(idx("unrelated"));
+  });
+
+  it("uses the Cohere semantic override when provided", () => {
+    const ranked = fuseCandidates(
+      [
+        candidate("a", { similarity: 0.9 }),
+        candidate("b", { similarity: 0.1 }),
+      ],
+      { now: NOW, semanticOverride: [0.0, 1.0] },
+    );
+    expect(ranked[0].memory.id).toBe("b");
+  });
+
+  it("returns an empty list for no candidates", () => {
+    expect(fuseCandidates([], { now: NOW })).toEqual([]);
+  });
+});

--- a/apps/api/src/memory/retrieve.ts
+++ b/apps/api/src/memory/retrieve.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { generateObject, rerank } from "ai";
+import { generateObject, rerank as rerankMemories } from "ai";
 import { z } from "zod";
 import { db } from "../db/client.js";
 import { memories, messages, type Memory } from "@aura/db/schema";
@@ -48,6 +48,11 @@ interface RetrievalOptions {
       totalTokens?: number;
     },
   ) => void;
+  /**
+   * Optional Cohere rerank pass. Score fusion is the default ranker; when set,
+   * Cohere's relevance scores replace raw cosine as the semantic fusion signal.
+   */
+  rerank?: boolean;
 }
 
 const MAX_FULLTEXT_LEXEMES = 8;
@@ -296,6 +301,7 @@ async function fetchEntityMatchedMemories(
       sourceThreadTs: row.source_thread_ts ?? null,
       sourceChannelId: row.source_channel_id ?? null,
       relatedUserIds: row.related_user_ids ?? [],
+      linkedMemoryIds: row.linked_memory_ids ?? [],
       embedding: row.embedding,
       relevanceScore: row.relevance_score ?? 1,
       shareable: row.shareable ?? 0,
@@ -325,6 +331,109 @@ async function fetchEntityMatchedMemories(
   }
 }
 
+/** A merged retrieval candidate carrying every raw fusion signal. */
+interface FusionCandidate {
+  memory: Memory;
+  /** Cosine similarity (1 - distance); 0 for entity-only candidates. */
+  similarity: number;
+  /** Raw BM25 (ts_rank_cd) over the OR of query lexemes; 0 when none matched. */
+  bm25: number;
+  /** Fraction of resolved query entities this memory is linked to (0..1). */
+  entityBoost: number;
+}
+
+const FUSION_WEIGHTS = {
+  semantic: 0.42,
+  bm25: 0.18,
+  entity: 0.15,
+  link: 0.1,
+  recency: 0.05,
+  relevance: 0.1,
+} as const;
+
+const BM25_SIGMOID_SCALE = 12;
+const BM25_SIGMOID_MID = 0.08;
+const LINK_ANCHOR_COUNT = 5;
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+/** Min-max normalize to [0,1]; collapses to a clamp when the range is ~0. */
+function minMaxNormalize(values: number[]): number[] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min;
+  if (!Number.isFinite(range) || range < 1e-9) {
+    return values.map((v) => Math.max(0, Math.min(1, v)));
+  }
+  return values.map((v) => (v - min) / range);
+}
+
+export interface FusionResult {
+  memory: Memory;
+  score: number;
+}
+
+/**
+ * Fuse merged candidates into a single ranked list via explicit weighted score
+ * fusion (#1054), replacing the old "RRF -> Cohere-as-default" path.
+ */
+export function fuseCandidates(
+  candidates: FusionCandidate[],
+  opts: { now: number; semanticOverride?: number[] },
+): FusionResult[] {
+  if (candidates.length === 0) return [];
+  const { now, semanticOverride } = opts;
+
+  const semNorm = semanticOverride
+    ? semanticOverride.map((v) => Math.max(0, Math.min(1, v)))
+    : minMaxNormalize(candidates.map((c) => Math.max(0, c.similarity)));
+  const bm25Norm = candidates.map((c) =>
+    c.bm25 > 0 ? sigmoid(BM25_SIGMOID_SCALE * (c.bm25 - BM25_SIGMOID_MID)) : 0,
+  );
+
+  const baseScore = candidates.map(
+    (c, i) =>
+      FUSION_WEIGHTS.semantic * semNorm[i] +
+      FUSION_WEIGHTS.bm25 * bm25Norm[i] +
+      FUSION_WEIGHTS.entity * c.entityBoost,
+  );
+  const anchorIdx = candidates
+    .map((_, i) => i)
+    .sort((a, b) => baseScore[b] - baseScore[a])
+    .slice(0, LINK_ANCHOR_COUNT);
+  const linkedFromAnchors = new Set<string>();
+  for (const i of anchorIdx) {
+    for (const id of candidates[i].memory.linkedMemoryIds ?? []) {
+      linkedFromAnchors.add(id);
+    }
+  }
+
+  const scored = candidates.map((c, i) => {
+    const ageDays = (now - new Date(c.memory.createdAt).getTime()) / 86_400_000;
+    const recency = Math.max(0, 1 - ageDays / 365);
+    const linkBoost = linkedFromAnchors.has(c.memory.id) ? 1 : 0;
+
+    const score =
+      FUSION_WEIGHTS.semantic * semNorm[i] +
+      FUSION_WEIGHTS.bm25 * bm25Norm[i] +
+      FUSION_WEIGHTS.entity * c.entityBoost +
+      FUSION_WEIGHTS.link * linkBoost +
+      FUSION_WEIGHTS.recency * recency +
+      FUSION_WEIGHTS.relevance * c.memory.relevanceScore;
+
+    return { memory: c.memory, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored;
+}
+
 /**
  * Retrieve relevant memories using hybrid search (vector + full-text) with RRF fusion.
  *
@@ -341,7 +450,7 @@ async function fetchEntityMatchedMemories(
 export async function retrieveMemories(
   options: RetrievalOptions,
 ): Promise<Memory[]> {
-  const { query, queryEmbedding: precomputed, currentUserId, limit = 20, minRelevanceScore = 0.1, adminMode = false, workspaceId, onUsage, asOf } = options;
+  const { query, queryEmbedding: precomputed, currentUserId, limit = 20, minRelevanceScore = 0.1, adminMode = false, workspaceId, onUsage, asOf, rerank = false } = options;
   const start = Date.now();
 
   try {
@@ -381,6 +490,10 @@ export async function retrieveMemories(
       ? sql`${memories.workspaceId} = ${workspaceId}`
       : sql`TRUE`;
     const baseFilter = sql`${memories.embedding} IS NOT NULL AND ${memories.relevanceScore} >= ${minRelevanceScore} AND ${statusFilter} AND ${workspaceFilter}`;
+    const combinedTsQuery = lexemes.join(" | ");
+    const bm25Sql = lexemes.length > 0
+      ? sql`COALESCE(ts_rank_cd(m.search_vector, to_tsquery('english', ${combinedTsQuery}), 4), 0.0)`
+      : sql`0.0`;
 
     logger.debug(`Extracted ${lexemes.length} lexemes for fulltext search`, {
       lexemes,
@@ -443,7 +556,8 @@ export async function retrieveMemories(
       SELECT
         m.*,
         COALESCE(rrf_score(v.rank), 0.0) + COALESCE(rrf_score(f.rank), 0.0) AS rrf_score,
-        (1 - (m.embedding <=> ${vectorSql})) AS similarity
+        (1 - (m.embedding <=> ${vectorSql})) AS similarity,
+        ${bm25Sql} AS bm25
       FROM (
         SELECT COALESCE(v.id, f.id) AS id, v.rank AS vector_rank, f.rank AS fulltext_rank
         FROM vector_search v
@@ -476,6 +590,7 @@ export async function retrieveMemories(
         sourceThreadTs: row.source_thread_ts ?? null,
         sourceChannelId: row.source_channel_id ?? null,
         relatedUserIds: row.related_user_ids ?? [],
+        linkedMemoryIds: row.linked_memory_ids ?? [],
         embedding: row.embedding,
         relevanceScore: row.relevance_score ?? 1,
         shareable: row.shareable ?? 0,
@@ -492,6 +607,7 @@ export async function retrieveMemories(
       } as Memory,
       similarity: Number(row.similarity ?? 0),
       rrfScore: Number(row.rrf_score ?? 0),
+      bm25: Number(row.bm25 ?? 0),
     }));
 
     // Merge entity-matched memories; track entity boost as a separate signal
@@ -512,6 +628,7 @@ export async function retrieveMemories(
         memory: m,
         similarity: 0,
         rrfScore: ENTITY_RRF_BOOST,
+        bm25: 0,
         entityBoost: entityBoostScore(m.id),
       }));
 
@@ -528,81 +645,35 @@ export async function retrieveMemories(
       });
     }
 
-    const rerankingModel = await getRerankingModel();
     const now = Date.now();
-    let topMemories: Memory[];
-
-    if (rerankingModel && results.length > 0) {
-      const documents = results.map((r) => r.memory.content);
-
-      const { ranking } = await rerank({
-        model: rerankingModel,
-        query,
-        documents,
-        topN: results.length,
-      });
-
-      const ENTITY_WEIGHT = 0.1;
-      const scored = ranking.map((item) => {
-        const result = results[item.originalIndex];
-        const memory = result.memory;
-        const ageMs = now - new Date(memory.createdAt).getTime();
-        const ageDays = ageMs / (1000 * 60 * 60 * 24);
-        const recencyBoost = Math.max(0, 1 - ageDays / 365);
-
-        const score = item.score * (0.8 - ENTITY_WEIGHT / 2) + recencyBoost * (0.2 - ENTITY_WEIGHT / 2) + result.entityBoost * ENTITY_WEIGHT;
-        return { memory, score, originalIndex: item.originalIndex, cohereScore: item.score };
-      });
-
-      scored.sort((a, b) => b.score - a.score);
-      topMemories = scored.slice(0, limit).map((s) => s.memory);
-
-      logger.info(
-        `Reranked ${results.length} memories → top ${topMemories.length} in ${Date.now() - start}ms`,
-        {
-          query: query.substring(0, 100),
-          totalCandidates: results.length,
-          lexemeCount: lexemes.length,
-          method: "hybrid-rrf+cohere-rerank",
-        },
-      );
-      const reranking = scored.slice(0, limit).map((s, newRank) =>
-        `${s.originalIndex + 1} → ${newRank + 1} (cohere=${s.cohereScore.toFixed(3)}, final=${s.score.toFixed(3)})`
-      ).join(", ");
-      logger.debug(`Reranking details: ${reranking}`);
-    } else {
-      const RRF_K = 60;
-      const maxRrfScore = 2 / (1 + RRF_K);
-
-      const scored = results.map(({ memory, similarity, rrfScore, entityBoost }) => {
-        const ageMs = now - new Date(memory.createdAt).getTime();
-        const ageDays = ageMs / (1000 * 60 * 60 * 24);
-        const recencyBoost = Math.max(0, 1 - ageDays / 365);
-
-        const normalizedRrf = maxRrfScore > 0 ? Math.min(rrfScore / maxRrfScore, 1) : 0;
-        const score =
-          normalizedRrf * 0.4 +
-          similarity * 0.2 +
-          memory.relevanceScore * 0.1 +
-          recencyBoost * 0.1 +
-          entityBoost * 0.2;
-
-        return { memory, score };
-      });
-
-      scored.sort((a, b) => b.score - a.score);
-      topMemories = scored.slice(0, limit).map((s) => s.memory);
-
-      logger.info(
-        `Retrieved ${topMemories.length} memories (hybrid+legacy scoring) in ${Date.now() - start}ms`,
-        {
-          query: query.substring(0, 100),
-          totalCandidates: results.length,
-          lexemeCount: lexemes.length,
-          method: "hybrid-rrf+legacy",
-        },
-      );
+    let semanticOverride: number[] | undefined;
+    if (rerank && results.length > 0) {
+      const rerankingModel = await getRerankingModel();
+      if (rerankingModel) {
+        const { ranking } = await rerankMemories({
+          model: rerankingModel,
+          query,
+          documents: results.map((r) => r.memory.content),
+          topN: results.length,
+        });
+        semanticOverride = new Array<number>(results.length).fill(0);
+        for (const item of ranking) semanticOverride[item.originalIndex] = item.score;
+      }
     }
+
+    const fused = fuseCandidates(results, { now, semanticOverride });
+    const topMemories = fused.slice(0, limit).map((f) => f.memory);
+
+    logger.info(
+      `Retrieved ${topMemories.length} memories (score-fusion${semanticOverride ? "+cohere" : ""}) in ${Date.now() - start}ms`,
+      {
+        query: query.substring(0, 100),
+        totalCandidates: results.length,
+        lexemeCount: lexemes.length,
+        topScore: fused[0]?.score.toFixed(3),
+        method: semanticOverride ? "score-fusion+cohere" : "score-fusion",
+      },
+    );
 
     return topMemories;
   } catch (error: any) {

--- a/apps/api/src/memory/store.ts
+++ b/apps/api/src/memory/store.ts
@@ -530,6 +530,77 @@ export async function storeMemories(newMemories: NewMemory[]): Promise<string[]>
   }
 }
 
+/** Hard cap on how many neighbors a single memory links to (#1054). */
+const MAX_LINKED_MEMORIES = 25;
+
+/**
+ * Recompute `linked_memory_ids` (#1054) for a freshly-stored batch and every
+ * existing memory that shares an entity with one of them.
+ *
+ * Two memories are "linked" when they share at least one resolved entity (via
+ * `memory_entities`), scoped to the same workspace. The edge is symmetric, so we
+ * recompute the full neighbor set for the new memories AND their neighbors —
+ * keeping the graph consistent in both directions. This materializes the
+ * adjacency so the retrieval ranker can apply a graph-expansion boost without a
+ * join at read time (the multi-hop "surface the other operands" signal).
+ *
+ * Idempotent and set-based: one UPDATE per batch. Call AFTER entity linking.
+ */
+export async function updateLinkedMemoryIds(
+  workspaceId: string,
+  memoryIds: string[],
+): Promise<void> {
+  const ids = memoryIds.filter(Boolean);
+  if (ids.length === 0) return;
+
+  const idList = sql.join(
+    ids.map((id) => sql`${id}::uuid`),
+    sql`, `,
+  );
+
+  try {
+    await db.execute(sql`
+      WITH affected AS (
+        SELECT DISTINCT m.id
+        FROM memories m
+        WHERE m.workspace_id = ${workspaceId}
+          AND (
+            m.id IN (${idList})
+            OR m.id IN (
+              SELECT me2.memory_id
+              FROM memory_entities me1
+              JOIN memory_entities me2 ON me2.entity_id = me1.entity_id
+              WHERE me1.memory_id IN (${idList})
+            )
+          )
+      ),
+      neighbors AS (
+        SELECT a.id AS memory_id,
+               (array_agg(DISTINCT me2.memory_id))[1:${sql.raw(String(MAX_LINKED_MEMORIES))}] AS linked
+        FROM affected a
+        JOIN memory_entities me1 ON me1.memory_id = a.id
+        JOIN memory_entities me2
+          ON me2.entity_id = me1.entity_id AND me2.memory_id <> a.id
+        JOIN memories mb ON mb.id = me2.memory_id AND mb.workspace_id = ${workspaceId}
+        GROUP BY a.id
+      )
+      UPDATE memories
+      SET linked_memory_ids = COALESCE(
+            (SELECT linked FROM neighbors WHERE neighbors.memory_id = memories.id),
+            '{}'::uuid[]
+          )
+      WHERE workspace_id = ${workspaceId}
+        AND id IN (SELECT id FROM affected)
+    `);
+  } catch (error) {
+    logger.warn("updateLinkedMemoryIds failed — continuing without graph links", {
+      error: String(error).slice(0, 200),
+      workspaceId,
+      count: ids.length,
+    });
+  }
+}
+
 // ── Invocation Context Storage ──────────────────────────────────────────────
 
 const MAX_TOOL_CONTENT_LENGTH = 2000;

--- a/packages/db/drizzle/0071_linked_memory_ids.sql
+++ b/packages/db/drizzle/0071_linked_memory_ids.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "memories" ADD COLUMN "linked_memory_ids" uuid[] DEFAULT '{}'::uuid[] NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1780042500000,
       "tag": "0070_model_capabilities",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1780099200000,
+      "tag": "0071_linked_memory_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/backfill-linked-memory-ids.ts
+++ b/packages/db/scripts/backfill-linked-memory-ids.ts
@@ -1,0 +1,75 @@
+/**
+ * Backfill `memories.linked_memory_ids` (#1054).
+ *
+ * Two memories are "linked" when they share at least one resolved entity (via
+ * `memory_entities`), scoped to the same workspace. This materializes that
+ * adjacency so the retrieval ranker can apply a graph-expansion boost without a
+ * join at read time. New writes maintain the column via
+ * `updateLinkedMemoryIds()` in the extractor; this script populates pre-existing
+ * rows once.
+ *
+ * Set-based and workspace-batched (one UPDATE per workspace) to bound memory on
+ * large tenants. Idempotent — re-running recomputes the same sets.
+ *
+ * Run:
+ *   pnpm --filter @aura/db exec tsx scripts/backfill-linked-memory-ids.ts
+ * (wrap with ./scripts/env.sh / --prod to target a specific database)
+ */
+
+import { neon } from "@neondatabase/serverless";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const MAX_LINKS = 25;
+const sql = neon(DATABASE_URL);
+
+async function run() {
+  const col = await sql`
+    SELECT column_name FROM information_schema.columns
+    WHERE table_name = 'memories' AND column_name = 'linked_memory_ids'
+  `;
+  if (col.length === 0) {
+    console.error("linked_memory_ids column missing — run migrations first.");
+    process.exit(1);
+  }
+
+  const workspaces = await sql`
+    SELECT DISTINCT workspace_id FROM memories WHERE workspace_id IS NOT NULL
+  `;
+  console.log(`Backfilling linked_memory_ids across ${workspaces.length} workspace(s)…`);
+
+  let totalUpdated = 0;
+  for (const { workspace_id: workspaceId } of workspaces as Array<{ workspace_id: string }>) {
+    const updated = await sql`
+      WITH neighbors AS (
+        SELECT me1.memory_id AS memory_id,
+               (array_agg(DISTINCT me2.memory_id))[1:${MAX_LINKS}] AS linked
+        FROM memory_entities me1
+        JOIN memory_entities me2
+          ON me2.entity_id = me1.entity_id AND me2.memory_id <> me1.memory_id
+        JOIN memories m1 ON m1.id = me1.memory_id AND m1.workspace_id = ${workspaceId}
+        JOIN memories m2 ON m2.id = me2.memory_id AND m2.workspace_id = ${workspaceId}
+        GROUP BY me1.memory_id
+      )
+      UPDATE memories
+      SET linked_memory_ids = COALESCE(n.linked, '{}'::uuid[])
+      FROM neighbors n
+      WHERE memories.id = n.memory_id
+        AND memories.workspace_id = ${workspaceId}
+      RETURNING memories.id
+    `;
+    totalUpdated += updated.length;
+    console.log(`  ${workspaceId}: linked ${updated.length} memories`);
+  }
+
+  console.log(`Done. Updated ${totalUpdated} memories total.`);
+}
+
+run().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -156,6 +156,17 @@ export const memories = pgTable(
       .array()
       .notNull()
       .default(sql`'{}'::text[]`),
+    /**
+     * IDs of other memories that share at least one resolved entity with this
+     * one (#1054). Materialized at store time so the retrieval ranker can apply
+     * a graph-expansion ("spreading activation") boost — surfacing the other
+     * operands of a multi-hop question once one of them is retrieved — without
+     * a join at read time. Workspace-scoped; never references cross-tenant rows.
+     */
+    linkedMemoryIds: uuid("linked_memory_ids")
+      .array()
+      .notNull()
+      .default(sql`'{}'::uuid[]`),
     embedding: vector("embedding", { dimensions: 1536 }),
     importance: integer("importance"),
     relevanceScore: real("relevance_score").notNull().default(1.0),


### PR DESCRIPTION
**Single change:** #1054 score-fusion scorer replacing legacy RRF/Cohere ranker (retrieve.ts). One of 5 atomic decompositions of #1059.

**Base:** main. **Dependency:** INCLUDES `linked_memory_ids` schema (drizzle 0071) + store maintenance + backfill, because the graph-link boost term hard-depends on that column. This is the only atomic PR carrying storage/plumbing.

**Bench:** auto-fires on non-draft PR (medium, lme+locomo). NOTE: needs from_stage=extract (not score reuse) since it adds a storage column the persistent phase2 workspace lacks.

**Expected effect:** fused vector+BM25+graph scoring; primary candidate for QA/recall gains.