### PR TITLE
fix(tools): list_jobs surfaces enabled recurring jobs + status:'all' (#1118)

### DIFF
--- a/apps/api/src/tools/jobs.test.ts
+++ b/apps/api/src/tools/jobs.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type Predicate = ((row: Record<string, unknown>) => boolean) & {
+  kind?: string;
+};
+
+const dbMock = vi.hoisted(() => {
+  const state = {
+    rows: [] as Array<Record<string, unknown>>,
+    whereCalls: [] as unknown[],
+    select: vi.fn(),
+  };
+
+  function createQuery() {
+    let predicate: Predicate | undefined;
+
+    const query: any = {
+      from: vi.fn(() => query),
+      where: vi.fn((condition: Predicate) => {
+        predicate = condition;
+        state.whereCalls.push(condition);
+        return query;
+      }),
+      orderBy: vi.fn(() => query),
+      limit: vi.fn((limit: number) => {
+        const filtered = predicate
+          ? state.rows.filter((row) => predicate?.(row))
+          : state.rows;
+
+        return Promise.resolve(filtered.slice(0, limit));
+      }),
+    };
+
+    return query;
+  }
+
+  state.select.mockImplementation(() => createQuery());
+
+  return state;
+});
+
+const schemaMock = vi.hoisted(() => {
+  const column = (key: string) => ({ key });
+
+  return {
+    jobs: {
+      id: column("id"),
+      name: column("name"),
+      description: column("description"),
+      cronSchedule: column("cronSchedule"),
+      frequencyConfig: column("frequencyConfig"),
+      channelId: column("channelId"),
+      executeAt: column("executeAt"),
+      requestedBy: column("requestedBy"),
+      priority: column("priority"),
+      status: column("status"),
+      timezone: column("timezone"),
+      retries: column("retries"),
+      lastExecutedAt: column("lastExecutedAt"),
+      executionCount: column("executionCount"),
+      playbook: column("playbook"),
+      lastResult: column("lastResult"),
+      enabled: column("enabled"),
+      createdAt: column("createdAt"),
+    },
+    jobExecutions: {
+      jobId: column("jobId"),
+      startedAt: column("startedAt"),
+    },
+  };
+});
+
+const drizzleMock = vi.hoisted(() => {
+  const keyOf = (column: { key: string }) => column.key;
+  const predicate = (
+    kind: string,
+    fn: (row: Record<string, unknown>) => boolean,
+  ): Predicate => Object.assign(fn, { kind });
+
+  return {
+    eq: vi.fn((column: { key: string }, value: unknown) =>
+      predicate("eq", (row) => row[keyOf(column)] === value),
+    ),
+    ne: vi.fn((column: { key: string }, value: unknown) =>
+      predicate("ne", (row) => row[keyOf(column)] !== value),
+    ),
+    isNotNull: vi.fn((column: { key: string }) =>
+      predicate("isNotNull", (row) => row[keyOf(column)] != null),
+    ),
+    and: vi.fn((...conditions: Array<Predicate | undefined>) => {
+      const activeConditions = conditions.filter(Boolean) as Predicate[];
+      return predicate("and", (row) =>
+        activeConditions.every((condition) => condition(row)),
+      );
+    }),
+    or: vi.fn((...conditions: Array<Predicate | undefined>) => {
+      const activeConditions = conditions.filter(Boolean) as Predicate[];
+      return predicate("or", (row) =>
+        activeConditions.some((condition) => condition(row)),
+      );
+    }),
+    desc: vi.fn((column: { key: string }) => ({ column })),
+    sql: vi.fn(),
+  };
+});
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    select: dbMock.select,
+  },
+}));
+
+vi.mock("@aura/db/schema", () => schemaMock);
+
+vi.mock("drizzle-orm", () => drizzleMock);
+
+vi.mock("../lib/tool.js", () => ({
+  defineTool: (config: unknown) => config,
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/permissions.js", () => ({
+  hasRole: vi.fn(),
+}));
+
+vi.mock("./slack.js", () => ({
+  resolveChannelByName: vi.fn(),
+}));
+
+vi.mock("../cron/execute-job.js", () => ({
+  executeJob: vi.fn(),
+}));
+
+vi.mock("@vercel/functions", () => ({
+  waitUntil: vi.fn(),
+}));
+
+function baseJob(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "job-1",
+    name: "one-shot",
+    description: "do the thing",
+    cronSchedule: null,
+    frequencyConfig: null,
+    channelId: null,
+    executeAt: new Date("2026-05-20T09:00:00.000Z"),
+    requestedBy: "U_REQUESTER",
+    priority: "normal",
+    status: "pending",
+    timezone: "UTC",
+    retries: 0,
+    lastExecutedAt: null,
+    executionCount: 0,
+    playbook: null,
+    lastResult: null,
+    enabled: 1,
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+async function listJobs(input: Record<string, unknown> = {}) {
+  const { createJobTools } = await import("./jobs.js");
+  const tool = createJobTools(undefined, { timezone: "UTC" } as any)
+    .list_jobs as any;
+
+  return tool.execute(tool.inputSchema.parse(input));
+}
+
+describe("list_jobs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T08:00:00.000Z"));
+    dbMock.rows = [];
+    dbMock.whereCalls = [];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("includes enabled recurring jobs with completed status by default", async () => {
+    dbMock.rows = [
+      baseJob({
+        id: "job-recurring",
+        name: "sync-meta-comments-daily",
+        status: "completed",
+        cronSchedule: "0 9 * * *",
+        lastExecutedAt: new Date("2026-05-19T09:00:00.000Z"),
+        executionCount: 42,
+        lastResult: "ok",
+      }),
+    ];
+
+    const result = await listJobs();
+
+    expect(result.ok).toBe(true);
+    expect(result.jobs).toHaveLength(1);
+    expect(result.jobs[0]).toMatchObject({
+      name: "sync-meta-comments-daily",
+      status: "completed",
+      enabled: true,
+      is_recurring: true,
+      last_executed_at: "2026-05-19T09:00:00Z",
+      next_run_at: "2026-05-20T09:00:00Z",
+      execution_count: 42,
+      last_result: "ok",
+    });
+  });
+
+  it("hides disabled recurring jobs by default unless using their status or all", async () => {
+    const disabledRecurring = baseJob({
+      id: "job-disabled",
+      name: "disabled-digest",
+      status: "completed",
+      enabled: 0,
+      cronSchedule: "0 9 * * *",
+    });
+    dbMock.rows = [disabledRecurring];
+
+    await expect(listJobs()).resolves.toMatchObject({
+      ok: true,
+      jobs: [],
+      count: 0,
+    });
+
+    await expect(listJobs({ status: "completed" })).resolves.toMatchObject({
+      ok: true,
+      jobs: [expect.objectContaining({ name: "disabled-digest" })],
+      count: 1,
+    });
+
+    await expect(listJobs({ status: "all" })).resolves.toMatchObject({
+      ok: true,
+      jobs: [expect.objectContaining({ name: "disabled-digest" })],
+      count: 1,
+    });
+  });
+
+  it("computes next_run_at for valid cron schedules and null for invalid ones", async () => {
+    dbMock.rows = [
+      baseJob({
+        id: "job-valid",
+        name: "valid-recurring",
+        status: "completed",
+        cronSchedule: "0 9 * * *",
+      }),
+      baseJob({
+        id: "job-invalid",
+        name: "invalid-recurring",
+        status: "completed",
+        cronSchedule: "not a cron",
+      }),
+    ];
+
+    const result = await listJobs({ status: "all" });
+
+    expect(result.ok).toBe(true);
+    expect(result.jobs).toEqual([
+      expect.objectContaining({
+        name: "valid-recurring",
+        next_run_at: "2026-05-20T09:00:00Z",
+      }),
+      expect.objectContaining({
+        name: "invalid-recurring",
+        next_run_at: null,
+      }),
+    ]);
+  });
+
+  it("returns every job up to the limit when status is all", async () => {
+    dbMock.rows = [
+      baseJob({ id: "job-1", name: "pending-job", status: "pending" }),
+      baseJob({ id: "job-2", name: "failed-job", status: "failed" }),
+      baseJob({ id: "job-3", name: "cancelled-job", status: "cancelled" }),
+    ];
+
+    const result = await listJobs({ status: "all", limit: 2 });
+
+    expect(result.ok).toBe(true);
+    expect(result.jobs.map((job: { name: string }) => job.name)).toEqual([
+      "pending-job",
+      "failed-job",
+    ]);
+    expect(result.count).toBe(2);
+    expect(dbMock.whereCalls).toHaveLength(0);
+  });
+});

