### PR TITLE
Add Cursor agent issue dispatch and model controls

### DIFF
--- a/apps/api/src/app.cursor-agent.test.ts
+++ b/apps/api/src/app.cursor-agent.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   recordErrorMock: vi.fn(),
   resolveSlackDestinationMock: vi.fn(),
   safePostMessageMock: vi.fn(),
+  selectRowsMock: vi.fn(),
   waitUntilPromises: [] as Array<Promise<unknown>>,
 }));
 
@@ -130,7 +131,7 @@ vi.mock("./db/client.js", () => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          limit: vi.fn(async () => []),
+          limit: mocks.selectRowsMock,
         })),
       })),
     })),
@@ -162,6 +163,7 @@ describe("Cursor agent webhook", () => {
     mocks.getCredentialMock.mockResolvedValue("gh-token");
     mocks.resolveSlackDestinationMock.mockResolvedValue("DADMIN");
     mocks.safePostMessageMock.mockResolvedValue({ ok: true });
+    mocks.selectRowsMock.mockResolvedValue([]);
     mocks.fetchMock.mockImplementation(async (url: string) => {
       if (url === "https://api.github.com/graphql") {
         return {
@@ -215,6 +217,120 @@ describe("Cursor agent webhook", () => {
         channel: "DADMIN",
         text: expect.stringContaining(
           "<https://github.com/AuraHQ-ai/aura/pull/1037|Fix webhook>",
+        ),
+      }),
+    );
+    expect(mocks.recordErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("patches a missing Fixes line for issue-backed dispatches", async () => {
+    mocks.selectRowsMock.mockResolvedValue([
+      {
+        content: [
+          "## Cursor Agent Dispatch",
+          "- **Agent ID**: agent_issue",
+          "- **Branch**: cursor/issue-1031",
+          "- **Repo**: AuraHQ-ai/aura",
+          "- **Issue**: #1031",
+          "- **Requester**: UREQUESTER",
+          "- **Channel**: C123",
+          "- **Thread**: 1700000000.000000",
+        ].join("\n"),
+      },
+    ]);
+    mocks.resolveSlackDestinationMock.mockResolvedValue("DREQUESTER");
+    mocks.fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.github.com/graphql") {
+        const body = JSON.parse(String(init?.body));
+        if (String(body.query).includes("repository(owner:")) {
+          return {
+            ok: true,
+            status: 200,
+            json: vi.fn(async () => ({
+              data: {
+                repository: {
+                  pullRequest: {
+                    id: "PR_kwDOExample",
+                    isDraft: false,
+                    number: 1040,
+                  },
+                },
+              },
+            })),
+          } as unknown as Response;
+        }
+      }
+
+      if (
+        url ===
+          "https://api.github.com/repos/AuraHQ-ai/aura/pulls/1040" &&
+        init?.method === "PATCH"
+      ) {
+        const body = JSON.parse(String(init.body));
+        expect(body.body).toBe("Fixes #1031\n\nImplementation details");
+        return {
+          ok: true,
+          status: 200,
+          json: vi.fn(async () => ({ body: body.body })),
+        } as unknown as Response;
+      }
+
+      if (url === "https://api.github.com/repos/AuraHQ-ai/aura/pulls/1040") {
+        return {
+          ok: true,
+          status: 200,
+          json: vi.fn(async () => ({
+            title: "Implement issue dispatch",
+            body: "Implementation details",
+          })),
+        } as unknown as Response;
+      }
+
+      if (url === "https://api.cursor.com/v0/agents/agent_issue/conversation") {
+        return {
+          ok: true,
+          status: 200,
+          json: vi.fn(async () => ({})),
+        } as unknown as Response;
+      }
+
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const rawBody = JSON.stringify({
+      id: "agent_issue",
+      status: "FINISHED",
+      target: {
+        prUrl: "https://github.com/AuraHQ-ai/aura/pull/1040",
+      },
+    });
+
+    const response = await app.request("/api/webhook/cursor-agent", {
+      method: "POST",
+      headers: {
+        "x-webhook-signature": sign(rawBody),
+        "content-type": "application/json",
+      },
+      body: rawBody,
+    });
+
+    expect(response.status).toBe(200);
+    await Promise.all(mocks.waitUntilPromises);
+
+    expect(mocks.loggerInfoMock).toHaveBeenCalledWith(
+      "Cursor agent webhook: patched missing PR Fixes line",
+      {
+        owner: "AuraHQ-ai",
+        repo: "aura",
+        number: 1040,
+        issueNumber: 1031,
+      },
+    );
+    expect(mocks.safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "DREQUESTER",
+        text: expect.stringContaining(
+          "<https://github.com/AuraHQ-ai/aura/pull/1040|Implement issue dispatch>",
         ),
       }),
     );

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -929,6 +929,7 @@ app.post("/api/webhook/cursor-agent", async (c) => {
       let channelId = "";
       let threadTs = "";
       let repo = process.env.AURA_REPO_DEFAULT || "AuraHQ-ai/aura";
+      let issueNumber: number | undefined;
 
       if (agentId) {
         const trackingRows = await db
@@ -945,12 +946,14 @@ app.post("/api/webhook/cursor-agent", async (c) => {
           const channelMatch = content.match(/\*\*Channel\*\*:\s*(\S+)/);
           const threadMatch = content.match(/\*\*Thread\*\*:\s*(\S+)/);
           const repoMatch = content.match(/\*\*Repo\*\*:\s*(\S+)/);
+          const issueMatch = content.match(/\*\*Issue\*\*:\s*#?(\d+)/);
           if (requesterMatch && requesterMatch[1] !== "unknown")
             requester = requesterMatch[1];
           if (channelMatch) channelId = channelMatch[1];
           if (threadMatch && threadMatch[1] !== "none")
             threadTs = threadMatch[1];
           if (repoMatch) repo = repoMatch[1];
+          if (issueMatch) issueNumber = Number(issueMatch[1]);
         }
       }
 
@@ -993,12 +996,20 @@ app.post("/api/webhook/cursor-agent", async (c) => {
       if (isFinished && resolvedPrUrl) {
         try {
           const { getCredential } = await import("./lib/credentials.js");
-          const { markPullRequestReadyForReview } = await import(
+          const {
+            ensurePullRequestFixesIssue,
+            markPullRequestReadyForReview,
+          } = await import(
             "./lib/cursor-agent.js"
           );
           const ghToken = await getCredential("github_token");
           await markPullRequestReadyForReview({
             prUrl: resolvedPrUrl,
+            githubToken: ghToken,
+          });
+          await ensurePullRequestFixesIssue({
+            prUrl: resolvedPrUrl,
+            issueNumber,
             githubToken: ghToken,
           });
         } catch (error) {

--- a/apps/api/src/lib/cursor-agent.test.ts
+++ b/apps/api/src/lib/cursor-agent.test.ts
@@ -10,7 +10,15 @@ vi.mock("./logger.js", () => ({
   },
 }));
 
+vi.mock("./credentials.js", () => ({
+  resolveCredentialValue: vi.fn(async (name: string) =>
+    name === "cursor_api_key" ? "cursor-key" : null,
+  ),
+}));
+
 const {
+  ensurePullRequestFixesIssue,
+  launchCursorAgent,
   markPullRequestReadyForReview,
   parseGitHubPullRequestUrl,
   resolveCursorAgentPrUrl,
@@ -22,11 +30,59 @@ function jsonResponse(data: unknown): Response {
     ok: true,
     status: 200,
     json: vi.fn(async () => data),
+    text: vi.fn(async () => JSON.stringify(data)),
   } as unknown as Response;
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("launchCursorAgent", () => {
+  async function captureLaunchBody(params: {
+    model?: string;
+  } = {}): Promise<Record<string, unknown>> {
+    let capturedBody: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body));
+      return jsonResponse({ id: "agent_123", status: "running" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await launchCursorAgent({
+      prompt: "Fix the bug",
+      repository: "https://github.com/AuraHQ-ai/aura",
+      ...params,
+    });
+
+    expect(capturedBody).toBeDefined();
+    return capturedBody!;
+  }
+
+  it("sends model in the request body when provided", async () => {
+    const body = await captureLaunchBody({ model: "claude-sonnet-4.5" });
+
+    expect(body.model).toBe("claude-sonnet-4.5");
+  });
+
+  it("omits model when no model is provided", async () => {
+    const body = await captureLaunchBody();
+
+    expect(body).not.toHaveProperty("model");
+  });
+
+  it("omits model when the model is an empty string", async () => {
+    const body = await captureLaunchBody({ model: "" });
+
+    expect(body).not.toHaveProperty("model");
+  });
+
+  it("omits model when the model is auto", async () => {
+    const body = await captureLaunchBody({ model: "auto" });
+
+    expect(body).not.toHaveProperty("model");
+  });
 });
 
 describe("resolveCursorAgentPrUrl", () => {
@@ -226,5 +282,54 @@ describe("markPullRequestReadyForReview", () => {
         error: "github down",
       },
     );
+  });
+});
+
+describe("ensurePullRequestFixesIssue", () => {
+  it("patches the PR body when the Fixes line is missing", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body));
+        expect(body.body).toBe("Fixes #1031\n\nImplementation notes");
+        return jsonResponse({ body: body.body });
+      }
+
+      return jsonResponse({ body: "Implementation notes" });
+    });
+
+    const result = await ensurePullRequestFixesIssue({
+      prUrl: "https://github.com/AuraHQ-ai/aura/pull/1040",
+      issueNumber: 1031,
+      githubToken: "gh-token",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("patched");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Cursor agent webhook: patched missing PR Fixes line",
+      {
+        owner: "AuraHQ-ai",
+        repo: "aura",
+        number: 1040,
+        issueNumber: 1031,
+      },
+    );
+  });
+
+  it("does not patch when an accepted closing line is already present", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ body: "Summary\n\nCloses #1031" }),
+    );
+
+    const result = await ensurePullRequestFixesIssue({
+      prUrl: "https://github.com/AuraHQ-ai/aura/pull/1040",
+      issueNumber: 1031,
+      githubToken: "gh-token",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toBe("already_present");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/lib/cursor-agent.ts
+++ b/apps/api/src/lib/cursor-agent.ts
@@ -21,6 +21,7 @@ export interface LaunchCursorAgentParams {
   /** Full GitHub URL, e.g. "https://github.com/owner/repo" */
   repository: string;
   ref?: string;
+  model?: string;
   branchName?: string;
   autoCreatePr?: boolean;
   webhookUrl?: string;
@@ -60,11 +61,68 @@ export interface GitHubPullRequestRef {
   number: number;
 }
 
+export interface GitHubIssueSnapshot {
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  htmlUrl?: string;
+}
+
 export type MarkPullRequestReadyResult =
   | "marked"
   | "already_ready"
   | "skipped"
   | "failed";
+
+export type EnsurePullRequestFixesIssueResult =
+  | "patched"
+  | "already_present"
+  | "skipped"
+  | "failed";
+
+export function normalizeCursorModel(
+  model: string | null | undefined,
+): string | undefined {
+  const trimmed = model?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "auto") return undefined;
+  return trimmed;
+}
+
+export function resolveCursorModel({
+  explicitModel,
+  envDefault = process.env.CURSOR_DEFAULT_MODEL,
+}: {
+  explicitModel?: string | null;
+  envDefault?: string | null;
+}): string | undefined {
+  return normalizeCursorModel(explicitModel) ?? normalizeCursorModel(envDefault);
+}
+
+export function buildCursorIssuePrompt({
+  repo,
+  issueNumber,
+  title,
+  body,
+  additionalNotes,
+}: {
+  repo: string;
+  issueNumber: number;
+  title: string;
+  body: string;
+  additionalNotes?: string;
+}): string {
+  const notes = additionalNotes?.trim();
+  return [
+    `Implement GitHub issue #${issueNumber} in ${repo} exactly as written: ${title}`,
+    `Read the full issue body below carefully before writing any code. It is the canonical spec — do not re-synthesize or reinterpret it. Follow the repo's existing conventions and run the checks named in the issue's acceptance criteria.`,
+    `When you open the PR, the PR body MUST start with the line: Fixes #${issueNumber}`,
+    `--- ISSUE BODY ---\n${body}`,
+    notes ? `--- ADDITIONAL DISPATCH NOTES ---\n${notes}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
 
 interface GitHubGraphqlResponse<T> {
   data?: T;
@@ -93,6 +151,68 @@ export function parseGitHubPullRequestUrl(
   } catch {
     return null;
   }
+}
+
+export async function fetchGitHubIssueSnapshot({
+  repo,
+  issueNumber,
+  githubToken,
+  fetchImpl = fetch,
+}: {
+  repo: string;
+  issueNumber: number;
+  githubToken?: string | null;
+  fetchImpl?: typeof fetch;
+}): Promise<GitHubIssueSnapshot> {
+  if (!githubToken) {
+    throw new Error(
+      `GitHub token is required to fetch issue #${issueNumber} from ${repo} (configure GITHUB_TOKEN or github_token credential)`,
+    );
+  }
+
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${repo}/issues/${issueNumber}`,
+    {
+      headers: {
+        Authorization: `token ${githubToken}`,
+        Accept: "application/vnd.github.v3+json",
+        "User-Agent": "Aura",
+      },
+    },
+  );
+
+  let body: any;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub issue #${issueNumber} fetch failed (${response.status}): ${
+        body?.message || "unknown error"
+      }`,
+    );
+  }
+
+  if (body?.pull_request) {
+    throw new Error(
+      `GitHub item #${issueNumber} in ${repo} is a pull request, not an issue`,
+    );
+  }
+
+  if (body?.state === "closed") {
+    throw new Error(`GitHub issue #${issueNumber} in ${repo} is closed`);
+  }
+
+  return {
+    number: Number(body?.number ?? issueNumber),
+    title: String(body?.title ?? ""),
+    body: typeof body?.body === "string" ? body.body : "",
+    state: String(body?.state ?? ""),
+    htmlUrl: typeof body?.html_url === "string" ? body.html_url : undefined,
+  };
 }
 
 async function githubGraphql<T>({
@@ -238,6 +358,98 @@ export async function markPullRequestReadyForReview({
   }
 }
 
+export async function ensurePullRequestFixesIssue({
+  prUrl,
+  issueNumber,
+  githubToken,
+  fetchImpl = fetch,
+}: {
+  prUrl: string;
+  issueNumber: number | undefined;
+  githubToken: string | null | undefined;
+  fetchImpl?: typeof fetch;
+}): Promise<EnsurePullRequestFixesIssueResult> {
+  if (!issueNumber || !githubToken) return "skipped";
+
+  const pr = parseGitHubPullRequestUrl(prUrl);
+  if (!pr) return "skipped";
+
+  const fixesLinePattern = new RegExp(
+    `(?:^|\\n)\\s*(?:fixes|closes|resolves)\\s+#${issueNumber}\\b`,
+    "i",
+  );
+
+  try {
+    const headers = {
+      Authorization: `token ${githubToken}`,
+      Accept: "application/vnd.github.v3+json",
+      "Content-Type": "application/json",
+      "User-Agent": "Aura",
+    };
+
+    const pullUrl = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`;
+    const response = await fetchImpl(pullUrl, { headers });
+    let body: any;
+    try {
+      body = await response.json();
+    } catch {
+      body = undefined;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `GitHub PR #${pr.number} fetch failed (${response.status}): ${
+          body?.message || "unknown error"
+        }`,
+      );
+    }
+
+    const currentBody = typeof body?.body === "string" ? body.body : "";
+    if (fixesLinePattern.test(currentBody)) {
+      return "already_present";
+    }
+
+    const patchedBody = `Fixes #${issueNumber}\n\n${currentBody}`;
+    const patchResponse = await fetchImpl(pullUrl, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ body: patchedBody }),
+    });
+
+    let patchBody: any;
+    try {
+      patchBody = await patchResponse.json();
+    } catch {
+      patchBody = undefined;
+    }
+
+    if (!patchResponse.ok) {
+      throw new Error(
+        `GitHub PR #${pr.number} patch failed (${patchResponse.status}): ${
+          patchBody?.message || "unknown error"
+        }`,
+      );
+    }
+
+    logger.info("Cursor agent webhook: patched missing PR Fixes line", {
+      owner: pr.owner,
+      repo: pr.repo,
+      number: pr.number,
+      issueNumber,
+    });
+    return "patched";
+  } catch (error) {
+    logger.warn("Cursor agent webhook: failed to enforce PR Fixes line", {
+      owner: pr.owner,
+      repo: pr.repo,
+      number: pr.number,
+      issueNumber,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return "failed";
+  }
+}
+
 export async function resolveCursorAgentPrUrl({
   prUrl,
   branchName,
@@ -286,6 +498,9 @@ export async function launchCursorAgent(
       ...(params.ref && { ref: params.ref }),
     },
   };
+
+  const model = normalizeCursorModel(params.model);
+  if (model) body.model = model;
 
   const target: Record<string, unknown> = {};
   if (params.branchName) target.branchName = params.branchName;

--- a/apps/api/src/tools/cursor-agent.test.ts
+++ b/apps/api/src/tools/cursor-agent.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@example.com/db";
+
+const mocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  getCredential: vi.fn(),
+  insertValues: vi.fn(),
+  insertOnConflictDoUpdate: vi.fn(),
+  launchCursorAgent: vi.fn(),
+}));
+
+vi.mock("../lib/tool.js", () => ({
+  defineTool: (config: any) => config,
+}));
+
+vi.mock("../lib/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/settings.js", () => ({
+  getConfig: mocks.getConfig,
+}));
+
+vi.mock("../lib/credentials.js", () => ({
+  getCredential: mocks.getCredential,
+  resolveCredentialValue: vi.fn(),
+}));
+
+vi.mock("../db/client.js", () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: mocks.insertValues.mockImplementation(() => ({
+        onConflictDoUpdate: mocks.insertOnConflictDoUpdate,
+      })),
+    })),
+  },
+}));
+
+vi.mock("../lib/cursor-agent.js", async () => {
+  const actual = await vi.importActual<typeof import("../lib/cursor-agent.js")>(
+    "../lib/cursor-agent.js",
+  );
+  return {
+    ...actual,
+    launchCursorAgent: mocks.launchCursorAgent,
+  };
+});
+
+const { createCursorAgentTools } = await import("./cursor-agent.js");
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn(async () => data),
+  } as unknown as Response;
+}
+
+function dispatchTool() {
+  return createCursorAgentTools({
+    userId: "U123",
+    channelId: "C123",
+    threadTs: "1700000000.000000",
+  } as any).dispatch_cursor_agent as any;
+}
+
+describe("dispatch_cursor_agent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.CURSOR_DEFAULT_MODEL;
+    mocks.getConfig.mockImplementation(async (_key: string, fallback?: string) =>
+      fallback ?? "",
+    );
+    mocks.getCredential.mockResolvedValue("gh-token");
+    mocks.insertOnConflictDoUpdate.mockResolvedValue(undefined);
+    mocks.launchCursorAgent.mockResolvedValue({
+      id: "agent_123",
+      dashboardUrl: "https://cursor.com/agents/agent_123",
+    });
+  });
+
+  it("uses CURSOR_DEFAULT_MODEL when no explicit model is provided", async () => {
+    process.env.CURSOR_DEFAULT_MODEL = "gpt-5";
+    const tool = dispatchTool();
+
+    const result = await tool.execute(
+      tool.inputSchema.parse({
+        issue_description: "Fix a small bug",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mocks.launchCursorAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gpt-5" }),
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("- **Model**: gpt-5"),
+      }),
+    );
+  });
+
+  it("dispatches issue prompts with the canonical pointer, verbatim body, and Fixes instruction", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("https://api.github.com/repos/AuraHQ-ai/aura/issues/1031");
+      return jsonResponse({
+        number: 1031,
+        title: "Canonical pointer prompt",
+        body: "First body line\n\nSecond body line",
+        state: "open",
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const tool = dispatchTool();
+
+    const result = await tool.execute(
+      tool.inputSchema.parse({
+        issue: 1031,
+        key_files: ["apps/api/src/lib/cursor-agent.ts"],
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    const launchParams = mocks.launchCursorAgent.mock.calls[0][0];
+    expect(launchParams.prompt).toContain(
+      "Implement GitHub issue #1031 in AuraHQ-ai/aura exactly as written: Canonical pointer prompt",
+    );
+    expect(launchParams.prompt).toContain(
+      "--- ISSUE BODY ---\nFirst body line\n\nSecond body line",
+    );
+    expect(launchParams.prompt).toContain(
+      "When you open the PR, the PR body MUST start with the line: Fixes #1031",
+    );
+    expect(launchParams.prompt).toContain(
+      "Key files to focus on:\n- apps/api/src/lib/cursor-agent.ts",
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("- **Issue**: #1031"),
+      }),
+    );
+  });
+
+  it("requires issue_description only when issue is absent", () => {
+    const tool = dispatchTool();
+
+    expect(() => tool.inputSchema.parse({})).toThrow(
+      /Provide either issue or issue_description/,
+    );
+  });
+
+  it("keeps the issue body primary and appends issue_description as additional notes when both are provided", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          number: 1031,
+          title: "Primary issue",
+          body: "Canonical issue body",
+          state: "open",
+        }),
+      ),
+    );
+    const tool = dispatchTool();
+
+    await tool.execute(
+      tool.inputSchema.parse({
+        issue: 1031,
+        issue_description: "Use the existing feature branch.",
+      }),
+    );
+
+    const prompt = mocks.launchCursorAgent.mock.calls[0][0].prompt as string;
+    const bodyIndex = prompt.indexOf("--- ISSUE BODY ---\nCanonical issue body");
+    const notesIndex = prompt.indexOf(
+      "--- ADDITIONAL DISPATCH NOTES ---\nUse the existing feature branch.",
+    );
+    expect(bodyIndex).toBeGreaterThanOrEqual(0);
+    expect(notesIndex).toBeGreaterThan(bodyIndex);
+  });
+});

