### PR TITLE
fix(credentials): add rename + reveal, fix iOS input zoom

### DIFF
--- a/apps/api/src/routes/dashboard/credentials.ts
+++ b/apps/api/src/routes/dashboard/credentials.ts
@@ -348,6 +348,166 @@ dashboardCredentialsApp.openapi(updateCredentialValueRoute, async (c) => {
   }
 });
 
+const NAME_PATTERN = /^[a-z][a-z0-9_]{1,62}$/;
+
+const updateCredentialNameRoute = createRoute({
+  method: "patch",
+  path: "/{id}/name",
+  tags: ["Credentials"],
+  summary: "Rename a credential",
+  request: {
+    params: idParamSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({ name: z.string() }),
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: z.any() } },
+      description: "Success",
+    },
+    400: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Invalid name",
+    },
+    404: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Not found",
+    },
+    409: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Name already in use",
+    },
+    500: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Error",
+    },
+  },
+});
+
+dashboardCredentialsApp.openapi(updateCredentialNameRoute, async (c) => {
+  try {
+    const id = c.req.param("id");
+    const { name } = await c.req.json<{ name: string }>();
+
+    const normalizedName = (name ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9_]/g, "_");
+
+    if (!NAME_PATTERN.test(normalizedName)) {
+      return c.json(
+        {
+          error:
+            "Invalid name. Use 2-63 characters: lowercase letters, numbers, and underscores, starting with a letter.",
+        },
+        400,
+      );
+    }
+
+    const [existing] = await db
+      .select({ id: credentials.id, name: credentials.name })
+      .from(credentials)
+      .where(eq(credentials.id, id))
+      .limit(1);
+
+    if (!existing) return c.json({ error: "Not found" }, 404);
+
+    try {
+      const [updated] = await db
+        .update(credentials)
+        .set({ name: normalizedName, updatedAt: new Date() })
+        .where(eq(credentials.id, id))
+        .returning({ id: credentials.id, name: credentials.name });
+
+      await db.insert(credentialAuditLog).values({
+        credentialId: id,
+        credentialName: normalizedName,
+        accessedBy: "dashboard",
+        action: "update",
+        context: `Renamed from ${existing.name} to ${normalizedName}`,
+      });
+
+      return c.json(updated as any, 200);
+    } catch (error) {
+      if (String(error).includes("credentials_workspace_owner_id_name_unique")) {
+        return c.json({ error: "A credential with that name already exists for this owner." }, 409);
+      }
+      throw error;
+    }
+  } catch (error) {
+    logger.error("Failed to rename credential", { error: String(error) });
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
+const revealCredentialRoute = createRoute({
+  method: "get",
+  path: "/{id}/reveal",
+  tags: ["Credentials"],
+  summary: "Reveal the plaintext credential value",
+  request: {
+    params: idParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ value: z.string() }),
+        },
+      },
+      description: "Success",
+    },
+    404: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Not found",
+    },
+    500: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Error",
+    },
+  },
+});
+
+dashboardCredentialsApp.openapi(revealCredentialRoute, async (c) => {
+  try {
+    const id = c.req.param("id");
+
+    const [cred] = await db
+      .select({ id: credentials.id, name: credentials.name, value: credentials.value })
+      .from(credentials)
+      .where(eq(credentials.id, id))
+      .limit(1);
+
+    if (!cred) return c.json({ error: "Not found" }, 404);
+
+    let value: string;
+    try {
+      value = decryptCredential(cred.value);
+    } catch (error) {
+      logger.error("Failed to decrypt credential for reveal", { id, error: String(error) });
+      return c.json({ error: "Unable to decrypt credential value" }, 500);
+    }
+
+    await db.insert(credentialAuditLog).values({
+      credentialId: id,
+      credentialName: cred.name,
+      accessedBy: "dashboard",
+      action: "read",
+      context: "Revealed via dashboard",
+    });
+
+    return c.json({ value } as any, 200);
+  } catch (error) {
+    logger.error("Failed to reveal credential", { error: String(error) });
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
+
 const createGrantRoute = createRoute({
   method: "post",
   path: "/{id}/grants",

--- a/apps/dashboard/src/globals.css
+++ b/apps/dashboard/src/globals.css
@@ -93,6 +93,22 @@ body {
   margin: 0;
 }
 
+/*
+ * iOS Safari zooms the viewport when a focused form control has a computed
+ * font-size below 16px. The base root font-size is 14px (compact UI), so the
+ * Tailwind `text-base`/`text-sm` inputs resolve under 16px on mobile and
+ * trigger that zoom. Force at least 16px on touch-sized viewports (below the
+ * `md` breakpoint). This rule is intentionally unlayered so it wins over
+ * Tailwind utility classes regardless of specificity.
+ */
+@media (max-width: 767px) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+
 [data-separator] {
   transition: background-color 0.15s ease;
 }

--- a/apps/dashboard/src/routes/credentials/$id.tsx
+++ b/apps/dashboard/src/routes/credentials/$id.tsx
@@ -13,7 +13,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { DetailSkeleton } from "@/components/page-skeleton";
 import { cn, formatDate } from "@/lib/utils";
 import { useState, useMemo } from "react";
-import { ArrowLeft, Trash2, UserPlus, Check, ChevronsUpDown, Shield, ScrollText } from "lucide-react";
+import { ArrowLeft, Trash2, UserPlus, Check, ChevronsUpDown, Shield, ScrollText, Pencil, Eye, EyeOff } from "lucide-react";
 
 interface Grant {
   id: string;
@@ -82,6 +82,9 @@ function CredentialDetailPage() {
   const [granteeId, setGranteeId] = useState("");
   const [permission, setPermission] = useState("read");
   const [userPickerOpen, setUserPickerOpen] = useState(false);
+  const [showRename, setShowRename] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const [revealedValue, setRevealedValue] = useState<string | null>(null);
 
   const selectedUser = useMemo(
     () => users.find((u) => u.slackUserId === granteeId),
@@ -94,12 +97,30 @@ function CredentialDetailPage() {
       queryClient.invalidateQueries({ queryKey: ["credentials"] });
       setShowUpdateValue(false);
       setNewValue("");
+      setRevealedValue(null);
     },
   });
 
   const scopeMutation = useMutation({
     mutationFn: (scope: string) => apiPatch(`/credentials/${id}/scope`, { scope }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["credentials"] }),
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: () => apiPatch(`/credentials/${id}/name`, { name: renameValue }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["credentials"] });
+      setShowRename(false);
+      setRenameValue("");
+    },
+  });
+
+  const revealMutation = useMutation({
+    mutationFn: () => apiGet<{ value: string }>(`/credentials/${id}/reveal`),
+    onSuccess: (res) => {
+      setRevealedValue(res.value);
+      queryClient.invalidateQueries({ queryKey: ["credentials", id] });
+    },
   });
 
   const grantMutation = useMutation({
@@ -138,6 +159,16 @@ function CredentialDetailPage() {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Badge variant="secondary">{data.type}</Badge>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setRenameValue(data.name);
+              setShowRename(true);
+            }}
+          >
+            <Pencil className="h-4 w-4" /> Rename
+          </Button>
           <Button variant="outline" size="sm" onClick={() => setShowUpdateValue(true)}>Update Value</Button>
           <Button
             variant="destructive"
@@ -153,7 +184,30 @@ function CredentialDetailPage() {
         <Card>
           <CardHeader><CardTitle className="text-sm">Value</CardTitle></CardHeader>
           <CardContent>
-            <code className="text-sm font-mono">{data.maskedValue}</code>
+            <div className="flex items-center gap-2 min-w-0">
+              <code className="text-sm font-mono truncate flex-1">
+                {revealedValue ?? data.maskedValue}
+              </code>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0"
+                disabled={revealMutation.isPending}
+                title={revealedValue ? "Hide value" : "Reveal value"}
+                onClick={() => {
+                  if (revealedValue) {
+                    setRevealedValue(null);
+                  } else {
+                    revealMutation.mutate();
+                  }
+                }}
+              >
+                {revealedValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </Button>
+            </div>
+            {revealMutation.isError && (
+              <p className="text-xs text-destructive mt-1">Failed to reveal value</p>
+            )}
           </CardContent>
         </Card>
         <Card>
@@ -261,6 +315,40 @@ function CredentialDetailPage() {
           </div>
         </TabsContent>
       </Tabs>
+
+      <Dialog open={showRename} onOpenChange={setShowRename}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename Credential</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input
+              placeholder="e.g. github_token"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Lowercase letters, numbers, and underscores only. Must start with a letter.
+            </p>
+            {renameMutation.isError && (
+              <p className="text-xs text-destructive">
+                {renameMutation.error instanceof Error
+                  ? renameMutation.error.message
+                  : "Failed to rename credential"}
+              </p>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setShowRename(false)}>Cancel</Button>
+              <Button
+                onClick={() => renameMutation.mutate()}
+                disabled={!renameValue || renameValue === data.name || renameMutation.isPending}
+              >
+                {renameMutation.isPending ? "Renaming..." : "Rename"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={showUpdateValue} onOpenChange={setShowUpdateValue}>
         <DialogContent>

--- a/apps/dashboard/src/routes/credentials/$id.tsx
+++ b/apps/dashboard/src/routes/credentials/$id.tsx
@@ -149,15 +149,17 @@ function CredentialDetailPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-3 flex-wrap">
-        <Button variant="ghost" size="icon-sm" asChild>
-          <Link to="/credentials"><ArrowLeft className="h-4 w-4" /></Link>
-        </Button>
-        <div className="min-w-0 flex-1">
-          <h1 className="text-base font-semibold font-mono truncate">{data.name}</h1>
-          <p className="text-sm text-muted-foreground">Owned by {data.ownerName}</p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-3 min-w-0">
+          <Button variant="ghost" size="icon-sm" className="shrink-0" asChild>
+            <Link to="/credentials"><ArrowLeft className="h-4 w-4" /></Link>
+          </Button>
+          <div className="min-w-0 flex-1">
+            <h1 className="text-base font-semibold font-mono truncate">{data.name}</h1>
+            <p className="text-sm text-muted-foreground truncate">Owned by {data.ownerName}</p>
+          </div>
         </div>
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex items-center gap-2 flex-wrap sm:ml-auto sm:shrink-0">
           <Badge variant="secondary">{data.type}</Badge>
           <Button
             variant="outline"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three bugs reported while using the credentials module in the dashboard:

1. **Can update a secret but can't rename it** — there was no rename path in the UI or API (name was only set at create time).
2. **Can't reveal a secret** — the detail page only showed a masked value, and there was no reveal endpoint.
3. **Mobile inputs trigger iOS zoom on focus** — the compact `14px` root font size made inputs resolve below `16px`, which makes iOS Safari zoom the viewport on focus. This affected form fields across the whole app.

## Changes

### API (`apps/api/src/routes/dashboard/credentials.ts`)
- Added `PATCH /credentials/{id}/name` to rename a credential. Normalizes the name (lowercases, replaces invalid chars with `_`), validates against the DB pattern `^[a-z][a-z0-9_]{1,62}$` returning a clear `400`, returns `409` on the uniqueness constraint, and writes an `update` audit log entry.
- Added `GET /credentials/{id}/reveal` that decrypts and returns the plaintext value, and records a `read` audit log entry (`accessedBy: "dashboard"`, context `Revealed via dashboard`).

### Dashboard (`apps/dashboard/src/routes/credentials/$id.tsx`)
- Added a **Rename** button + dialog with validation hint and server-error surfacing.
- Added a reveal/hide eye toggle on the Value card that fetches the plaintext on demand; the revealed value is cleared after a value update so it never shows a stale secret.

### Dashboard styling (`apps/dashboard/src/globals.css`)
- Added an unlayered media query forcing `font-size: 16px` on `input`/`select`/`textarea` below the `md` breakpoint (`max-width: 767px`) to stop iOS Safari from zooming on focus. It is intentionally unlayered so it wins over Tailwind utility classes. Checkbox/radio/range are excluded.

## Notes
- Reveal returns plaintext only over the authenticated dashboard API (JWT session or `DASHBOARD_API_SECRET`) and every reveal is recorded in the credential audit log.
- No schema/migration changes were needed — the `update`/`read` audit actions and the name uniqueness constraint already exist.

## Verification
- `pnpm typecheck` passes for both `apps/api` and `apps/dashboard` (also enforced by the pre-push hook, which passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50bd9be6-4ba2-42da-9b96-516de17fb9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50bd9be6-4ba2-42da-9b96-516de17fb9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

