### PR TITLE
Default new credential owner to current user

### DIFF
--- a/apps/dashboard/src/routes/credentials/index.tsx
+++ b/apps/dashboard/src/routes/credentials/index.tsx
@@ -34,7 +34,8 @@ import {
 import { TableRowsSkeleton } from "@/components/page-skeleton";
 import { Pagination } from "@/components/pagination";
 import { cn, formatDate } from "@/lib/utils";
-import { useState, useMemo } from "react";
+import { useAuth } from "@/lib/auth";
+import { useState, useMemo, useEffect } from "react";
 import { Plus, Search, Check, ChevronsUpDown } from "lucide-react";
 
 const SCOPE_LABELS: Record<
@@ -72,6 +73,7 @@ const PAGE_SIZE = 100;
 
 function CredentialsPage() {
   const queryClient = useQueryClient();
+  const { session } = useAuth();
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [showCreate, setShowCreate] = useState(false);
@@ -109,6 +111,18 @@ function CredentialsPage() {
     () => users.find((u) => u.slackUserId === newOwnerId),
     [users, newOwnerId],
   );
+  const ownerLabel =
+    selectedOwner?.displayName ||
+    selectedOwner?.slackUserId ||
+    (newOwnerId === session?.slackUserId
+      ? session.name || session.slackUserId
+      : null);
+
+  useEffect(() => {
+    if (showCreate && session?.slackUserId && !newOwnerId) {
+      setNewOwnerId(session.slackUserId);
+    }
+  }, [showCreate, session?.slackUserId, newOwnerId]);
 
   const createMutation = useMutation({
     mutationFn: (payload: {
@@ -256,10 +270,7 @@ function CredentialsPage() {
                     aria-expanded={ownerPickerOpen}
                     className="w-full justify-between font-normal"
                   >
-                    {selectedOwner
-                      ? selectedOwner.displayName ||
-                        selectedOwner.slackUserId
-                      : "Select owner…"}
+                    {ownerLabel || "Select owner…"}
                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                   </Button>
                 </PopoverTrigger>

--- a/apps/dashboard/src/routes/credentials/index.tsx
+++ b/apps/dashboard/src/routes/credentials/index.tsx
@@ -35,7 +35,7 @@ import { TableRowsSkeleton } from "@/components/page-skeleton";
 import { Pagination } from "@/components/pagination";
 import { cn, formatDate } from "@/lib/utils";
 import { useAuth } from "@/lib/auth";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Plus, Search, Check, ChevronsUpDown } from "lucide-react";
 
 const SCOPE_LABELS: Record<
@@ -118,11 +118,24 @@ function CredentialsPage() {
       ? session.name || session.slackUserId
       : null);
 
-  useEffect(() => {
-    if (showCreate && session?.slackUserId && !newOwnerId) {
-      setNewOwnerId(session.slackUserId);
-    }
-  }, [showCreate, session?.slackUserId, newOwnerId]);
+  const resetCreateForm = useCallback(() => {
+    setNewName("");
+    setNewType("token");
+    setNewValue("");
+    setNewOwnerId(session?.slackUserId ?? "");
+    setNewScope("member");
+    setOwnerPickerOpen(false);
+  }, [session?.slackUserId]);
+
+  const openCreateDialog = () => {
+    resetCreateForm();
+    setShowCreate(true);
+  };
+
+  const handleCreateOpenChange = (open: boolean) => {
+    setShowCreate(open);
+    if (!open) resetCreateForm();
+  };
 
   const createMutation = useMutation({
     mutationFn: (payload: {
@@ -135,11 +148,7 @@ function CredentialsPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["credentials"] });
       setShowCreate(false);
-      setNewName("");
-      setNewType("token");
-      setNewValue("");
-      setNewOwnerId("");
-      setNewScope("member");
+      resetCreateForm();
     },
   });
 
@@ -175,7 +184,7 @@ function CredentialsPage() {
             className="pl-9"
           />
         </div>
-        <Button size="sm" onClick={() => setShowCreate(true)}>
+        <Button size="sm" onClick={openCreateDialog}>
           <Plus className="h-4 w-4" /> Add Credential
         </Button>
       </div>
@@ -240,7 +249,7 @@ function CredentialsPage() {
 
       <Pagination total={total} pageSize={PAGE_SIZE} page={page} onPageChange={setPage} />
 
-      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+      <Dialog open={showCreate} onOpenChange={handleCreateOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Add Credential</DialogTitle>
@@ -354,7 +363,7 @@ function CredentialsPage() {
             <div className="flex justify-end gap-2 pt-1">
               <Button
                 variant="outline"
-                onClick={() => setShowCreate(false)}
+                onClick={() => handleCreateOpenChange(false)}
               >
                 Cancel
               </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- prefill the credential owner field in the create-credential dialog with the logged-in user's Slack ID
- show the current session user's name immediately while the workspace user list is still loading
- reset the create-credential form on open and close so reopening the dialog always starts clean with the current user selected

## Comparison notes
- I compared this against related credential branches and the current Vite dashboard route; none of the accessible remote branches already implemented this exact owner-defaulting behavior in `apps/dashboard/src/routes/credentials/index.tsx`
- the refinement worth keeping was making the dialog lifecycle deterministic instead of relying on a one-time effect, which avoids stale owner state after cancel/reopen

## Testing
- `pnpm typecheck`
- pre-push hook typechecks for `apps/api` and `apps/dashboard` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84585a35-a255-4778-b9fd-d1d1c2291167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84585a35-a255-4778-b9fd-d1d1c2291167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

