### PR TITLE
feat(observability): post-deploy smoke check for external API integrations (#986)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { logger } from "./lib/logger.js";
 import { resolveSlackDestination } from "./tools/slack.js";
 import { recordError } from "./lib/metrics.js";
 import { safePostMessage } from "./lib/slack-messaging.js";
+import { runSmokeCheck } from "./lib/smoke-check.js";
 import crypto from "node:crypto";
 import { eq, sql } from "drizzle-orm";
 import { db } from "./db/client.js";
@@ -137,6 +138,31 @@ app.get("/", (c) => {
 
 app.get("/api/health", (c) => {
   return c.json({ ok: true, timestamp: new Date().toISOString() });
+});
+
+// Internal post-deploy smoke check. If SMOKE_CHECK_SECRET is not configured,
+// keep the endpoint callable but log loudly so deploy-hook setup mistakes show up.
+app.get("/api/internal/smoke", async (c) => {
+  const secret = process.env.SMOKE_CHECK_SECRET;
+  const header = c.req.header("x-smoke-secret") || "";
+
+  if (!secret) {
+    logger.warn("SMOKE_CHECK_SECRET not configured — running smoke check without secret gate");
+  } else if (header !== secret) {
+    logger.warn("Invalid smoke check secret — rejecting");
+    return c.json({ error: "Invalid smoke check secret" }, 401);
+  }
+
+  const result = await runSmokeCheck({
+    slackClient,
+    deploy: c.req.query("deploy") || c.req.query("sha"),
+  });
+
+  if (result.failures > 0) {
+    return c.json(result, 500);
+  }
+
+  return c.json(result);
 });
 
 // ── Dashboard API (authenticated with DASHBOARD_API_SECRET) ─────────────────

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -50,7 +50,7 @@ export interface ModelCatalogResponse {
   lastSyncedAt: string | null;
 }
 
-interface GatewayModel {
+export interface GatewayModel {
   id: string;
   owned_by?: string;
   name?: string;
@@ -237,7 +237,7 @@ function toPricePerMillion(
   return (numeric * 1_000_000).toString();
 }
 
-async function fetchGatewayModels(): Promise<GatewayModel[]> {
+export async function fetchGatewayModels(): Promise<GatewayModel[]> {
   const response = await fetch(GATEWAY_MODELS_URL);
   if (!response.ok) {
     throw new Error(`Gateway models fetch failed: ${response.status}`);

--- a/apps/api/src/lib/smoke-check.test.ts
+++ b/apps/api/src/lib/smoke-check.test.ts
@@ -1,0 +1,134 @@
+import type { WebClient } from "@slack/web-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
+
+const mocks = vi.hoisted(() => ({
+  safePostMessage: vi.fn(),
+  resolveSlackDestination: vi.fn(),
+  recordError: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock("./cursor-agent.js", () => ({
+  listCursorAgents: vi.fn(),
+}));
+
+vi.mock("./bigquery.js", () => ({
+  getBigQueryClient: vi.fn(),
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  fetchGatewayModels: vi.fn(),
+  getModelCatalogResponse: vi.fn(),
+}));
+
+vi.mock("./slack-messaging.js", () => ({
+  safePostMessage: mocks.safePostMessage,
+}));
+
+vi.mock("../tools/slack.js", () => ({
+  resolveSlackDestination: mocks.resolveSlackDestination,
+}));
+
+vi.mock("./metrics.js", () => ({
+  recordError: mocks.recordError,
+}));
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: mocks.loggerWarn,
+    error: vi.fn(),
+  },
+}));
+
+const { runSmokeCheck } = await import("./smoke-check.js");
+
+describe("runSmokeCheck", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SMOKE_CHECK_NOTIFY_USER;
+    delete process.env.SMOKE_CHECK_SUCCESS_CHANNEL;
+    delete process.env.FOUNDER_USER_ID;
+    delete process.env.AURA_ADMIN_USER_IDS;
+    mocks.resolveSlackDestination.mockResolvedValue("DOWNER");
+    mocks.safePostMessage.mockResolvedValue({ ok: true });
+  });
+
+  it("returns zero failures and uses the quiet success path when all probes pass", async () => {
+    const result = await runSmokeCheck({
+      slackClient: {} as WebClient,
+      deploy: "abc123",
+      successChannel: "COPS",
+      probes: [
+        { name: "Cursor API", run: vi.fn(async () => ({ ok: true, detail: "list agents 200" })) },
+        { name: "Slack auth", run: vi.fn(async () => ({ ok: true, detail: "auth.test ok" })) },
+      ],
+    });
+
+    expect(result).toEqual({
+      deploy: "abc123",
+      failures: 0,
+      results: [
+        { name: "Cursor API", ok: true, detail: "list agents 200" },
+        { name: "Slack auth", ok: true, detail: "auth.test ok" },
+      ],
+    });
+    expect(mocks.resolveSlackDestination).not.toHaveBeenCalled();
+    expect(mocks.recordError).not.toHaveBeenCalled();
+    expect(mocks.safePostMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "COPS",
+        text: expect.stringContaining(":white_check_mark: Deploy abc123 smoke check"),
+      }),
+    );
+  });
+
+  it("isolates probe errors, increments failures, and sends the loud failure DM", async () => {
+    process.env.SMOKE_CHECK_NOTIFY_USER = "UOWNER";
+
+    const afterFailureProbe = vi.fn(async () => ({ ok: true, detail: "still ran" }));
+    const result = await runSmokeCheck({
+      slackClient: {} as WebClient,
+      deploy: "def456",
+      probes: [
+        {
+          name: "Cursor API",
+          run: vi.fn(async () => {
+            throw new Error("Cursor API GET /agents failed (404)");
+          }),
+        },
+        { name: "Slack auth", run: afterFailureProbe },
+      ],
+    });
+
+    expect(result.failures).toBe(1);
+    expect(result.results).toEqual([
+      {
+        name: "Cursor API",
+        ok: false,
+        detail: "Cursor API GET /agents failed (404)",
+      },
+      { name: "Slack auth", ok: true, detail: "still ran" },
+    ]);
+    expect(afterFailureProbe).toHaveBeenCalledTimes(1);
+    expect(mocks.recordError).toHaveBeenCalledWith(
+      "smoke_check",
+      expect.any(Error),
+      expect.objectContaining({
+        deploy: "def456",
+        failingProbes: ["Cursor API"],
+      }),
+    );
+    expect(mocks.resolveSlackDestination).toHaveBeenCalledWith(expect.anything(), "UOWNER");
+    expect(mocks.safePostMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "DOWNER",
+        text: expect.stringContaining(":warning: :x: Deploy def456 smoke check FAILED"),
+      }),
+    );
+  });
+});