--- a/apps/api/src/tools/jobs.test.ts
+++ b/apps/api/src/tools/jobs.test.ts
@@ -210,8 +210,8 @@ describe("list_jobs", () => {
       status: "completed",
       enabled: true,
       is_recurring: true,
-      last_executed_at: "2026-05-19T09:00:00Z",
-      next_run_at: "2026-05-20T09:00:00Z",
+      last_executed_at: "2026-05-19T09:00:00+00:00",
+      next_run_at: "2026-05-20T09:00:00+00:00",
       execution_count: 42,
       last_result: "ok",
     });
@@ -268,7 +268,7 @@ describe("list_jobs", () => {
     expect(result.jobs).toEqual([
       expect.objectContaining({
         name: "valid-recurring",
-        next_run_at: "2026-05-20T09:00:00Z",
+        next_run_at: "2026-05-20T09:00:00+00:00",
       }),
       expect.objectContaining({
         name: "invalid-recurring",

--- a/apps/api/src/tools/jobs.ts
+++ b/apps/api/src/tools/jobs.ts
@@ -279,12 +279,12 @@ export function createJobTools(
 
     list_jobs: defineTool({
       description:
-        "List jobs by status. See what's pending, completed, or failed. Shows both one-shot tasks and recurring jobs.",
+        "List jobs. Always includes enabled recurring jobs regardless of their last execution status, with last/next run info. Filter one-shots by status, or use status:'all'. For execution history of a specific job, use read_job_trace with the job name.",
       inputSchema: z.object({
         status: z
-          .enum(["pending", "running", "completed", "failed", "cancelled"])
+          .enum(["pending", "running", "completed", "failed", "cancelled", "all"])
           .default("pending")
-          .describe("Filter by status"),
+          .describe("Filter by status, or use 'all' to include every job"),
         recurring_only: z
           .boolean()
           .default(false)
@@ -298,42 +298,67 @@ export function createJobTools(
       }),
       execute: async ({ status, recurring_only, limit }) => {
         try {
-          const conditions = [eq(jobs.status, status)];
+          const recurringCondition = and(
+            isNotNull(jobs.cronSchedule),
+            ne(jobs.cronSchedule, ""),
+          )!;
+          const enabledRecurringCondition = and(
+            eq(jobs.enabled, 1),
+            recurringCondition,
+          )!;
+          const conditions: Array<ReturnType<typeof eq>> = [];
+          if (status !== "all") {
+            conditions.push(or(eq(jobs.status, status), enabledRecurringCondition)!);
+          }
           if (recurring_only) {
-            conditions.push(
-              and(isNotNull(jobs.cronSchedule), ne(jobs.cronSchedule, ""))!,
-            );
+            conditions.push(recurringCondition);
           }
 
-          const rows = await db
-            .select()
-            .from(jobs)
-            .where(and(...conditions))
+          const query = db.select().from(jobs);
+          const rows = await (conditions.length > 0
+            ? query.where(and(...conditions))
+            : query
+          )
             .orderBy(desc(jobs.createdAt))
             .limit(limit);
 
           const filtered = rows;
 
           const tz = context?.timezone;
-          const result = filtered.map((j) => ({
-            id: j.id,
-            name: j.name,
-            description: j.description.substring(0, 120),
-            enabled: j.enabled === 1,
-            is_recurring: !!j.cronSchedule,
-            cron_schedule: j.cronSchedule,
-            frequency_config: j.frequencyConfig,
-            execute_at: formatTimestamp(j.executeAt, tz) || null,
-            channel_id: j.channelId || null,
-            requested_by: j.requestedBy,
-            priority: j.priority,
-            status: j.status,
-            retries: j.retries,
-            last_executed_at: formatTimestamp(j.lastExecutedAt, tz) || null,
-            execution_count: j.executionCount,
-            has_playbook: !!j.playbook,
-            last_result: j.lastResult ? j.lastResult.substring(0, 200) : null,
-          }));
+          const result = filtered.map((j) => {
+            let nextRunAt: string | null = null;
+            if (j.cronSchedule) {
+              try {
+                const next = CronExpressionParser.parse(j.cronSchedule, {
+                  tz: j.timezone ?? "UTC",
+                }).next().toDate();
+                nextRunAt = formatTimestamp(next, tz) || null;
+              } catch {
+                nextRunAt = null;
+              }
+            }
+
+            return {
+              id: j.id,
+              name: j.name,
+              description: j.description.substring(0, 120),
+              enabled: j.enabled === 1,
+              is_recurring: !!j.cronSchedule,
+              cron_schedule: j.cronSchedule,
+              frequency_config: j.frequencyConfig,
+              execute_at: formatTimestamp(j.executeAt, tz) || null,
+              next_run_at: nextRunAt,
+              channel_id: j.channelId || null,
+              requested_by: j.requestedBy,
+              priority: j.priority,
+              status: j.status,
+              retries: j.retries,
+              last_executed_at: formatTimestamp(j.lastExecutedAt, tz) || null,
+              execution_count: j.executionCount,
+              has_playbook: !!j.playbook,
+              last_result: j.lastResult ? j.lastResult.substring(0, 200) : null,
+            };
+          });
 
           logger.info("list_jobs tool called", { status, count: result.length });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Include enabled recurring jobs in `list_jobs` even when their last execution status is completed or failed.
- Add `status: "all"` to list all jobs without a status predicate.
- Surface `next_run_at` for recurring jobs, with invalid cron schedules reported as `null`.
- Add unit coverage for default recurring visibility, disabled recurring behavior, `next_run_at`, and `status: "all"`.

Fixes #1118

## Testing
- `pnpm --filter aura-api exec vitest run src/tools/jobs.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
- `pnpm --filter aura-api test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d86864b5-b866-4f36-98c3-a8a7cf26cf24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d86864b5-b866-4f36-98c3-a8a7cf26cf24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

