### PR TITLE
Fix Slack stream death from ~3-min total stream lifetime cap

### DIFF
--- a/apps/api/src/pipeline/respond.test.ts
+++ b/apps/api/src/pipeline/respond.test.ts
@@ -236,6 +236,81 @@ describe("generateResponse Slack stream handling", () => {
     });
   });
 
+  it("splits to a fresh stream when total stream age exceeds 60s across sequential short tools", async () => {
+    vi.useFakeTimers();
+    const gate = deferred<void>();
+    const firstStream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondStream = {
+      append: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([firstStream, secondStream]);
+
+    mockAgentStream((async function* () {
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "echo one" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
+      };
+      // Wall-clock time passes between short tools — no single tool ever
+      // stays pending past LONG_TOOL_SPLIT_MS, but the stream still ages.
+      await gate.promise;
+      yield {
+        type: "tool-call",
+        toolCallId: "call-2",
+        toolName: "run_command",
+        input: { command: "echo two" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-2",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "", stderr: "" },
+      };
+      yield { type: "text-delta", text: "Done." };
+    })());
+
+    const responsePromise = generateResponse(baseOptions(slackClient));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(slackClient.chatStream).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(70_000);
+    expect(slackClient.chatStream).toHaveBeenCalledTimes(1);
+
+    gate.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(responsePromise).resolves.toMatchObject({
+      raw: "Done.",
+      alreadyPosted: true,
+    });
+
+    expect(slackClient.chatStream).toHaveBeenCalledTimes(2);
+    expect(firstStream.stop).toHaveBeenCalled();
+    expect(secondStream.append).toHaveBeenCalledWith({
+      chunks: [expect.objectContaining({
+        type: "markdown_text",
+        text: "Done.",
+      })],
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      "Slack stream exceeded max age; splitting to a fresh stream",
+      expect.objectContaining({
+        channelId: "C123",
+        thresholdMs: 60_000,
+      }),
+    );
+  });
+
   it("emits an optimistic tool card on tool-input-start and updates it on tool-call", async () => {
     const stream = {
       append: vi.fn().mockResolvedValue(undefined),
@@ -386,7 +461,7 @@ describe("generateResponse Slack stream handling", () => {
     }));
   });
 
-  it("does not log message_not_in_streaming_state when postMessage fallback succeeds", async () => {
+  it("logs message_not_in_streaming_state as recovered when postMessage fallback succeeds", async () => {
     const stream = {
       append: vi.fn().mockRejectedValueOnce(Object.assign(new Error("message_not_in_streaming_state"), {
         data: { error: "message_not_in_streaming_state" },
@@ -401,7 +476,18 @@ describe("generateResponse Slack stream handling", () => {
 
     await generateResponse(baseOptions(slackClient));
 
-    expect(logError).not.toHaveBeenCalled();
+    const mnisLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "message_not_in_streaming_state",
+    );
+    expect(mnisLogs).toHaveLength(1);
+    expect(mnisLogs[0]?.[0]).toMatchObject({
+      errorName: "MessageNotInStreamingState",
+      channelId: "C123",
+      context: expect.objectContaining({
+        fallback: "postMessage",
+        fallbackRecovered: true,
+      }),
+    });
     expect(logger.warn).toHaveBeenCalledWith(
       "chatStream append left streaming state, falling back to postMessage",
       expect.objectContaining({
@@ -422,6 +508,61 @@ describe("generateResponse Slack stream handling", () => {
       thread_ts: "1710000000.000000",
       text: expect.stringContaining("Recovered fallback text."),
     }));
+  });
+
+  it("posts an interruption stub when the stream dies with an empty unsent buffer", async () => {
+    const stream = {
+      append: vi.fn()
+        .mockResolvedValueOnce(undefined) // intro text streams fine
+        .mockRejectedValueOnce(Object.assign(new Error("message_not_in_streaming_state"), {
+          data: { error: "message_not_in_streaming_state" },
+        })),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const slackClient = createSlackClient([stream]);
+
+    mockAgentStream((async function* () {
+      yield { type: "text-delta", text: "Intro." };
+      yield {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        input: { command: "true" },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "run_command",
+        output: { ok: true, exit_code: 0, stdout: "ok", stderr: "" },
+      };
+    })());
+
+    await generateResponse(baseOptions(slackClient));
+
+    // Everything visible already streamed before the freeze and the post-tool
+    // tail is empty — the fallback must post a stub, not an empty block list.
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: "C123",
+      thread_ts: "1710000000.000000",
+      text: "_Turn interrupted after 1 tool call — rerun?_",
+      blocks: expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          text: expect.objectContaining({
+            text: "_Turn interrupted after 1 tool call — rerun?_",
+          }),
+        }),
+      ]),
+    }));
+
+    const mnisLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "message_not_in_streaming_state",
+    );
+    expect(mnisLogs).toHaveLength(1);
+    expect(mnisLogs[0]?.[0]).toMatchObject({
+      errorName: "MessageNotInStreamingState",
+      context: expect.objectContaining({ fallbackRecovered: true, toolCallCount: 0 }),
+    });
   });
 
   it("does not record an error event when channel_type_not_supported fallback succeeds", async () => {
@@ -696,7 +837,7 @@ describe("generateResponse Slack stream handling", () => {
     }));
   });
 
-  it("does not error-log or relaunch superseded empty completions", async () => {
+  it("logs a supersede observability row but never relaunches or logs empty completions when superseded", async () => {
     const stream = {
       append: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
@@ -754,6 +895,22 @@ describe("generateResponse Slack stream handling", () => {
         channelId: "C123",
       }),
     );
+
+    // Issue #1121: supersede recovery is preserved, but the event itself is
+    // now always visible in error_events with the abort reason.
+    const supersededLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "superseded_while_streaming",
+    );
+    expect(supersededLogs).toHaveLength(1);
+    expect(supersededLogs[0]?.[0]).toMatchObject({
+      errorName: "InvocationSupersededDuringStream",
+      channelId: "C123",
+      context: expect.objectContaining({
+        invocationId: "test-invocation",
+        abortReason: "unknown",
+        toolCallCount: 1,
+      }),
+    });
   });
 
   it("logs empty completions for tool-error-only continuation segments", async () => {
@@ -872,6 +1029,19 @@ describe("generateResponse Slack stream handling", () => {
     await vi.advanceTimersByTimeAsync(180_000);
 
     await responseExpectation;
+
+    const inactivityLogs = vi.mocked(logError).mock.calls.filter(
+      ([entry]) => entry.errorCode === "stream_inactivity_abort",
+    );
+    expect(inactivityLogs).toHaveLength(1);
+    expect(inactivityLogs[0]?.[0]).toMatchObject({
+      errorName: "StreamInactivityAbort",
+      channelId: "C123",
+      context: expect.objectContaining({
+        accumulatedTextLength: 0,
+        toolCallCount: 0,
+      }),
+    });
 
     const abortLogs = vi.mocked(logError).mock.calls.filter(
       ([entry]) => entry.errorCode === "stream_aborted_by_watchdog",

--- a/apps/api/src/pipeline/respond.ts
+++ b/apps/api/src/pipeline/respond.ts
@@ -208,6 +208,16 @@ const STREAM_THRESHOLD_WHITESPACE = 9_000;
 const STREAM_HARD_LIMIT = 9_500;
 const MAX_CONTINUATIONS = 5;
 const LONG_TOOL_SPLIT_MS = 75_000;
+// Slack's chat.stream transport enforces a hard cap (~3 minutes) on the TOTAL
+// lifetime of a single stream, independent of activity. Keepalive appends only
+// beat the ~30s idle timeout — they do NOT extend the lifetime cap — and
+// LONG_TOOL_SPLIT_MS only covers a single tool staying pending past 75s. Turns
+// made of many sequential short tool calls (20-40s each) accumulate past the
+// cap, the stream dies at the transport layer, and composed text never flushes
+// (issue #1121). We proactively split to a fresh stream once the current one
+// exceeds this wall-clock age, checked at safe boundaries (text-delta and
+// tool-result/tool-error handling) — never mid-append.
+const STREAM_MAX_AGE_MS = 60_000;
 const STREAM_CONTINUATION_TOMBSTONE = "_(continuing in a new message...)_";
 const TOOL_CONTINUATION_OUTPUT = "continuing in a new message...";
 const EMPTY_COMPLETION_RELAUNCH_PROMPT = "(continue - you ended without responding. Summarize what you found.)";
@@ -400,6 +410,10 @@ export async function generateResponse(
   if (options.recipientUserId) streamParams.recipient_user_id = options.recipientUserId;
 
   let streamer: any = null;
+  // Wall-clock start time of the CURRENT Slack stream. Reset whenever
+  // splitToNewStream() creates a fresh stream — NOT between tool results —
+  // so it tracks total stream age for the STREAM_MAX_AGE_MS check.
+  let streamStartedAt = Date.now();
 
   // ── Streaming fallback ──────────────────────────────────────────────
   // Some channel types (e.g. Slack List internal channels) don't support
@@ -430,6 +444,22 @@ export async function generateResponse(
       },
     });
     pendingChannelTypeUnsupportedFallback = null;
+  }
+
+  /**
+   * Write the stashed message_not_in_streaming_state error to error_events.
+   * Always logged regardless of fallback outcome (issue #1121); the
+   * `fallbackRecovered` tag lets dashboards separate recovered from
+   * unrecovered occurrences.
+   */
+  function flushPendingMessageNotInStreamingStateError(recovered: boolean): void {
+    if (!pendingMessageNotInStreamingStateError) return;
+    const pending = pendingMessageNotInStreamingStateError;
+    pendingMessageNotInStreamingStateError = null;
+    logError({
+      ...pending,
+      context: { ...(pending.context ?? {}), fallbackRecovered: recovered },
+    });
   }
 
   async function tryStreamAppend(
@@ -529,21 +559,22 @@ export async function generateResponse(
       } else {
         // Unknown streaming error — don't kill the response, fall back gracefully
         streamingFailed = true;
-        const errorLog = {
-          errorName: "UnexpectedStreamError",
-          errorMessage: err?.message || "unexpected error on stream append",
-          errorCode: err?.data?.error || "unknown",
-          channelId,
-          context: {
-            fallback: "postMessage",
-            ...(err?.data?.error === "message_not_in_streaming_state" && {
-              isFallbackRecovery: true,
-            }),
-          },
-        };
 
         if (err?.data?.error === "message_not_in_streaming_state") {
-          pendingMessageNotInStreamingStateError = errorLog;
+          // Stash for finalize: always written to error_events once the
+          // fallback outcome is known, tagged recovered/unrecovered
+          // (issue #1121 — previously swallowed when the fallback succeeded).
+          pendingMessageNotInStreamingStateError = {
+            errorName: "MessageNotInStreamingState",
+            errorMessage: err?.message || "message_not_in_streaming_state on stream append",
+            errorCode: "message_not_in_streaming_state",
+            channelId,
+            context: {
+              fallback: "postMessage",
+              streamAgeMs: Date.now() - streamStartedAt,
+              toolCallCount: toolCallRecords.length,
+            },
+          };
           logger.warn("chatStream append left streaming state, falling back to postMessage", {
             channelId,
             slackError: err?.data?.error,
@@ -555,7 +586,13 @@ export async function generateResponse(
             slackError: err?.data?.error,
             message: err?.message,
           });
-          logError(errorLog);
+          logError({
+            errorName: "UnexpectedStreamError",
+            errorMessage: err?.message || "unexpected error on stream append",
+            errorCode: err?.data?.error || "unknown",
+            channelId,
+            context: { fallback: "postMessage" },
+          });
         }
       }
       if (streamingFailed) {
@@ -567,7 +604,7 @@ export async function generateResponse(
 
   // ── Inactivity timeout ───────────────────────────────────────────────
   type StreamAbortReason = "inactivity" | "long_tool" | "superseded" | "unknown";
-  type ContinuationReason = "length" | "long_tool";
+  type ContinuationReason = "length" | "long_tool" | "stream_age";
 
   const abortController = new AbortController();
   let inactivityTimer: ReturnType<typeof setTimeout> = undefined as any;
@@ -578,6 +615,21 @@ export async function generateResponse(
     inactivityTimer = setTimeout(() => {
       logger.warn("LLM inactivity timeout (180s), aborting");
       lastAbortReason = "inactivity";
+      // Log at the point of abort: the abort doesn't always surface as a
+      // thrown AbortError (the SDK may end the stream gracefully), so the
+      // catch-side StreamAborted log alone can miss these (issue #1121).
+      logError({
+        errorName: "StreamInactivityAbort",
+        errorMessage: "LLM stream aborted after 180s of inactivity",
+        errorCode: "stream_inactivity_abort",
+        channelId,
+        context: {
+          accumulatedTextLength: accumulatedText.length,
+          toolCallCount: toolCallRecords.length,
+          segmentIndex: currentSegmentIndex,
+          streamAgeMs: Date.now() - streamStartedAt,
+        },
+      });
       abortController.abort("inactivity");
     }, 180_000);
   };
@@ -611,6 +663,7 @@ export async function generateResponse(
 
   if (!skipStreaming) {
     streamer = slackClient.chatStream(streamParams as any);
+    streamStartedAt = Date.now();
   }
 
   let supersededDuringStream = false;
@@ -905,6 +958,8 @@ export async function generateResponse(
 
   async function appendTextDelta(text: string): Promise<void> {
     if (!text) return;
+    // Age-based split happens at the delta boundary, before any append.
+    await splitForStreamAge();
     accumulatedText += text;
     currentSegmentTextLength += text.length;
     let remaining = processChunkForTables(text);
@@ -988,7 +1043,9 @@ export async function generateResponse(
       segmentEnd: "split",
     });
 
-    if (reason === "long_tool") {
+    // Close out dangling in-progress tool cards on the old stream before
+    // abandoning it (age splits can happen while tools are still pending).
+    if (reason === "long_tool" || (reason === "stream_age" && pendingToolInputs.size > 0)) {
       await appendStreamTombstone();
     }
 
@@ -1002,6 +1059,7 @@ export async function generateResponse(
 
     try {
       streamer = slackClient.chatStream(streamParams as any);
+      streamStartedAt = Date.now();
       currentStreamLength = 0;
       streamTombstoneSent = false;
       continuationCount++;
@@ -1045,6 +1103,37 @@ export async function generateResponse(
       if (!streamingFailed && pendingToolInputs.size > 0) {
         startLongToolSplitTimer();
       }
+    }
+  }
+
+  function streamAgeExceeded(): boolean {
+    return (
+      !streamingFailed &&
+      streamer != null &&
+      continuationCount < MAX_CONTINUATIONS &&
+      Date.now() - streamStartedAt >= STREAM_MAX_AGE_MS
+    );
+  }
+
+  /**
+   * Split to a fresh Slack stream when the current one is approaching the
+   * ~3-minute total stream lifetime cap (see STREAM_MAX_AGE_MS). Independent
+   * of pendingToolInputs — sequential short tools never trigger the
+   * LONG_TOOL_SPLIT_MS mechanism but still age the stream past the cap.
+   * Must only be called at safe boundaries (between deltas / after tool
+   * results), never mid-append.
+   */
+  async function splitForStreamAge(): Promise<void> {
+    if (!streamAgeExceeded()) return;
+    logger.info("Slack stream exceeded max age; splitting to a fresh stream", {
+      channelId,
+      streamAgeMs: Date.now() - streamStartedAt,
+      thresholdMs: STREAM_MAX_AGE_MS,
+      pendingToolCount: pendingToolInputs.size,
+      toolCallCount: toolCallRecords.length,
+    });
+    if (!await splitToNewStream("stream_age") && streamingFailed) {
+      fallbackStartIdx = accumulatedText.length;
     }
   }
 
@@ -1278,6 +1367,7 @@ export async function generateResponse(
               fallbackStartIdx = accumulatedText.length;
             }
           }
+          await splitForStreamAge();
           break;
         }
 
@@ -1324,6 +1414,7 @@ export async function generateResponse(
               fallbackStartIdx = accumulatedText.length;
             }
           }
+          await splitForStreamAge();
           break;
         }
         }
@@ -1470,6 +1561,14 @@ export async function generateResponse(
         : finalText;
       const blocks: any[] = [];
       const formattedUnsent = unsentText ? formatForSlack(unsentText) : "";
+      // Issue #1121: when the stream died after everything visible had
+      // already been streamed (pure tool-call tail), the unsent buffer is
+      // empty and the fallback would post an effectively empty block list.
+      // Post a short stub instead so the user knows the turn was cut short.
+      const interruptedStubText =
+        !emptyCompletionDetected && !formattedUnsent && toolCallRecords.length > 0
+          ? `_Turn interrupted after ${toolCallRecords.length} tool call${toolCallRecords.length === 1 ? "" : "s"} — rerun?_`
+          : null;
       if (formattedUnsent) {
         for (let i = 0; i < formattedUnsent.length; i += 3000) {
           blocks.push({
@@ -1478,6 +1577,12 @@ export async function generateResponse(
             expand: true,
           });
         }
+      } else if (interruptedStubText) {
+        blocks.push({
+          type: "section",
+          text: { type: "mrkdwn", text: interruptedStubText },
+          expand: true,
+        });
       }
       if (pendingTableBlock) {
         blocks.push(pendingTableBlock);
@@ -1496,7 +1601,7 @@ export async function generateResponse(
       const toolMeta = buildToolMetadata(toolCallRecords);
       const fallbackText = emptyCompletionDetected
         ? emptyCompletionFallbackText
-        : formattedUnsent || "_I processed your request but had nothing to say._";
+        : interruptedStubText ?? (formattedUnsent || "_I processed your request but had nothing to say._");
 
       try {
         const fallbackResult = await safePostMessage(slackClient, {
@@ -1508,9 +1613,7 @@ export async function generateResponse(
         });
 
         if (!fallbackResult.ok) {
-          if (pendingMessageNotInStreamingStateError) {
-            logError(pendingMessageNotInStreamingStateError);
-          }
+          flushPendingMessageNotInStreamingStateError(false);
           logger.warn("LLM response lost — channel does not support posting", {
             channelId,
             rawLength: finalText.length,
@@ -1518,6 +1621,7 @@ export async function generateResponse(
           });
           logChannelTypeUnsupportedFallbackFailure("safePostMessage_returned_not_ok");
         } else {
+          flushPendingMessageNotInStreamingStateError(true);
           pendingChannelTypeUnsupportedFallback = null;
           logger.info(`LLM completed in ${llmMs}ms (fallback postMessage)`, {
             rawLength: finalText.length,
@@ -1526,9 +1630,7 @@ export async function generateResponse(
           });
         }
       } catch (fallbackErr: any) {
-        if (pendingMessageNotInStreamingStateError) {
-          logError(pendingMessageNotInStreamingStateError);
-        }
+        flushPendingMessageNotInStreamingStateError(false);
         logger.error("Fallback safePostMessage also failed — posting plain text", {
           channelId,
           error: fallbackErr?.message || String(fallbackErr),
@@ -1699,6 +1801,23 @@ export async function generateResponse(
       logger.info("Stream interrupted — invocation superseded", {
         invocationId: error.invocationId,
         channelId,
+      });
+
+      // Observability only — supersede recovery semantics (PR #1000) are
+      // unchanged. Without this row, 0-token hangs that get superseded by a
+      // user follow-up never appear in error_events (issue #1121).
+      logError({
+        errorName: "InvocationSupersededDuringStream",
+        errorMessage: error?.message || "Invocation superseded while streaming",
+        errorCode: "superseded_while_streaming",
+        channelId,
+        context: {
+          invocationId: error.invocationId,
+          abortReason: lastAbortReason,
+          accumulatedTextLength: accumulatedText.length,
+          toolCallCount: toolCallRecords.length,
+          streamAgeMs: Date.now() - streamStartedAt,
+        },
       });
 
       if (streamer && !streamingFailed) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1121

Slack's `chat.stream` enforces a hard cap (~3 minutes) on the **total** lifetime of a single stream. Turns with many sequential short tool calls (8–12 calls of 20–40s each) accumulate past the cap: the stream dies at the transport layer, composed text never flushes, the turn never finalizes, traces record 0 tokens, and nothing lands in `error_events`. Existing protections (keepalives, `LONG_TOOL_SPLIT_MS`) only cover idle timeouts and single long-pending tools — nothing tracked stream age across multiple short tools.

All changes are in `apps/api/src/pipeline/respond.ts` (+ its test file).

## 1. Stream-age-based split

- New documented constant `STREAM_MAX_AGE_MS = 60_000` explaining the ~3-min lifetime cap.
- `streamStartedAt` is set when a Slack stream is started and reset whenever `splitToNewStream()` creates a fresh one — it is **not** cleared between tool results, so it tracks wall-clock age of the current stream.
- `splitForStreamAge()` forces `splitToNewStream("stream_age")` once the age threshold is exceeded, independent of `pendingToolInputs`. It's checked at the existing safe boundaries: start of `appendTextDelta` (delta boundary, never mid-append) and after tool-result / tool-error handling.
- If tools are still pending at an age split, the existing tombstone closes their in-progress cards on the old stream.
- The `LONG_TOOL_SPLIT_MS` single-tool mechanism is unchanged and complementary.

## 2. Always log to `error_events`

- `message_not_in_streaming_state` now gets a dedicated `MessageNotInStreamingState` row that is written **whenever it occurs**, tagged `fallbackRecovered: true/false` so dashboards can separate recovered from unrecovered occurrences (previously swallowed when the fallback succeeded).
- Inactivity watchdog aborts log `StreamInactivityAbort` / `stream_inactivity_abort` at the point of abort (the abort doesn't always surface as a thrown `AbortError`, so the catch-side `StreamAborted` log alone misses these).
- Superseded-while-streaming turns log `InvocationSupersededDuringStream` / `superseded_while_streaming` with the abort reason. PR #1000's supersede recovery semantics are unchanged — this is observability only.

## 3. Empty-fallback stub

When the fallback path finds an empty unsent buffer (everything streamed before the freeze, pure tool-call tail), it now posts `_Turn interrupted after N tool calls — rerun?_` (N = tool calls executed this turn) instead of an effectively empty block list.

## Testing

- `pnpm typecheck` passes (API + dashboard).
- `pnpm --filter aura-api test`: 322/322 pass.
- New/updated tests in `respond.test.ts`:
  - age-based split across sequential short tools (70s of wall clock, no single tool pending >75s → fresh stream)
  - `message_not_in_streaming_state` logged as recovered when fallback succeeds
  - interruption stub posted when the unsent buffer is empty
  - `stream_inactivity_abort` logged on watchdog abort
  - `superseded_while_streaming` logged while preserving PR #1000 behavior (no empty-completion logs, no relaunch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-618b8471-e401-46be-b6e7-b8fa46fb8ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-618b8471-e401-46be-b6e7-b8fa46fb8ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