--- a/apps/api/src/lib/smoke-check.ts
+++ b/apps/api/src/lib/smoke-check.ts
@@ -1,0 +1,261 @@
+import type { WebClient } from "@slack/web-api";
+import { listCursorAgents } from "./cursor-agent.js";
+import { getBigQueryClient } from "./bigquery.js";
+import {
+  fetchGatewayModels,
+  getModelCatalogResponse,
+} from "./model-catalog.js";
+import { logger } from "./logger.js";
+import { recordError } from "./metrics.js";
+import { safePostMessage } from "./slack-messaging.js";
+import { resolveSlackDestination } from "../tools/slack.js";
+
+export interface SmokeProbeResult {
+  name: string;
+  ok: boolean;
+  detail: string;
+  skipped?: boolean;
+}
+
+export interface SmokeProbe {
+  name: string;
+  run: () => Promise<Omit<SmokeProbeResult, "name">>;
+}
+
+export interface SmokeCheckResult {
+  deploy?: string;
+  results: SmokeProbeResult[];
+  failures: number;
+}
+
+export interface RunSmokeCheckOptions {
+  slackClient: WebClient;
+  deploy?: string;
+  probes?: SmokeProbe[];
+  notifyUser?: string | null;
+  successChannel?: string | null;
+}
+
+const REQUIRED_ENV_VARS = [
+  "SANDBOX_WEBHOOK_SECRET",
+  "CURSOR_WEBHOOK_SECRET",
+  "AURA_PUBLIC_URL",
+  "DATABASE_URL",
+] as const;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function firstConfiguredAdmin(): string | null {
+  return (
+    (process.env.AURA_ADMIN_USER_IDS || "")
+      .split(",")
+      .map((id) => id.trim())
+      .find(Boolean) ?? null
+  );
+}
+
+function resolveDeploySha(deploy?: string): string | undefined {
+  return (
+    deploy?.trim() ||
+    process.env.VERCEL_GIT_COMMIT_SHA?.trim() ||
+    process.env.GITHUB_SHA?.trim() ||
+    undefined
+  );
+}
+
+function formatProbeLine(result: SmokeProbeResult): string {
+  const icon = result.ok ? (result.skipped ? ":large_yellow_circle:" : ":white_check_mark:") : ":x:";
+  const status = result.ok ? (result.skipped ? "skipped" : "ok") : "failed";
+  return `- ${result.name}: ${status} (${result.detail})`;
+}
+
+function formatSummary(result: SmokeCheckResult): string {
+  const deployLabel = result.deploy ? `Deploy ${result.deploy}` : "Deploy";
+  const header =
+    result.failures > 0
+      ? `:warning: :x: ${deployLabel} smoke check FAILED`
+      : `:white_check_mark: ${deployLabel} smoke check`;
+
+  return [header, ...result.results.map(formatProbeLine)].join("\n");
+}
+
+function defaultNotifyUser(): string | null {
+  return (
+    process.env.SMOKE_CHECK_NOTIFY_USER?.trim() ||
+    process.env.FOUNDER_USER_ID?.trim() ||
+    firstConfiguredAdmin()
+  );
+}
+
+async function notifySmokeCheckResult(
+  slackClient: WebClient,
+  result: SmokeCheckResult,
+  options: Pick<RunSmokeCheckOptions, "notifyUser" | "successChannel">,
+): Promise<void> {
+  const text = formatSummary(result);
+
+  if (result.failures > 0) {
+    const target = options.notifyUser ?? defaultNotifyUser();
+    const failingProbes = result.results
+      .filter((probe) => !probe.ok)
+      .map((probe) => probe.name);
+
+    recordError("smoke_check", new Error(`${result.failures} smoke probe(s) failed`), {
+      deploy: result.deploy,
+      failingProbes,
+    });
+
+    if (!target) {
+      logger.warn("Smoke check failure notification skipped: no target configured", {
+        deploy: result.deploy,
+        failingProbes,
+      });
+      return;
+    }
+
+    const dmChannelId = await resolveSlackDestination(slackClient, target);
+    if (!dmChannelId) {
+      logger.warn("Smoke check failure notification skipped: target did not resolve", {
+        deploy: result.deploy,
+        target,
+        failingProbes,
+      });
+      return;
+    }
+
+    await safePostMessage(slackClient, {
+      channel: dmChannelId,
+      text,
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    return;
+  }
+
+  const successChannel = options.successChannel ?? process.env.SMOKE_CHECK_SUCCESS_CHANNEL?.trim();
+  if (!successChannel) return;
+
+  await safePostMessage(slackClient, {
+    channel: successChannel,
+    text,
+    unfurl_links: false,
+    unfurl_media: false,
+  });
+}
+
+export function createDefaultSmokeProbes(slackClient: WebClient): SmokeProbe[] {
+  return [
+    {
+      name: "Vercel env vars",
+      run: async () => {
+        const missing = REQUIRED_ENV_VARS.filter((name) => !process.env[name]);
+        const present = REQUIRED_ENV_VARS.length - missing.length;
+        const base = `${present}/${REQUIRED_ENV_VARS.length} present`;
+
+        return {
+          ok: missing.length === 0,
+          detail: missing.length > 0 ? `${base}; missing ${missing.join(", ")}` : base,
+        };
+      },
+    },
+    {
+      name: "Cursor API",
+      run: async () => {
+        await listCursorAgents();
+        return { ok: true, detail: "list agents 200" };
+      },
+    },
+    {
+      name: "Slack auth",
+      run: async () => {
+        const auth = await slackClient.auth.test();
+        return {
+          ok: Boolean(auth.ok),
+          detail: auth.ok ? `auth.test ok${auth.team ? ` for ${auth.team}` : ""}` : "auth.test failed",
+        };
+      },
+    },
+    {
+      name: "AI Gateway catalog",
+      run: async () => {
+        const [liveModels, storedCatalog] = await Promise.all([
+          fetchGatewayModels(),
+          getModelCatalogResponse(),
+        ]);
+        const liveIds = new Set(liveModels.map((model) => model.id));
+        const storedIds = storedCatalog.catalog.map((model) => model.value);
+        const overlap = storedIds.filter((modelId) => liveIds.has(modelId));
+
+        return {
+          ok: liveModels.length > 0 && overlap.length > 0,
+          detail: `${liveModels.length} live, ${storedIds.length} stored, ${overlap.length} overlap`,
+        };
+      },
+    },
+    {
+      name: "BigQuery",
+      run: async () => {
+        const client = await getBigQueryClient();
+        if (!client) {
+          return {
+            ok: true,
+            skipped: true,
+            detail: "skipped: google_bq_credentials not configured",
+          };
+        }
+
+        const [datasets] = await client.getDatasets();
+        return { ok: true, detail: `listed ${datasets.length} dataset(s)` };
+      },
+    },
+  ];
+}
+
+export async function runSmokeCheck(
+  options: RunSmokeCheckOptions,
+): Promise<SmokeCheckResult> {
+  const deploy = resolveDeploySha(options.deploy);
+  const probes = options.probes ?? createDefaultSmokeProbes(options.slackClient);
+  const results: SmokeProbeResult[] = [];
+
+  for (const probe of probes) {
+    try {
+      const result = await probe.run();
+      results.push({
+        name: probe.name,
+        ok: result.ok,
+        detail: result.detail,
+        ...(result.skipped !== undefined ? { skipped: result.skipped } : {}),
+      });
+    } catch (error) {
+      results.push({
+        name: probe.name,
+        ok: false,
+        detail: errorMessage(error),
+      });
+    }
+  }
+
+  const smokeResult: SmokeCheckResult = {
+    ...(deploy ? { deploy } : {}),
+    results,
+    failures: results.filter((result) => !result.ok).length,
+  };
+
+  try {
+    await notifySmokeCheckResult(options.slackClient, smokeResult, options);
+  } catch (error) {
+    recordError("smoke_check_notify", error, {
+      deploy: smokeResult.deploy,
+      failures: smokeResult.failures,
+    });
+    logger.warn("Smoke check notification failed", {
+      deploy: smokeResult.deploy,
+      error: errorMessage(error),
+    });
+  }
+
+  return smokeResult;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add secret-gated `GET /api/internal/smoke` for post-deploy integration smoke checks.
- Add a smoke-check registry/orchestrator covering env presence, Cursor Agents list API, Slack auth, AI Gateway catalog overlap, and best-effort BigQuery reachability.
- Send loud Slack DMs on failures and optional quiet success posts via `SMOKE_CHECK_SUCCESS_CHANNEL`.

Closes #986

## How it was tested
- `npx tsc --noEmit` from `apps/api`
- `pnpm --filter aura-api test -- src/lib/smoke-check.test.ts` (Vitest matched and ran the API suite: 38 files / 271 tests passed)
- `pnpm typecheck`
- Pre-push hook: `pnpm --filter aura-api typecheck` and `pnpm --filter aura-dashboard typecheck`

## Vercel deploy-hook wiring
1. Set `SMOKE_CHECK_SECRET` in Vercel production env.
2. Set optional failure target env `SMOKE_CHECK_NOTIFY_USER`; otherwise Aura falls back to `FOUNDER_USER_ID`, then the first `AURA_ADMIN_USER_IDS` entry.
3. Optionally set `SMOKE_CHECK_SUCCESS_CHANNEL` for quiet all-pass confirmations. Leave unset to avoid success noise.
4. Configure the Vercel deploy hook / post-deploy automation to call:
   ```bash
   curl -fsS "${AURA_PUBLIC_URL}/api/internal/smoke?deploy=$VERCEL_GIT_COMMIT_SHA" \
     -H "x-smoke-secret: $SMOKE_CHECK_SECRET"
   ```
   The endpoint returns `{ deploy, results, failures }` and responds with HTTP 500 when any probe fails.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f594a24-9489-41cc-986d-7ce59d6f36b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f594a24-9489-41cc-986d-7ce59d6f36b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

