### PR TITLE
docs: deployment + dashboard docs for Vercel WDK adoption (#1116)

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -144,6 +144,8 @@ A copy-to-clipboard button in the chat header exports the current conversation (
 
 Each chat message carries its own `modelId` / `resolvedModelId` metadata, so the exported JSON records which model actually produced each turn even when the selection changes mid-conversation.
 
+Chat generation is durable: each send starts a server-side workflow run (tracked in the `dashboard_chat_runs` table), and the browser is just a stream reader. Refreshing, switching threads, or reconnecting from another session reattaches to the live stream instead of killing the run -- only the Stop button (a server-side cancel endpoint) actually stops generation. Threads are scoped to the signed-in user's session.
+
 ## Navigation
 
 Account controls (settings, account menu) live in the sidebar footer, following the Cursor navigation pattern. The header stays focused on page actions. Theme selection (light/dark/system) is inside Settings rather than the header.

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -84,6 +84,7 @@ Models are normally resolved from database settings first, then the DB-backed mo
 |----------|-------------|
 | `LOG_LEVEL` | Logging verbosity |
 | `SHOW_REASONING_IN_SLACK` | Set to `"true"` to post extended thinking traces as thread replies |
+| `AURA_WDK_SLACK_RESPOND` | Set to `1`/`true` to route Slack responses through the durable Workflow DevKit pipeline (off by default; also settable via the `wdk_slack_respond` workspace setting) |
 
 ## Adding Variables via CLI
 

--- a/content/docs/deployment/vercel.mdx
+++ b/content/docs/deployment/vercel.mdx
@@ -27,26 +27,29 @@ Each `apps/*` project deploys as a separate Vercel project.
 
 ## Architecture
 
-- **Runtime:** Node.js serverless functions
+- **Runtime:** Node.js serverless functions, emitted via the Build Output API by a Nitro build
 - **Framework:** Hono for HTTP routing
-- **Entry point:** `apps/api/src/app.ts` exports the Hono app; `apps/api/api/index.ts` is the Vercel handler
-- **Build:** `tsc` compiles TypeScript, then `pnpm --filter @aura/db db:migrate` runs pending Drizzle migrations
+- **Entry point:** `apps/api/src/app.ts` exports the Hono app; `apps/api/src/nitro-app.ts` is the Nitro server entry that routes all HTTP traffic to it (`apps/api/nitro.config.ts`)
+- **Workflows:** the `workflow/nitro` module compiles `"use workflow"` / `"use step"` directives in `apps/api/workflows/` (durable Slack respond, dashboard chat) into dedicated queue-triggered functions and registers the `/.well-known/workflow/v1/*` handler routes
+- **Build:** the `buildCommand` in `apps/api/vercel.json` runs migrations, builds the dashboard into `public/`, then `nitro build --preset vercel` followed by `scripts/patch-vercel-output.mjs` (restores the SPA fallback rewrite in `.vercel/output/config.json`)
+
+There are no filesystem function entrypoints anymore -- the legacy `apps/api/api/index.ts` and `apps/api/api/cron/*` handlers were removed when the Nitro build landed (PR #1116). Cron schedules live **only** in `apps/api/vercel.json`; defining the same cron in the Build Output config too makes Vercel reject the deployment ("duplicated cron job").
 
 ## Deployment Flow
 
 ```
-Push to main → Vercel Build → tsc → Run Migrations → Deploy
+Push to main → Vercel Build → Run Migrations → Dashboard Build → nitro build (Build Output API) → Deploy
 ```
 
-The `vercel-build` script in `apps/api/package.json`:
+The `buildCommand` in `apps/api/vercel.json`:
 
 ```json
 {
-  "scripts": {
-    "vercel-build": "pnpm --filter @aura/db db:migrate"
-  }
+  "buildCommand": "pnpm --filter @aura/db build && pnpm --filter @aura/db db:migrate && pnpm --filter aura-dashboard build && rm -rf public && cp -r ../dashboard/dist public && pnpm build:vercel"
 }
 ```
+
+Local development: `pnpm dev` in `apps/api` runs `nitro dev` (workflows run in the Local World); the legacy tsx watcher is still available as `pnpm dev:node`.
 
 ## Important Rules
 


### PR DESCRIPTION
Daily docs-maintenance run (Jun 11).

PR #1116 removed the filesystem function entrypoints (`apps/api/api/index.ts`, `apps/api/api/cron/*`) that `deployment/vercel.mdx` documented as the live architecture -- that page was factually wrong (P0).

**Changes:**
- `deployment/vercel.mdx`: Architecture + Deployment Flow rewritten for the Nitro/Build Output API setup -- `src/nitro-app.ts` entry, `workflow/nitro` module compiling `workflows/` into queue-triggered functions, the real `buildCommand` from `apps/api/vercel.json`, the crons-only-in-vercel.json rule (duplicate cron = rejected deploy), and `nitro dev` vs `dev:node` for local dev.
- `deployment/environment-variables.mdx`: added `AURA_WDK_SLACK_RESPOND` (durable Slack respond feature flag, off by default, also a workspace setting).
- `dashboard.mdx`: Chat section now covers durable workflow runs (`dashboard_chat_runs`), resumable streams, server-side-only cancel, and per-user thread scoping.

Source: commit `4a934c8` (#1116).