### PR TITLE
Mark Cursor webhook PRs ready on finish

### DIFF
--- a/apps/api/src/app.cursor-agent.test.ts
+++ b/apps/api/src/app.cursor-agent.test.ts
@@ -1,0 +1,223 @@
+import crypto from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
+process.env.CURSOR_WEBHOOK_SECRET = "cursor-secret";
+process.env.AURA_ADMIN_USER_IDS = "UADMIN";
+
+const mocks = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  getCredentialMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+  recordErrorMock: vi.fn(),
+  resolveSlackDestinationMock: vi.fn(),
+  safePostMessageMock: vi.fn(),
+  waitUntilPromises: [] as Array<Promise<unknown>>,
+}));
+
+vi.mock("@slack/web-api", () => ({
+  WebClient: vi.fn(function WebClient() {
+    return {};
+  }),
+}));
+
+vi.mock("@vercel/functions", () => ({
+  waitUntil: (promise: Promise<unknown>) => {
+    mocks.waitUntilPromises.push(promise);
+  },
+}));
+
+vi.mock("./cron/consolidate.js", async () => {
+  const { Hono } = await import("hono");
+  return { cronApp: new Hono() };
+});
+
+vi.mock("./cron/heartbeat.js", async () => {
+  const { Hono } = await import("hono");
+  return { heartbeatApp: new Hono() };
+});
+
+vi.mock("./cron/supervisor.js", async () => {
+  const { Hono } = await import("hono");
+  return { supervisorApp: new Hono() };
+});
+
+vi.mock("./webhook/elevenlabs.js", async () => {
+  const { Hono } = await import("hono");
+  return { elevenlabsWebhookApp: new Hono() };
+});
+
+vi.mock("./webhook/sandbox-command.js", async () => {
+  const { Hono } = await import("hono");
+  return { createSandboxCommandWebhookApp: vi.fn(() => new Hono()) };
+});
+
+vi.mock("./routes/dashboard/index.js", async () => {
+  const { Hono } = await import("hono");
+  return { dashboardApp: new Hono() };
+});
+
+vi.mock("./pipeline/index.js", () => ({
+  runPipeline: vi.fn(),
+}));
+
+vi.mock("./slack/home.js", () => ({
+  ACTION_TO_SETTING: {},
+  CREDENTIAL_ACTIONS: {},
+  TOOLS_REPO_SAVE_ACTION: "tools_repo_save",
+  TOOLS_REPO_SETTING_KEY: "tools_repo",
+  buildAddCredentialBlocks: vi.fn(() => []),
+  hasRole: vi.fn(async () => true),
+  openAddCredentialModal: vi.fn(),
+  openCredentialAccessModal: vi.fn(),
+  openCredentialModal: vi.fn(),
+  openShareCredentialModal: vi.fn(),
+  openUpdateCredentialModal: vi.fn(),
+  publishHomeTab: vi.fn(),
+}));
+
+vi.mock("./lib/api-credentials.js", () => ({
+  deleteApiCredential: vi.fn(),
+  grantApiCredentialAccess: vi.fn(),
+  hasPermission: vi.fn(async () => true),
+  listApiCredentials: vi.fn(async () => []),
+  storeApiCredential: vi.fn(),
+}));
+
+vi.mock("./lib/confirmation.js", () => ({
+  resolveConfirmation: vi.fn(),
+}));
+
+vi.mock("./lib/tool.js", () => ({
+  executionContext: {
+    getStore: vi.fn(() => undefined),
+  },
+}));
+
+vi.mock("./lib/settings.js", () => ({
+  getConfig: vi.fn(async (_key: string, fallback?: string) => fallback ?? ""),
+  setSetting: vi.fn(),
+}));
+
+vi.mock("./lib/logger.js", () => ({
+  logger: {
+    info: mocks.loggerInfoMock,
+    warn: mocks.loggerWarnMock,
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./tools/slack.js", () => ({
+  resolveSlackDestination: mocks.resolveSlackDestinationMock,
+}));
+
+vi.mock("./lib/metrics.js", () => ({
+  recordError: mocks.recordErrorMock,
+}));
+
+vi.mock("./lib/slack-messaging.js", () => ({
+  safePostMessage: mocks.safePostMessageMock,
+}));
+
+vi.mock("./db/client.js", () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        catch: vi.fn(),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => []),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("./lib/credentials.js", () => ({
+  getCredential: mocks.getCredentialMock,
+}));
+
+const app = (await import("./app.js")).default;
+
+function sign(rawBody: string): string {
+  return (
+    "sha256=" +
+    crypto
+      .createHmac("sha256", process.env.CURSOR_WEBHOOK_SECRET!)
+      .update(rawBody, "utf8")
+      .digest("hex")
+  );
+}
+
+describe("Cursor agent webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.waitUntilPromises.length = 0;
+    process.env.CURSOR_WEBHOOK_SECRET = "cursor-secret";
+    process.env.AURA_ADMIN_USER_IDS = "UADMIN";
+    mocks.getCredentialMock.mockResolvedValue("gh-token");
+    mocks.resolveSlackDestinationMock.mockResolvedValue("DADMIN");
+    mocks.safePostMessageMock.mockResolvedValue({ ok: true });
+    mocks.fetchMock.mockImplementation(async (url: string) => {
+      if (url === "https://api.github.com/graphql") {
+        return {
+          ok: false,
+          status: 500,
+          json: vi.fn(async () => ({ message: "github down" })),
+        } as unknown as Response;
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        json: vi.fn(async () => ({ title: "Fix webhook" })),
+      } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", mocks.fetchMock);
+  });
+
+  it("logs GitHub ready failures and still sends the PR notification", async () => {
+    const rawBody = JSON.stringify({
+      status: "FINISHED",
+      target: {
+        prUrl: "https://github.com/AuraHQ-ai/aura/pull/1037",
+      },
+    });
+
+    const response = await app.request("/api/webhook/cursor-agent", {
+      method: "POST",
+      headers: {
+        "x-webhook-signature": sign(rawBody),
+        "content-type": "application/json",
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await Promise.all(mocks.waitUntilPromises);
+
+    expect(mocks.loggerWarnMock).toHaveBeenCalledWith(
+      "Cursor agent webhook: failed to mark PR ready for review",
+      {
+        owner: "AuraHQ-ai",
+        repo: "aura",
+        number: 1037,
+        error: "GitHub GraphQL request failed (500): github down",
+      },
+    );
+    expect(mocks.safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "DADMIN",
+        text: expect.stringContaining(
+          "<https://github.com/AuraHQ-ai/aura/pull/1037|Fix webhook>",
+        ),
+      }),
+    );
+    expect(mocks.recordErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -973,6 +973,25 @@ app.post("/api/webhook/cursor-agent", async (c) => {
         }
       }
 
+      if (isFinished && resolvedPrUrl) {
+        try {
+          const { getCredential } = await import("./lib/credentials.js");
+          const { markPullRequestReadyForReview } = await import(
+            "./lib/cursor-agent.js"
+          );
+          const ghToken = await getCredential("github_token");
+          await markPullRequestReadyForReview({
+            prUrl: resolvedPrUrl,
+            githubToken: ghToken,
+          });
+        } catch (error) {
+          logger.warn("Cursor agent webhook: failed to mark PR ready for review", {
+            prUrl: resolvedPrUrl,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
       let prTitle = "";
       if (resolvedPrUrl) {
         const prMatch = resolvedPrUrl.match(/\/pull\/(\d+)$/);

--- a/apps/api/src/lib/cursor-agent.test.ts
+++ b/apps/api/src/lib/cursor-agent.test.ts
@@ -1,15 +1,33 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
 
-const { resolveCursorAgentPrUrl } = await import("./cursor-agent.js");
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const {
+  markPullRequestReadyForReview,
+  parseGitHubPullRequestUrl,
+  resolveCursorAgentPrUrl,
+} = await import("./cursor-agent.js");
+const { logger } = await import("./logger.js");
 
 function jsonResponse(data: unknown): Response {
   return {
     ok: true,
+    status: 200,
     json: vi.fn(async () => data),
   } as unknown as Response;
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("resolveCursorAgentPrUrl", () => {
   it("passes through the payload PR URL when present", async () => {
@@ -76,5 +94,137 @@ describe("resolveCursorAgentPrUrl", () => {
     });
 
     expect(result).toBe("");
+  });
+});
+
+describe("parseGitHubPullRequestUrl", () => {
+  it("parses owner, repo, and number from a GitHub PR URL", () => {
+    expect(
+      parseGitHubPullRequestUrl("https://github.com/AuraHQ-ai/aura/pull/1037"),
+    ).toEqual({
+      owner: "AuraHQ-ai",
+      repo: "aura",
+      number: 1037,
+    });
+  });
+
+  it("returns null for non-PR URLs", () => {
+    expect(
+      parseGitHubPullRequestUrl(
+        "https://github.com/AuraHQ-ai/aura/tree/feature-branch",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("markPullRequestReadyForReview", () => {
+  it("marks a draft PR ready for review", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+
+      if (String(body.query).includes("repository(owner:")) {
+        return jsonResponse({
+          data: {
+            repository: {
+              pullRequest: {
+                id: "PR_kwDOExample",
+                isDraft: true,
+                number: 1037,
+              },
+            },
+          },
+        });
+      }
+
+      if (String(body.query).includes("markPullRequestReadyForReview")) {
+        expect(body.variables).toEqual({ pullRequestId: "PR_kwDOExample" });
+        return jsonResponse({
+          data: {
+            markPullRequestReadyForReview: {
+              pullRequest: {
+                id: "PR_kwDOExample",
+                isDraft: false,
+                number: 1037,
+              },
+            },
+          },
+        });
+      }
+
+      throw new Error("unexpected GraphQL query");
+    });
+
+    const result = await markPullRequestReadyForReview({
+      prUrl: "https://github.com/AuraHQ-ai/aura/pull/1037",
+      githubToken: "gh-token",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("marked");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Cursor agent webhook: marked PR #1037 ready for review",
+      {
+        owner: "AuraHQ-ai",
+        repo: "aura",
+        number: 1037,
+      },
+    );
+  });
+
+  it("no-ops when the PR is already ready for review", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              id: "PR_kwDOExample",
+              isDraft: false,
+              number: 1037,
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await markPullRequestReadyForReview({
+      prUrl: "https://github.com/AuraHQ-ai/aura/pull/1037",
+      githubToken: "gh-token",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("already_ready");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Cursor agent webhook: PR already ready for review",
+      {
+        owner: "AuraHQ-ai",
+        repo: "aura",
+        number: 1037,
+      },
+    );
+  });
+
+  it("logs a warning and resolves when GitHub fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("github down");
+    });
+
+    const result = await markPullRequestReadyForReview({
+      prUrl: "https://github.com/AuraHQ-ai/aura/pull/1037",
+      githubToken: "gh-token",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("failed");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Cursor agent webhook: failed to mark PR ready for review",
+      {
+        owner: "AuraHQ-ai",
+        repo: "aura",
+        number: 1037,
+        error: "github down",
+      },
+    );
   });
 });

--- a/apps/api/src/lib/cursor-agent.ts
+++ b/apps/api/src/lib/cursor-agent.ts
@@ -54,6 +54,190 @@ export interface ResolveCursorAgentPrUrlParams {
   fetchImpl?: typeof fetch;
 }
 
+export interface GitHubPullRequestRef {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+export type MarkPullRequestReadyResult =
+  | "marked"
+  | "already_ready"
+  | "skipped"
+  | "failed";
+
+interface GitHubGraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message?: string }>;
+  message?: string;
+}
+
+export function parseGitHubPullRequestUrl(
+  prUrl: string,
+): GitHubPullRequestRef | null {
+  try {
+    const url = new URL(prUrl);
+    if (url.hostname !== "github.com") return null;
+
+    const [owner, repo, pullSegment, numberSegment] = url.pathname
+      .split("/")
+      .filter(Boolean);
+    if (!owner || !repo || pullSegment !== "pull" || !numberSegment) {
+      return null;
+    }
+
+    const number = Number(numberSegment);
+    if (!Number.isInteger(number) || number <= 0) return null;
+
+    return { owner, repo, number };
+  } catch {
+    return null;
+  }
+}
+
+async function githubGraphql<T>({
+  githubToken,
+  query,
+  variables,
+  fetchImpl,
+}: {
+  githubToken: string;
+  query: string;
+  variables: Record<string, unknown>;
+  fetchImpl: typeof fetch;
+}): Promise<T | undefined> {
+  const response = await fetchImpl("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${githubToken}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "User-Agent": "Aura",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  let body: GitHubGraphqlResponse<T> | undefined;
+  try {
+    body = (await response.json()) as GitHubGraphqlResponse<T>;
+  } catch {
+    body = undefined;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub GraphQL request failed (${response.status}): ${
+        body?.message || "unknown error"
+      }`,
+    );
+  }
+
+  if (body?.errors?.length) {
+    throw new Error(
+      `GitHub GraphQL error: ${body.errors
+        .map((error) => error.message || "unknown error")
+        .join("; ")}`,
+    );
+  }
+
+  return body?.data;
+}
+
+export async function markPullRequestReadyForReview({
+  prUrl,
+  githubToken,
+  fetchImpl = fetch,
+}: {
+  prUrl: string;
+  githubToken: string | null | undefined;
+  fetchImpl?: typeof fetch;
+}): Promise<MarkPullRequestReadyResult> {
+  if (!githubToken) return "skipped";
+
+  const pr = parseGitHubPullRequestUrl(prUrl);
+  if (!pr) return "skipped";
+
+  try {
+    const data = await githubGraphql<{
+      repository: {
+        pullRequest: { id: string; isDraft: boolean; number: number } | null;
+      } | null;
+    }>({
+      githubToken,
+      fetchImpl,
+      query: `
+        query CursorWebhookPullRequest($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              id
+              isDraft
+              number
+            }
+          }
+        }
+      `,
+      variables: {
+        owner: pr.owner,
+        repo: pr.repo,
+        number: pr.number,
+      },
+    });
+
+    const pullRequest = data?.repository?.pullRequest;
+    if (!pullRequest) {
+      throw new Error(`GitHub PR #${pr.number} not found`);
+    }
+
+    if (!pullRequest.isDraft) {
+      logger.info("Cursor agent webhook: PR already ready for review", {
+        owner: pr.owner,
+        repo: pr.repo,
+        number: pr.number,
+      });
+      return "already_ready";
+    }
+
+    await githubGraphql<{
+      markPullRequestReadyForReview: {
+        pullRequest: { id: string; isDraft: boolean; number: number } | null;
+      } | null;
+    }>({
+      githubToken,
+      fetchImpl,
+      query: `
+        mutation CursorWebhookMarkPullRequestReady($pullRequestId: ID!) {
+          markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+            pullRequest {
+              id
+              isDraft
+              number
+            }
+          }
+        }
+      `,
+      variables: { pullRequestId: pullRequest.id },
+    });
+
+    logger.info(
+      `Cursor agent webhook: marked PR #${pr.number} ready for review`,
+      {
+        owner: pr.owner,
+        repo: pr.repo,
+        number: pr.number,
+      },
+    );
+    return "marked";
+  } catch (error) {
+    logger.warn("Cursor agent webhook: failed to mark PR ready for review", {
+      owner: pr.owner,
+      repo: pr.repo,
+      number: pr.number,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return "failed";
+  }
+}
+
 export async function resolveCursorAgentPrUrl({
   prUrl,
   branchName,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Parse resolved Cursor PR URLs and use GitHub GraphQL to mark draft PRs ready for review on FINISHED webhook events
- Treat already-ready PRs as a no-op and convert GitHub failures into warnings so Slack PR notifications still send
- Add helper-level coverage for draft/ready/error cases plus an app-level continuation test

## Verification
- `pnpm --filter aura-api exec vitest run src/lib/cursor-agent.test.ts src/app.cursor-agent.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
- `pnpm --filter aura-api test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f890c720-0950-4914-98cd-97fad346a201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f890c720-0950-4914-98cd-97fad346a201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

