### PR TITLE
Docs: update dashboard, Nitro, and WDK references

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -5,14 +5,14 @@ description: "How Aura's message pipeline, memory system, tools, and self-improv
 
 # Architecture
 
-Aura is a Hono-based application deployed on Vercel serverless functions. She processes Slack events, maintains long-term memory in PostgreSQL, and uses LLMs (Claude, Grok) for reasoning via the Vercel AI SDK.
+Aura is a Nitro-based application with Hono routing, deployed on Vercel serverless functions. She processes Slack events, maintains long-term memory in PostgreSQL, and uses LLMs (Claude, Grok) for reasoning via the Vercel AI SDK.
 
 ## Monorepo Structure
 
 ```
 aura/
 ├── apps/
-│   ├── api/            # Core agent (Hono + Vercel Functions)
+│   ├── api/            # Core agent (Nitro + Hono, Vercel Functions)
 │   │   └── src/
 │   │       ├── pipeline/    # Message processing, prompt assembly
 │   │       ├── tools/       # 25 tool modules (Slack, email, BigQuery, etc.)
@@ -43,7 +43,7 @@ aura/
 ## System Overview
 
 ```
-Slack Event → Vercel Function → Hono Router → Message Pipeline → LLM (Vercel AI SDK)
+Slack Event → Vercel Function → Nitro + Hono Router → Message Pipeline → LLM (Vercel AI SDK)
                                                       ↕
                                               PostgreSQL + pgvector
                                       (memories, messages, conversations, notes, jobs)
@@ -77,6 +77,10 @@ Every conversation is persisted with full detail:
 - **Metadata** — Channel, thread, user, model, duration
 
 The [Dashboard](/dashboard) provides a UI for browsing conversation traces, filtering by user/channel, and analyzing costs.
+
+## Durable Execution (Vercel Workflow DevKit)
+
+Aura uses the Vercel Workflow DevKit for durable execution in the Nitro API, with `"use workflow"` and `"use step"` directives defining resumable workflow boundaries. Dashboard chat always runs as a workflow in `apps/api/workflows/dashboard-chat.ts`: the server owns generation, the browser is only a stream reader, and streams can be resumed after disconnects. Slack respond has a flag-gated durable path in `apps/api/workflows/slack-respond.ts`, enabled by `AURA_WDK_SLACK_RESPOND=1` or the `wdk_slack_respond` dashboard setting. This path lets Slack message responses resume after function interruption while the legacy in-process responder remains the default when the flag is off.
 
 ## Tool System
 

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -50,6 +50,7 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `CURSOR_WEBHOOK_SECRET` | Secret for verifying Cursor agent webhook callbacks |
 | `COHERE_API_KEY` | Cohere API key for reranking search results |
 | `VERCEL_TOKEN` | Vercel token (injected into sandbox for deployments) |
+| `AURA_WDK_SLACK_RESPOND` | Enable the durable Slack respond path via the Vercel Workflow DevKit. When set to `1`, Slack message responses run as resumable workflows. Can also be toggled via the `wdk_slack_respond` setting in the dashboard. Off by default. |
 
 ## Dashboard
 

--- a/content/docs/deployment/vercel.mdx
+++ b/content/docs/deployment/vercel.mdx
@@ -14,8 +14,8 @@ Aura is a pnpm monorepo with multiple packages:
 ```
 aura/
 ├── apps/
-│   ├── api/          # Backend API (Hono, serverless functions)
-│   ├── dashboard/    # Admin dashboard (Next.js)
+│   ├── api/          # Backend API (Nitro + Hono, serverless functions)
+│   ├── dashboard/    # Admin dashboard (Vite + React + TanStack Router)
 │   └── web/          # Landing page + blog (Next.js)
 ├── packages/
 │   └── db/           # Shared database schema (Drizzle ORM)
@@ -28,21 +28,22 @@ Each `apps/*` project deploys as a separate Vercel project.
 ## Architecture
 
 - **Runtime:** Node.js serverless functions
-- **Framework:** Hono for HTTP routing
-- **Entry point:** `apps/api/src/app.ts` exports the Hono app; `apps/api/api/index.ts` is the Vercel handler
-- **Build:** `tsc` compiles TypeScript, then `pnpm --filter @aura/db db:migrate` runs pending Drizzle migrations
+- **Framework:** Nitro with Hono for HTTP routing
+- **Entry point:** Nitro builds the API from `apps/api/src/app.ts`, which exports the Hono app
+- **Build:** `nitro build --preset vercel` emits the Vercel functions, `node scripts/patch-vercel-output.mjs` patches the output, and `pnpm --filter @aura/db db:migrate` runs pending Drizzle migrations
 
 ## Deployment Flow
 
 ```
-Push to main → Vercel Build → tsc → Run Migrations → Deploy
+Push to main → Vercel Build → nitro build --preset vercel → Run Migrations → Deploy
 ```
 
-The `vercel-build` script in `apps/api/package.json`:
+The relevant scripts in `apps/api/package.json`:
 
 ```json
 {
   "scripts": {
+    "build:vercel": "nitro build --preset vercel && node scripts/patch-vercel-output.mjs",
     "vercel-build": "pnpm --filter @aura/db db:migrate"
   }
 }

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -35,8 +35,8 @@ Aura is organized as a monorepo with three main packages:
 ```
 aura/
 ├── apps/
-│   ├── api/          # Core agent — Hono API, message pipeline, tools, cron
-│   ├── dashboard/    # Admin dashboard — Next.js app for monitoring & management
+│   ├── api/          # Core agent — Nitro + Hono API, message pipeline, tools, cron
+│   ├── dashboard/    # Admin dashboard — Vite + React app for monitoring & management
 │   └── web/          # Marketing site — aurahq.ai
 ├── packages/
 │   └── db/           # Shared database layer — Drizzle ORM schema & migrations


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Correct dashboard framework references from Next.js to Vite + React / TanStack Router while leaving the marketing web app as Next.js.
- Update API docs to describe Nitro with Hono routing and document the `nitro build --preset vercel` build path.
- Add durable execution documentation for Vercel Workflow DevKit and document `AURA_WDK_SLACK_RESPOND`.

## Verification
- `npx tsc --noEmit` in `apps/api`
- `npx tsc --noEmit` in `apps/dashboard`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63cd38f7-e882-48f3-8a9c-d432fa9a0f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63cd38f7-e882-48f3-8a9c-d432fa9a0f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