--- a/apps/api/src/tools/cursor-agent.ts
+++ b/apps/api/src/tools/cursor-agent.ts
@@ -7,6 +7,73 @@ import type { ScheduleContext } from "@aura/db/schema";
 import { logger } from "../lib/logger.js";
 import { getConfig } from "../lib/settings.js";
 
+const dispatchCursorAgentInputSchema = z
+  .object({
+    issue_description: z
+      .string()
+      .optional()
+      .describe(
+        "Detailed description of the issue or task for the agent to work on. Required only when issue is absent. If issue is provided, this is appended as operational notes; canonical guardrails belong in the GitHub issue body.",
+      ),
+    issue: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "GitHub issue number in the target repository. Preferred dispatch path: Aura fetches the issue body, embeds it verbatim as the canonical spec, and enforces a Fixes #N PR body line.",
+      ),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Cursor model to use, e.g. 'claude-sonnet-4.5', 'gpt-5', 'composer-1.5'. " +
+          "Omit or leave empty to use Cursor's default auto-selection. " +
+          "Defaults to env CURSOR_DEFAULT_MODEL if set.",
+      ),
+    branch_prefix: z
+      .string()
+      .default("cursor")
+      .describe(
+        "Branch name prefix. The agent creates a branch like cursor/{slug}",
+      ),
+    ref: z
+      .string()
+      .optional()
+      .describe("Git ref (branch/tag/SHA) to base work on. Defaults to main"),
+    key_files: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "List of key files for the agent to focus on, e.g. ['src/app.ts', 'src/tools/slack.ts']",
+      ),
+    repository: z
+      .string()
+      .optional()
+      .describe(
+        "GitHub repository in owner/repo format, e.g. 'org/repo'. Defaults to 'AuraHQ-ai/aura'",
+      ),
+  })
+  .refine(
+    (input) =>
+      input.issue !== undefined ||
+      (input.issue_description?.trim().length ?? 0) > 0,
+    {
+      message: "Provide either issue or issue_description",
+      path: ["issue_description"],
+    },
+  );
+
+function slugifyBranchSource(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 40)
+      .replace(/^-+|-+$/g, "") || "cursor-agent-task"
+  );
+}
+
 /**
  * Create Cursor Cloud Agent tools for the AI SDK.
  * Provides async dispatch of Cursor agents for complex multi-file code tasks.
@@ -19,54 +86,62 @@ export function createCursorAgentTools(context?: ScheduleContext) {
         "Dispatch an async Cursor Cloud Agent to work on a code task in the Aura repo. " +
         "Use for complex multi-file changes that would take >5 minutes in the sandbox (refactors, new features, multi-step bug fixes). " +
         "Do NOT use for simple one-line fixes or tasks that run_command handles in <2 minutes. " +
+        "Prefer the issue parameter when dispatching from a GitHub issue; the issue body becomes the canonical spec snapshot, and one-off notes can go in issue_description. Put durable guardrails and acceptance criteria in the issue body. " +
+        "Use model to pin a Cursor model when needed; omit it for CURSOR_DEFAULT_MODEL or Cursor auto-selection. " +
         "The agent runs in the background (3-30 min), creates a branch, makes changes, opens a PR, and results arrive via webhook DM. " +
         "Returns immediately with the agent ID — don't wait for it or poll in a loop. Save the agent ID in your reply so you can reference it later. Admin-only.",
-      inputSchema: z.object({
-        issue_description: z
-          .string()
-          .describe(
-            "Detailed description of the issue or task for the agent to work on",
-          ),
-        branch_prefix: z
-          .string()
-          .default("cursor")
-          .describe(
-            "Branch name prefix. The agent creates a branch like cursor/{slug}",
-          ),
-        ref: z
-          .string()
-          .optional()
-          .describe(
-            "Git ref (branch/tag/SHA) to base work on. Defaults to main",
-          ),
-        key_files: z
-          .array(z.string())
-          .optional()
-          .describe(
-            "List of key files for the agent to focus on, e.g. ['src/app.ts', 'src/tools/slack.ts']",
-          ),
-        repository: z
-          .string()
-          .optional()
-          .describe(
-            "GitHub repository in owner/repo format, e.g. 'org/repo'. Defaults to 'AuraHQ-ai/aura'",
-          ),
-      }),
-      execute: async ({ issue_description, branch_prefix, ref, key_files, repository }) => {
+      inputSchema: dispatchCursorAgentInputSchema,
+      execute: async ({
+        issue_description,
+        issue,
+        model,
+        branch_prefix,
+        ref,
+        key_files,
+        repository,
+      }) => {
         try {
-          const { launchCursorAgent } = await import(
+          const {
+            buildCursorIssuePrompt,
+            fetchGitHubIssueSnapshot,
+            launchCursorAgent,
+            resolveCursorModel,
+          } = await import(
             "../lib/cursor-agent.js"
           );
 
           const defaultRepo = await getConfig("default_github_repo", "AuraHQ-ai/aura");
           const repo = repository || defaultRepo;
           const repoUrl = `https://github.com/${repo}`;
+          const resolvedModel = resolveCursorModel({ explicitModel: model });
 
-          const slug = issue_description
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")
-            .slice(0, 40)
-            .replace(/-$/, "");
+          let taskPrompt: string;
+          let slugSource: string;
+          let issueTitle = "";
+
+          if (issue !== undefined) {
+            const { getCredential } = await import("../lib/credentials.js");
+            const githubToken = await getCredential("github_token");
+            const issueSnapshot = await fetchGitHubIssueSnapshot({
+              repo,
+              issueNumber: issue,
+              githubToken,
+            });
+            issueTitle = issueSnapshot.title;
+            taskPrompt = buildCursorIssuePrompt({
+              repo,
+              issueNumber: issue,
+              title: issueSnapshot.title,
+              body: issueSnapshot.body,
+              additionalNotes: issue_description,
+            });
+            slugSource = `issue-${issue}-${issueSnapshot.title}`;
+          } else {
+            taskPrompt = `## Task\n\n${issue_description}`;
+            slugSource = issue_description || "";
+          }
+
+          const slug = slugifyBranchSource(slugSource);
           const branchName = `${branch_prefix}/${slug}`;
 
           const keyFilesSection =
@@ -88,7 +163,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
             : [];
 
           const prompt = [
-            `## Task\n\n${issue_description}`,
+            taskPrompt,
             `## Repository\n\n${repoDescription}`,
             keyFilesSection,
             `## Instructions\n\n${[...instructions, `- Never push directly to main — work on branch \`${branchName}\``, `- Create a PR with a clear description of changes`].join("\n")}`,
@@ -105,6 +180,7 @@ export function createCursorAgentTools(context?: ScheduleContext) {
             prompt,
             repository: repoUrl,
             ref: ref || "main",
+            model: resolvedModel,
             branchName,
             autoCreatePr: true,
             webhookUrl,
@@ -116,14 +192,21 @@ export function createCursorAgentTools(context?: ScheduleContext) {
             `- **Agent ID**: ${result.id}`,
             `- **Branch**: ${branchName}`,
             `- **Repo**: ${repo}`,
+            `- **Model**: ${resolvedModel || "auto"}`,
+            `- **Issue**: ${issue !== undefined ? `#${issue}` : "none"}`,
+            issueTitle ? `- **Issue Title**: ${issueTitle}` : "",
             `- **Requester**: ${context?.userId || "unknown"}`,
             `- **Channel**: ${context?.channelId || "unknown"}`,
             `- **Thread**: ${context?.threadTs || "none"}`,
             `- **Dispatched**: ${new Date().toISOString()}`,
             ``,
             `## Issue`,
-            issue_description,
-          ].join("\n");
+            issue !== undefined
+              ? `GitHub issue #${issue}${issue_description ? `\n\nAdditional dispatch notes:\n${issue_description}` : ""}`
+              : issue_description,
+          ]
+            .filter((line) => line !== "")
+            .join("\n");
 
           const sevenDays = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
           await db
@@ -172,7 +255,8 @@ export function createCursorAgentTools(context?: ScheduleContext) {
       },
       slack: {
         status: "Dispatching Cursor agent...",
-        detail: (i) => i.issue_description?.slice(0, 60),
+        detail: (i) =>
+          i.issue ? `#${i.issue}` : i.issue_description?.slice(0, 60),
         output: (r) => r.ok === false ? r.error : `Agent ${r.agent_id?.slice(0, 12)}… on \`${r.branch}\``,
       },
     }),

--- a/content/docs/tools/cursor-agent.mdx
+++ b/content/docs/tools/cursor-agent.mdx
@@ -9,6 +9,8 @@ Aura can dispatch [Cursor](https://cursor.sh) Cloud Agents for complex multi-fil
 
 **Required env vars:** `CURSOR_API_KEY`
 
+**Optional env vars:** `CURSOR_DEFAULT_MODEL` sets the default Cursor model for new dispatches when the tool call does not specify `model`.
+
 **Admin-only.** All Cursor agent tools require admin permissions.
 
 ---
@@ -19,17 +21,55 @@ Dispatch an async agent to work on a code task. Returns immediately with an agen
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `issue_description` | string | **yes** | Detailed description of the task |
+| `issue` | number | no | GitHub issue number in the target repo. Preferred path: fetches title/body and embeds the body verbatim as the canonical spec |
+| `issue_description` | string | required iff `issue` absent | Detailed description of the task. When `issue` is present, appended as additional dispatch notes |
+| `model` | string | no | Cursor model to use, e.g. `claude-sonnet-4.5`, `gpt-5`, `composer-1.5`. Explicit value overrides `CURSOR_DEFAULT_MODEL` |
 | `branch_prefix` | string | no | Branch prefix (default `cursor`) — agent creates `cursor/{slug}` |
 | `ref` | string | no | Git ref to base work on (default `main`) |
 | `key_files` | string[] | no | Key files for the agent to focus on |
 | `cursor_rules` | string | no | Additional `.cursor/rules` content injected for this task |
 | `repo` | string | no | GitHub repo (default: `AuraHQ-ai/aura`) |
 
+### Preferred issue dispatch
+
+Use `issue` when a GitHub issue is the source of truth:
+
+```json
+{ "issue": 1031, "model": "gpt-5" }
+```
+
+Aura fetches `GET /repos/{owner}/{repo}/issues/{issue}` with `GITHUB_TOKEN` / the `github_token` credential, rejects missing issues, PRs, and closed issues, then builds a pointer prompt:
+
+```text
+Implement GitHub issue #N in owner/repo exactly as written: {title}
+
+Read the full issue body below carefully before writing any code. It is the canonical spec — do not re-synthesize or reinterpret it.
+
+When you open the PR, the PR body MUST start with the line: Fixes #N
+
+--- ISSUE BODY ---
+{body}
+```
+
+The issue body is embedded verbatim so the agent works from the exact spec snapshot at dispatch time. If both `issue` and `issue_description` are provided, the issue body stays primary and `issue_description` is appended under `--- ADDITIONAL DISPATCH NOTES ---`; durable guardrails and acceptance criteria should go in the issue body.
+
+On completion, the webhook checks the PR body for `Fixes #N`, `Closes #N`, or `Resolves #N` and prepends `Fixes #N` if the line is missing.
+
+### Model selection
+
+Model resolution order:
+
+1. Non-empty `model` argument
+2. Non-empty `CURSOR_DEFAULT_MODEL`
+3. Omit the `model` field entirely so Cursor auto-selects
+
+Do not pass `""` or `"auto"` as a Cursor API model value; the tool omits the field instead.
+
 **Best practices:**
 - Always specify `key_files` to reduce agent wandering
 - Include `cursor_rules` for project-specific conventions (e.g. Drizzle migration breakpoints)
-- Say "create a PR" explicitly in the description — agents sometimes finish without opening one
+- Prefer `issue` over paraphrasing a well-specified GitHub issue
+- Say "create a PR" explicitly in the description when dispatching without `issue` — agents sometimes finish without opening one
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1031

## Summary
- Add optional Cursor model selection with `CURSOR_DEFAULT_MODEL` fallback while omitting empty/auto values from API requests.
- Add issue-backed dispatch that fetches GitHub issue snapshots, builds the canonical pointer prompt, and tracks issue/model metadata.
- Repair missing `Fixes #N`/closing lines from Cursor-agent PR bodies during completion webhook handling.
- Document the preferred issue dispatch path and model resolution behavior.

## Verification
- `npx tsc --noEmit` (apps/api)
- Monorepo `pnpm typecheck` via pre-push hook
- `pnpm --filter aura-api test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f66370de-3315-4cd8-9c76-39c13e21b716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f66370de-3315-4cd8-9c76-39c13e21b716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

