### PR TITLE
fix(observability): normalize Langfuse telemetry hygiene

### DIFF
--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -19,6 +19,7 @@ import {
 import { detectScriptOutputError } from "./script-output.js";
 import { buildStepUsages } from "../lib/cost-calculator.js";
 import { getScratchpadContents, cleanupScratchpad } from "../tools/scratchpad.js";
+import { withTrace } from "../lib/langfuse.js";
 import type { DetailedTokenUsage } from "@aura/db/schema";
 import {
   extractLastNSteps,
@@ -390,7 +391,20 @@ export async function executeJob(
         callingUserId: job.requestedBy,
         jobId: job.id,
       },
-      () => agent.generate({ prompt }),
+      () =>
+        withTrace(
+          {
+            traceName: "headless-job",
+            sessionId: job.threadTs || job.channelId || job.id,
+            userId: job.requestedBy,
+            tags: [
+              "channel:scheduled-job",
+              ...(job.channelId ? [`slack-channel:${job.channelId}`] : []),
+            ],
+            metadata: { slackUserId: job.requestedBy, jobId: job.id },
+          },
+          () => agent.generate({ prompt }),
+        ),
     );
 
     const { text, steps, totalUsage: usage } = generateResult;

--- a/apps/api/src/cron/supervisor.ts
+++ b/apps/api/src/cron/supervisor.ts
@@ -6,7 +6,7 @@ import { db } from "../db/client.js";
 import { getFastModel } from "../lib/ai.js";
 import { getCredential } from "../lib/credentials.js";
 import { logger } from "../lib/logger.js";
-import { aiTelemetry } from "../lib/langfuse.js";
+import { aiTelemetry, withTrace } from "../lib/langfuse.js";
 import { jobExecutions, jobOutcomes, jobs } from "@aura/db/schema";
 import { sendJobFailureDm, truncateJobFailureText } from "./job-notifications.js";
 
@@ -137,13 +137,29 @@ async function runSupervisorLlm(context: SupervisorContext): Promise<SupervisorD
   const timer = setTimeout(() => abortController.abort(), SUPERVISOR_LLM_TIMEOUT_MS);
 
   try {
-    const { object } = await generateObject({
-      model,
-      schema: supervisorDecisionSchema,
-      experimental_telemetry: aiTelemetry("supervisor-decision"),
-      system:
-        "You are Aura's job execution supervisor. Make one conservative decision from the provided fixed enum. Return only the structured object. Do not call tools.",
-      prompt: truncateForPrompt(`Review this completed job outcome and decide the next action.
+    const { object } = await withTrace(
+      {
+        traceName: "supervisor-decision",
+        sessionId: context.job.threadTs || context.job.channelId || context.job.id,
+        userId: context.job.requestedBy,
+        tags: [
+          "channel:supervisor",
+          ...(context.job.channelId ? [`slack-channel:${context.job.channelId}`] : []),
+        ],
+        metadata: {
+          slackUserId: context.job.requestedBy,
+          jobId: context.job.id,
+          outcomeId: context.outcome.id,
+        },
+      },
+      () =>
+        generateObject({
+          model,
+          schema: supervisorDecisionSchema,
+          experimental_telemetry: aiTelemetry("supervisor-decision"),
+          system:
+            "You are Aura's job execution supervisor. Make one conservative decision from the provided fixed enum. Return only the structured object. Do not call tools.",
+          prompt: truncateForPrompt(`Review this completed job outcome and decide the next action.
 
 Decision meanings:
 - silent_success: outcome succeeded cleanly and should be resolved with no DM. This is the default for routine recurring runs when cron_schedule is set and notify_on_success is false.
@@ -189,9 +205,10 @@ ${jsonForPrompt({
     error: execution.error,
   })),
 })}`),
-      temperature: 0,
-      abortSignal: abortController.signal,
-    });
+          temperature: 0,
+          abortSignal: abortController.signal,
+        }),
+    );
 
     return object;
   } finally {

--- a/apps/api/src/lib/langfuse.test.ts
+++ b/apps/api/src/lib/langfuse.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { normalizeLangfuseModelSlug } from "./langfuse.js";
+
+describe("normalizeLangfuseModelSlug", () => {
+  it("strips provider prefixes and normalizes dotted model versions", () => {
+    expect(normalizeLangfuseModelSlug("anthropic/claude-opus-4.8")).toBe(
+      "claude-opus-4-8",
+    );
+    expect(
+      normalizeLangfuseModelSlug(["anthropic", "claude-haiku-4.5"].join("/")),
+    ).toBe("claude-haiku-4-5");
+    expect(normalizeLangfuseModelSlug("openai/gpt-5.1")).toBe("gpt-5-1");
+  });
+
+  it("leaves bare dashed slugs intact", () => {
+    expect(normalizeLangfuseModelSlug("claude-sonnet-4-6")).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+
+  it("returns undefined for empty values", () => {
+    expect(normalizeLangfuseModelSlug(undefined)).toBeUndefined();
+    expect(normalizeLangfuseModelSlug("   ")).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/langfuse.ts
+++ b/apps/api/src/lib/langfuse.ts
@@ -25,13 +25,85 @@
  * no-op, so local/dev environments without keys run unaffected.
  */
 
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import {
+  NodeTracerProvider,
+  type ReadableSpan,
+  type Span,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import { propagateAttributes } from "@langfuse/tracing";
+import type { Context } from "@opentelemetry/api";
 import { logger } from "./logger.js";
 
 let provider: NodeTracerProvider | null = null;
 let spanProcessor: LangfuseSpanProcessor | null = null;
+
+const GEN_AI_MODEL_ATTRIBUTES = [
+  "gen_ai.request.model",
+  "gen_ai.response.model",
+  // AI SDK also keeps its pre-GenAI attributes. Langfuse currently prices from
+  // GenAI attributes, but normalizing both prevents future drift.
+  "ai.model.id",
+  "ai.response.model",
+];
+
+/**
+ * Convert AI Gateway/provider-qualified model IDs into the bare slugs Langfuse's
+ * pricing table matches against.
+ *
+ * Examples:
+ * - anthropic/claude-opus-4.8 -> claude-opus-4-8
+ * - claude-sonnet-4-6 -> claude-sonnet-4-6
+ * - openai/gpt-5.1 -> gpt-5-1
+ */
+export function normalizeLangfuseModelSlug(
+  modelId: string | undefined,
+): string | undefined {
+  const trimmed = modelId?.trim();
+  if (!trimmed) return undefined;
+
+  const bareSlug = trimmed.split("/").pop() ?? trimmed;
+  return bareSlug.replace(/\./g, "-");
+}
+
+function normalizeGenAIModelAttributes(span: ReadableSpan): void {
+  for (const attributeName of GEN_AI_MODEL_ATTRIBUTES) {
+    const value = span.attributes[attributeName];
+    if (typeof value !== "string") continue;
+
+    const normalized = normalizeLangfuseModelSlug(value);
+    if (normalized) {
+      span.attributes[attributeName] = normalized;
+    }
+  }
+}
+
+/**
+ * Central pre-export hygiene for Langfuse spans. The delegate keeps Langfuse's
+ * smart GenAI span filter, masking, media handling, and serverless flush
+ * behavior unchanged; we only canonicalize model slugs before it sees the span.
+ */
+class LangfuseHygieneSpanProcessor implements SpanProcessor {
+  constructor(private readonly delegate: LangfuseSpanProcessor) {}
+
+  onStart(span: Span, parentContext: Context): void {
+    this.delegate.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    normalizeGenAIModelAttributes(span);
+    this.delegate.onEnd(span);
+  }
+
+  forceFlush(): Promise<void> {
+    return this.delegate.forceFlush();
+  }
+
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+}
 
 /**
  * Redact obvious secrets before any input/output/metadata leaves the process.
@@ -116,7 +188,7 @@ export function initLangfuseTracing(): boolean {
   });
 
   provider = new NodeTracerProvider({
-    spanProcessors: [spanProcessor],
+    spanProcessors: [new LangfuseHygieneSpanProcessor(spanProcessor)],
   });
   provider.register();
 
@@ -175,8 +247,10 @@ export interface TraceAttributes {
   traceName?: string;
   /** Groups related turns into one conversation in the Sessions view. */
   sessionId?: string;
-  /** Enables per-user cost/quality analysis and filtering. */
+  /** Raw stable user id. Formatted centrally before propagation to Langfuse. */
   userId?: string;
+  /** Human-readable name rendered with the stable id in Langfuse's Users view. */
+  userName?: string | null;
   /** Filterable labels, e.g. ["channel:slack", "model:..."]. */
   tags?: string[];
   /** Arbitrary trace-level metadata. */
@@ -192,7 +266,14 @@ export interface TraceAttributes {
  */
 export function withTrace<T>(attrs: TraceAttributes, fn: () => T): T {
   if (!spanProcessor) return fn();
-  return propagateAttributes(attrs, fn);
+  const { userName, ...traceAttrs } = attrs;
+  return propagateAttributes(
+    {
+      ...traceAttrs,
+      userId: formatTraceUser(attrs.userId, userName),
+    },
+    fn,
+  );
 }
 
 /**

--- a/apps/api/src/pipeline/generate.ts
+++ b/apps/api/src/pipeline/generate.ts
@@ -12,7 +12,7 @@ import { createInteractivePrepareStep } from "./prepare-step.js";
 import { buildCachedSystemMessages, getEscalationModel } from "../lib/ai.js";
 import { getDeferredToolManifest } from "../tools/deferred.js";
 import { appendDeferredToolsBlock } from "../personality/system-prompt.js";
-import { aiTelemetry, withTrace, formatTraceUser } from "../lib/langfuse.js";
+import { aiTelemetry, withTrace } from "../lib/langfuse.js";
 
 /**
  * Channel-agnostic agentic stream.
@@ -93,7 +93,8 @@ export function createAgenticStream(options: AgenticStreamOptions) {
     {
       traceName: `${options.channelId ?? "agent"}-chat`,
       sessionId: options.threadTs ?? options.channelId ?? undefined,
-      userId: formatTraceUser(options.userId, options.userName),
+      userId: options.userId,
+      userName: options.userName,
       tags: [
         `channel:${options.channelId ?? "unknown"}`,
         `model:${options.modelId}`,

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -33,7 +33,7 @@ import {
 import { downloadEventFiles } from "../lib/files.js";
 import { getSettingJSON } from "../lib/settings.js";
 import { logger } from "../lib/logger.js";
-import { withTrace, formatTraceUser } from "../lib/langfuse.js";
+import { withTrace } from "../lib/langfuse.js";
 import { logError } from "../lib/error-logger.js";
 import { recordPipelineMetrics, recordError } from "../lib/metrics.js";
 import { trySetAssistantThreadStatus } from "../lib/slack-status.js";
@@ -445,7 +445,8 @@ export async function runPipeline(options: PipelineOptions): Promise<void> {
       {
         traceName: "slack-chat",
         sessionId: replyThreadTs ?? context.channelId,
-        userId: formatTraceUser(context.userId, displayName),
+        userId: context.userId,
+        userName: displayName,
         tags: [`channel:${context.channelType ?? "unknown"}`],
         metadata: { slackUserId: context.userId },
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Normalize AI SDK GenAI model span attributes centrally in `langfuse.ts` so AI Gateway-prefixed/dotted model IDs export as Langfuse-priced bare slugs.
- Centralize trace `userId` formatting in `withTrace` and pass raw user IDs/names from Slack and dashboard traces.
- Add trace user attribution for user-originated scheduled job and supervisor LLM traces.
- Add focused coverage for Langfuse model slug normalization.

Fixes #1102

## Verification
- `pnpm --filter aura-api test -- langfuse.test.ts` (Vitest ran the API test suite: 41 files / 291 tests passed)
- `cd apps/api && npx tsc --noEmit`
- `pnpm typecheck`
- `pnpm --filter aura-api lint` (fails: `eslint` executable is not installed in `apps/api`, matching the repo note in AGENTS.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de488198-003d-4b2f-a0dd-42d546b76e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de488198-003d-4b2f-a0dd-42d546b76e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

