### PR TITLE
Default credential owner to current user in Add Credential dialog

### DIFF
--- a/apps/dashboard/src/routes/credentials/index.tsx
+++ b/apps/dashboard/src/routes/credentials/index.tsx
@@ -34,7 +34,8 @@ import {
 import { TableRowsSkeleton } from "@/components/page-skeleton";
 import { Pagination } from "@/components/pagination";
 import { cn, formatDate } from "@/lib/utils";
-import { useState, useMemo } from "react";
+import { useAuth } from "@/lib/auth";
+import { useState, useMemo, useEffect } from "react";
 import { Plus, Search, Check, ChevronsUpDown } from "lucide-react";
 
 const SCOPE_LABELS: Record<
@@ -72,15 +73,22 @@ const PAGE_SIZE = 100;
 
 function CredentialsPage() {
   const queryClient = useQueryClient();
+  const { session } = useAuth();
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
   const [newType, setNewType] = useState("token");
   const [newValue, setNewValue] = useState("");
-  const [newOwnerId, setNewOwnerId] = useState("");
+  const [newOwnerId, setNewOwnerId] = useState(session?.slackUserId ?? "");
   const [newScope, setNewScope] = useState("member");
   const [ownerPickerOpen, setOwnerPickerOpen] = useState(false);
+
+  useEffect(() => {
+    if (showCreate && !newOwnerId && session?.slackUserId) {
+      setNewOwnerId(session.slackUserId);
+    }
+  }, [showCreate, newOwnerId, session?.slackUserId]);
 
   const { data, isLoading, isFetching, error } = useQuery({
     queryKey: ["credentials", search, page],
@@ -110,6 +118,13 @@ function CredentialsPage() {
     [users, newOwnerId],
   );
 
+  const selectedOwnerLabel = useMemo(() => {
+    if (!newOwnerId) return "Select owner…";
+    if (selectedOwner) return selectedOwner.displayName || selectedOwner.slackUserId;
+    if (session?.slackUserId === newOwnerId) return session.name || newOwnerId;
+    return newOwnerId;
+  }, [newOwnerId, selectedOwner, session?.slackUserId, session?.name]);
+
   const createMutation = useMutation({
     mutationFn: (payload: {
       name: string;
@@ -124,7 +139,7 @@ function CredentialsPage() {
       setNewName("");
       setNewType("token");
       setNewValue("");
-      setNewOwnerId("");
+      setNewOwnerId(session?.slackUserId ?? "");
       setNewScope("member");
     },
   });
@@ -256,10 +271,7 @@ function CredentialsPage() {
                     aria-expanded={ownerPickerOpen}
                     className="w-full justify-between font-normal"
                   >
-                    {selectedOwner
-                      ? selectedOwner.displayName ||
-                        selectedOwner.slackUserId
-                      : "Select owner…"}
+                    {selectedOwnerLabel}
                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                   </Button>
                 </PopoverTrigger>

--- a/apps/dashboard/src/routes/credentials/index.tsx
+++ b/apps/dashboard/src/routes/credentials/index.tsx
@@ -118,12 +118,12 @@ function CredentialsPage() {
     [users, newOwnerId],
   );
 
-  const selectedOwnerLabel = useMemo(() => {
-    if (!newOwnerId) return "Select owner…";
-    if (selectedOwner) return selectedOwner.displayName || selectedOwner.slackUserId;
-    if (session?.slackUserId === newOwnerId) return session.name || newOwnerId;
-    return newOwnerId;
-  }, [newOwnerId, selectedOwner, session?.slackUserId, session?.name]);
+  const ownerLabel =
+    selectedOwner?.displayName ||
+    selectedOwner?.slackUserId ||
+    (newOwnerId === session?.slackUserId
+      ? session.name || session.slackUserId
+      : null);
 
   const createMutation = useMutation({
     mutationFn: (payload: {
@@ -271,7 +271,7 @@ function CredentialsPage() {
                     aria-expanded={ownerPickerOpen}
                     className="w-full justify-between font-normal"
                   >
-                    {selectedOwnerLabel}
+                    {ownerLabel || "Select owner…"}
                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                   </Button>
                 </PopoverTrigger>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When adding a new credential at `/credentials`, the **Owner** field defaulted to nothing ("Select owner…"), forcing the user to manually pick themselves every time. This wires the dashboard auth session into the credentials page so the Owner defaults to the currently logged-in user.

## Changes

In `apps/dashboard/src/routes/credentials/index.tsx`:
- Import and use `useAuth()` to access the current `session`.
- Initialize `newOwnerId` to `session?.slackUserId`, and set it when the create dialog opens if no owner is selected yet (handles the case where the session resolves after first render).
- Reset the owner back to the current user (instead of empty) after a successful create.
- Add a `selectedOwnerLabel` fallback so the trigger shows the current user's name even when they aren't in the fetched users list (the `/users` API caps results at 100). Users can still change the owner via the combobox.

## Notes
- The user can still freely change the owner — this only sets a sensible default.
- `pnpm typecheck` passes for both `apps/api` and `apps/dashboard`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5546b105-f1cb-4f68-b6b2-ad34ac90a99d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5546b105-f1cb-4f68-b6b2-ad34ac90a99d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

