### PR TITLE
Fix sandbox detached command pid launch

### DIFF
--- a/apps/api/src/tools/sandbox.test.ts
+++ b/apps/api/src/tools/sandbox.test.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { createServer } from "node:http";
 import { promisify } from "node:util";
 import crypto from "node:crypto";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
@@ -70,7 +70,7 @@ vi.mock("../db/client.js", () => ({
   },
 }));
 
-import { buildDetachedScript, createSandboxTools } from "./sandbox.js";
+import { buildDetachedLaunchScript, buildDetachedScript, createSandboxTools } from "./sandbox.js";
 
 function mockCommandLifecycle(options: {
   waitStatus?: "exited" | "not_running" | "timeout";
@@ -92,7 +92,7 @@ function mockCommandLifecycle(options: {
   } = options;
 
   sandboxMocks.commandRun.mockImplementation(async (command: string, runOptions: any = {}) => {
-    if (runOptions.background) {
+    if (command.includes(".launch.sh")) {
       return { exitCode: 0, stdout: "", stderr: "" };
     }
 
@@ -131,6 +131,10 @@ function mockCommandLifecycle(options: {
 }
 
 describe("sandbox command tools", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockCommandLifecycle();
@@ -159,7 +163,7 @@ describe("sandbox command tools", () => {
       expect.stringContaining("nohup bash -c 'true'"),
       expect.objectContaining({
         cwd: "/home/user",
-        background: true,
+        timeoutMs: 5_000,
       }),
     );
     const waitCall = sandboxMocks.commandRun.mock.calls.find(([, options]) =>
@@ -228,7 +232,7 @@ describe("sandbox command tools", () => {
       expect.stringContaining("nohup bash -c 'sleep 300'"),
       expect.objectContaining({
         cwd: "/home/user/repo",
-        background: true,
+        timeoutMs: 5_000,
         envs: expect.objectContaining({
           FOO: "bar",
           SLACK_USER_ID: "U123",
@@ -246,6 +250,66 @@ describe("sandbox command tools", () => {
       workspaceId: "default",
     }));
     expect(toolMocks.markTurnSuspendedByDetachedCommand).toHaveBeenCalledWith(result.id);
+  });
+
+  it("waits for a slow detached pid file before returning", async () => {
+    let pidReads = 0;
+    sandboxMocks.commandRun.mockImplementation(async (command: string, runOptions: any = {}) => {
+      if (command.includes(".launch.sh")) {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+
+      if (command.startsWith("if [ -s ")) {
+        pidReads += 1;
+        if (pidReads < 4) {
+          throw new Error("pid not ready");
+        }
+        return { exitCode: 0, stdout: "9876\n", stderr: "" };
+      }
+
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command_detached as any;
+
+    const result = await tool.execute(tool.inputSchema.parse({ command: "sleep 300" }));
+
+    expect(result.pid).toBe(9876);
+    expect(pidReads).toBe(4);
+  });
+
+  it("includes launch diagnostics when a detached pid file is never written", async () => {
+    vi.useFakeTimers();
+    sandboxMocks.commandRun.mockImplementation(async (command: string, runOptions: any = {}) => {
+      if (command.includes(".launch.sh")) {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+
+      if (command.startsWith("if [ -s ")) {
+        throw new Error("pid missing");
+      }
+
+      if (runOptions.envs?.AURA_LAUNCH_DIAGNOSTICS) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            launcher_pid: "1234",
+            launch_stderr: "nohup: failed to run command 'bash': Permission denied",
+          }),
+          stderr: "",
+        };
+      }
+
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command_detached as any;
+
+    const resultPromise = tool.execute(tool.inputSchema.parse({ command: "sleep 300" }));
+    await vi.advanceTimersByTimeAsync(20_000);
+    const result = await resultPromise;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("did not write a pid file");
+    expect(result.error).toContain("launch stderr: nohup: failed to run command 'bash': Permission denied");
   });
 
   it("warns once when detached command webhook env vars are missing", async () => {
@@ -315,6 +379,38 @@ describe("sandbox command tools", () => {
 });
 
 describe("detached command wrapper callback", () => {
+  it("creates the missing background directory from the launch command", async () => {
+    const script = buildDetachedLaunchScript("feedbabe", "printf 'hello'", 1);
+
+    const { stdout } = await execFileAsync("bash", ["-c", `
+rm -rf /tmp/aura-bg
+${script}
+for _ in {1..40}; do
+  if [ -s /tmp/aura-bg/feedbabe.pid ] && [ -s /tmp/aura-bg/feedbabe.status ]; then
+    break
+  fi
+  sleep 0.05
+done
+printf 'pid='
+cat /tmp/aura-bg/feedbabe.pid
+printf 'status='
+cat /tmp/aura-bg/feedbabe.status
+printf 'out='
+cat /tmp/aura-bg/feedbabe.out
+`], {
+      env: {
+        ...process.env,
+        AURA_PUBLIC_URL: "",
+        SANDBOX_WEBHOOK_SECRET: "",
+      },
+      timeout: 5_000,
+    });
+
+    expect(stdout).toMatch(/pid=\d+\n/);
+    expect(stdout).toContain("status=0\n");
+    expect(stdout).toContain("out=hello");
+  });
+
   it("posts signed completion payload with stdout and stderr tails", async () => {
     const secret = "wrapper-secret";
     const received: Array<{ body: string; signature: string }> = [];

--- a/apps/api/src/tools/sandbox.test.ts
+++ b/apps/api/src/tools/sandbox.test.ts
@@ -210,6 +210,46 @@ describe("sandbox command tools", () => {
     expect(result.error).toContain("Call check_command({id: '");
   });
 
+  it("returns stdout and exit code 0 for a trivial command", async () => {
+    mockCommandLifecycle({
+      inspectStatus: "exited",
+      exitCode: 0,
+      stdout: "hello\n",
+      stderr: "",
+    });
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command as any;
+
+    const result = await tool.execute(tool.inputSchema.parse({ command: "echo hello" }));
+
+    expect(result).toEqual({
+      ok: true,
+      exit_code: 0,
+      stdout: "hello\n",
+      stderr: undefined,
+    });
+  });
+
+  it("returns stderr and non-zero exit code for a failing command", async () => {
+    mockCommandLifecycle({
+      inspectStatus: "exited",
+      exitCode: 1,
+      stdout: "",
+      stderr: "real failure\n",
+    });
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command as any;
+
+    const result = await tool.execute(
+      tool.inputSchema.parse({ command: "printf 'real failure\\n' >&2; exit 1" }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      exit_code: 1,
+      stdout: "",
+      stderr: "real failure\n",
+    });
+  });
+
   it("starts detached commands and returns id, pid, and started_at", async () => {
     const tool = createSandboxTools({
       userId: "U123",

--- a/apps/api/src/tools/sandbox.test.ts
+++ b/apps/api/src/tools/sandbox.test.ts
@@ -160,10 +160,10 @@ describe("sandbox command tools", () => {
     await tool.execute(input);
 
     expect(sandboxMocks.commandRun).toHaveBeenCalledWith(
-      expect.stringContaining("nohup bash -c 'true'"),
+      expect.stringContaining("exec bash -c '\\''true'\\''"),
       expect.objectContaining({
-        cwd: "/home/user",
-        timeoutMs: 5_000,
+        cwd: "/tmp",
+        timeoutMs: 10_000,
       }),
     );
     const waitCall = sandboxMocks.commandRun.mock.calls.find(([, options]) =>
@@ -229,10 +229,10 @@ describe("sandbox command tools", () => {
     expect(result.pid).toBe(4321);
     expect(result.started_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(sandboxMocks.commandRun).toHaveBeenCalledWith(
-      expect.stringContaining("nohup bash -c 'sleep 300'"),
+      expect.stringContaining("cd '\\''/home/user/repo'\\'' && exec bash -c '\\''sleep 300'\\''"),
       expect.objectContaining({
-        cwd: "/home/user/repo",
-        timeoutMs: 5_000,
+        cwd: "/tmp",
+        timeoutMs: 10_000,
         envs: expect.objectContaining({
           FOO: "bar",
           SLACK_USER_ID: "U123",
@@ -312,6 +312,42 @@ describe("sandbox command tools", () => {
     expect(result.error).toContain("launch stderr: nohup: failed to run command 'bash': Permission denied");
   });
 
+  it("includes foreground launch stderr when the launcher exits non-zero", async () => {
+    sandboxMocks.commandRun.mockImplementation(async (command: string, runOptions: any = {}) => {
+      if (command.includes(".launch.sh")) {
+        const error = new Error("exit status 1") as Error & {
+          exitCode: number;
+          stdout: string;
+          stderr: string;
+        };
+        error.exitCode = 1;
+        error.stdout = "launch stdout";
+        error.stderr = "launch stderr";
+        throw error;
+      }
+
+      if (runOptions.envs?.AURA_LAUNCH_DIAGNOSTICS) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ launch_stderr: "diagnostic stderr" }),
+          stderr: "",
+        };
+      }
+
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    const tool = createSandboxTools({ userId: "U123" } as any).run_command_detached as any;
+
+    const result = await tool.execute(tool.inputSchema.parse({ command: "echo hello" }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("launch command failed");
+    expect(result.error).toContain("error: exit status 1");
+    expect(result.error).toContain("stderr: launch stderr");
+    expect(result.error).toContain("stdout: launch stdout");
+    expect(result.error).toContain("launch stderr: diagnostic stderr");
+  });
+
   it("warns once when detached command webhook env vars are missing", async () => {
     vi.resetModules();
     delete process.env.AURA_PUBLIC_URL;
@@ -380,11 +416,13 @@ describe("sandbox command tools", () => {
 
 describe("detached command wrapper callback", () => {
   it("creates the missing background directory from the launch command", async () => {
-    const script = buildDetachedLaunchScript("feedbabe", "printf 'hello'", 1);
+    const script = buildDetachedLaunchScript("feedbabe", "printf 'hello'", 1, "/tmp");
 
     const { stdout } = await execFileAsync("bash", ["-c", `
 rm -rf /tmp/aura-bg
+(
 ${script}
+)
 for _ in {1..40}; do
   if [ -s /tmp/aura-bg/feedbabe.pid ] && [ -s /tmp/aura-bg/feedbabe.status ]; then
     break
@@ -439,7 +477,7 @@ cat /tmp/aura-bg/feedbabe.out
 
     const oldPublicUrl = process.env.AURA_PUBLIC_URL;
     process.env.AURA_PUBLIC_URL = `http://127.0.0.1:${address.port}`;
-    const script = buildDetachedScript("deadbeef", "printf 'hello'; printf 'warn' >&2", 1);
+    const script = buildDetachedScript("deadbeef", "printf 'hello'; printf 'warn' >&2", 1, "/tmp");
 
     try {
       await execFileAsync("bash", ["-c", script], {

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -35,12 +35,17 @@ interface DetachedCommandStatus {
 }
 
 type DetachedCommandDbStatus = "running" | "completed" | "failed" | "killed";
+type CommandRunResult = { exitCode?: number; stdout?: string; stderr?: string };
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function backgroundPath(id: string, suffix: "out" | "err" | "pid" | "status" | "started_at") {
+  return `${BACKGROUND_COMMAND_DIR}/${id}.${suffix}`;
+}
+
+function backgroundFile(id: string, suffix: string) {
   return `${BACKGROUND_COMMAND_DIR}/${id}.${suffix}`;
 }
 
@@ -204,15 +209,15 @@ export function buildDetachedScript(id: string, command: string, startedAtEpoch:
   const callbackUrl = `${getPublicUrl()}/api/webhook/sandbox-command`;
 
   return [
-    `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)}`,
-    `rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)}`,
-    `printf '%s\\n' ${shellQuote(String(startedAtEpoch))} > ${shellQuote(startedAtPath)}`,
+    `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)} || exit $?`,
+    `rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)} || exit $?`,
+    `printf '%s\\n' ${shellQuote(String(startedAtEpoch))} > ${shellQuote(startedAtPath)} || exit $?`,
     `nohup bash -c ${shellQuote(command)} > ${shellQuote(stdoutPath)} 2> ${shellQuote(stderrPath)} &`,
     "pid=$!",
-    `printf '%s\\n' "$pid" > ${shellQuote(pidPath)}`,
+    `printf '%s\\n' "$pid" > ${shellQuote(pidPath)} || exit $?`,
     "wait \"$pid\"",
     "exit_code=$?",
-    `printf '%s\\n' "$exit_code" > ${shellQuote(statusPath)}`,
+    `printf '%s\\n' "$exit_code" > ${shellQuote(statusPath)} || exit $?`,
     `if [ -n "\${AURA_PUBLIC_URL:-}" ] && [ -n "\${SANDBOX_WEBHOOK_SECRET:-}" ]; then`,
     `  AURA_COMMAND_ID=${shellQuote(id)} AURA_EXIT_CODE="$exit_code" AURA_STDOUT_PATH=${shellQuote(stdoutPath)} AURA_STDERR_PATH=${shellQuote(stderrPath)} AURA_PAYLOAD_PATH=${shellQuote(payloadPath)} AURA_SIGNATURE_PATH=${shellQuote(signaturePath)} python3 - <<'PY'`,
     "import hashlib",
@@ -254,11 +259,118 @@ export function buildDetachedScript(id: string, command: string, startedAtEpoch:
   ].join("\n");
 }
 
-async function readDetachedPid(sandbox: Sandbox, id: string, envs: CommandEnv): Promise<number> {
+export function buildDetachedLaunchScript(id: string, command: string, startedAtEpoch: number): string {
+  const stdoutPath = backgroundPath(id, "out");
+  const stderrPath = backgroundPath(id, "err");
+  const pidPath = backgroundPath(id, "pid");
+  const statusPath = backgroundPath(id, "status");
+  const startedAtPath = backgroundPath(id, "started_at");
+  const payloadPath = backgroundFile(id, "callback.json");
+  const signaturePath = backgroundFile(id, "callback.sig");
+  const launchOutPath = backgroundFile(id, "launch.out");
+  const launchErrPath = backgroundFile(id, "launch.err");
+  const launchPidPath = backgroundFile(id, "launch.pid");
+  const launchScriptPath = backgroundFile(id, "launch.sh");
+  const heredocMarker = `AURA_DETACHED_${id.toUpperCase()}_SCRIPT`;
+
+  return [
+    "set -eu",
+    `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)}`,
+    `rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)} ${shellQuote(launchOutPath)} ${shellQuote(launchErrPath)} ${shellQuote(launchPidPath)} ${shellQuote(launchScriptPath)}`,
+    `cat > ${shellQuote(launchScriptPath)} <<'${heredocMarker}'`,
+    buildDetachedScript(id, command, startedAtEpoch),
+    heredocMarker,
+    `chmod 700 ${shellQuote(launchScriptPath)}`,
+    `nohup bash ${shellQuote(launchScriptPath)} > ${shellQuote(launchOutPath)} 2> ${shellQuote(launchErrPath)} < /dev/null &`,
+    "launcher_pid=$!",
+    `printf '%s\\n' "$launcher_pid" > ${shellQuote(launchPidPath)}`,
+  ].join("\n");
+}
+
+function formatCommandRunResult(result: CommandRunResult | undefined): string {
+  if (!result) return "";
+  const parts: string[] = [];
+  if (typeof result.exitCode === "number") parts.push(`exit code ${result.exitCode}`);
+  const stderr = truncateOutput((result.stderr || "").trim(), 1000);
+  const stdout = truncateOutput((result.stdout || "").trim(), 1000);
+  if (stderr) parts.push(`stderr: ${stderr}`);
+  if (stdout) parts.push(`stdout: ${stdout}`);
+  return parts.join("; ");
+}
+
+async function readDetachedLaunchDiagnostics(
+  sandbox: Sandbox,
+  id: string,
+  envs: CommandEnv,
+): Promise<string> {
+  const diagnosticsScript = `python3 - <<'PY'
+import json
+import os
+
+command_id = os.environ["AURA_COMMAND_ID"]
+base = f"${BACKGROUND_COMMAND_DIR}/{command_id}"
+
+def read_snippet(path, max_bytes=2000):
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as file:
+            if size <= max_bytes:
+                data = file.read()
+            else:
+                file.seek(-max_bytes, os.SEEK_END)
+                data = file.read()
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+print(json.dumps({
+    "launcher_pid": read_snippet(f"{base}.launch.pid", 200).strip(),
+    "launch_stdout": read_snippet(f"{base}.launch.out").strip(),
+    "launch_stderr": read_snippet(f"{base}.launch.err").strip(),
+    "user_stdout": read_snippet(f"{base}.out").strip(),
+    "user_stderr": read_snippet(f"{base}.err").strip(),
+    "status": read_snippet(f"{base}.status", 200).strip(),
+}))
+PY`;
+
+  const result = await sandbox.commands.run(diagnosticsScript, {
+    timeoutMs: 2_000,
+    envs: {
+      ...envs,
+      AURA_COMMAND_ID: id,
+      AURA_LAUNCH_DIAGNOSTICS: "1",
+    },
+  });
+
+  const parsed = JSON.parse((result.stdout || "{}").trim()) as Record<string, unknown>;
+  const parts: string[] = [];
+  for (const [label, key] of [
+    ["launcher pid", "launcher_pid"],
+    ["launch stderr", "launch_stderr"],
+    ["launch stdout", "launch_stdout"],
+    ["user stderr", "user_stderr"],
+    ["user stdout", "user_stdout"],
+    ["status", "status"],
+  ] as const) {
+    const value = parsed[key];
+    if (typeof value === "string" && value.trim()) {
+      parts.push(`${label}: ${truncateOutput(value.trim(), 1000)}`);
+    }
+  }
+
+  return parts.join("; ");
+}
+
+async function readDetachedPid(
+  sandbox: Sandbox,
+  id: string,
+  envs: CommandEnv,
+  launchResult?: CommandRunResult,
+): Promise<number> {
   const pidPath = backgroundPath(id, "pid");
   const readPidCommand = `if [ -s ${shellQuote(pidPath)} ]; then cat ${shellQuote(pidPath)}; else exit 1; fi`;
 
-  for (const delayMs of [0, 50, 100, 200, 400, 800]) {
+  for (const delayMs of [0, 50, 100, 200, 400, 800, 1_200, 1_800, 2_500, 3_500]) {
     if (delayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
@@ -275,7 +387,19 @@ async function readDetachedPid(sandbox: Sandbox, id: string, envs: CommandEnv): 
     }
   }
 
-  throw new Error(`Detached command ${id} did not write a pid file`);
+  const details: string[] = [];
+  const launchSummary = formatCommandRunResult(launchResult);
+  if (launchSummary) details.push(`launch result: ${launchSummary}`);
+  try {
+    const diagnostics = await readDetachedLaunchDiagnostics(sandbox, id, envs);
+    if (diagnostics) details.push(diagnostics);
+  } catch (error: any) {
+    details.push(`diagnostics failed: ${error.message}`);
+  }
+
+  throw new Error(
+    `Detached command ${id} did not write a pid file${details.length ? ` (${details.join("; ")})` : ""}`,
+  );
 }
 
 async function startDetachedCommand(options: {
@@ -288,13 +412,22 @@ async function startDetachedCommand(options: {
   const startedAtEpoch = Math.floor(Date.now() / 1000);
   const started_at = new Date(startedAtEpoch * 1000).toISOString();
 
-  await options.sandbox.commands.run(buildDetachedScript(id, options.command, startedAtEpoch), {
-    cwd: options.cwd,
-    background: true,
-    envs: options.envs,
-  });
+  const launchResult = await options.sandbox.commands.run(
+    buildDetachedLaunchScript(id, options.command, startedAtEpoch),
+    {
+      cwd: options.cwd,
+      timeoutMs: 5_000,
+      envs: options.envs,
+    },
+  );
+  if (typeof launchResult.exitCode === "number" && launchResult.exitCode !== 0) {
+    const detail = formatCommandRunResult(launchResult);
+    throw new Error(
+      `Detached command ${id} launch failed before pid file${detail ? ` (${detail})` : ""}`,
+    );
+  }
 
-  const pid = await readDetachedPid(options.sandbox, id, options.envs);
+  const pid = await readDetachedPid(options.sandbox, id, options.envs, launchResult);
 
   return { id, pid, started_at };
 }

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -874,7 +874,7 @@ export function createSandboxTools(context?: ScheduleContext) {
         try {
           const sandbox = await getOrCreateSandbox(userId);
           const envs = await getSandboxEnvs(userId);
-          const userHome = "/home/user";
+          const userHome = await ensureUserHome(sandbox, userId, envs);
           const commandEnv = {
             ...envs,
             ...(env ?? {}),

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -35,7 +35,7 @@ interface DetachedCommandStatus {
 }
 
 type DetachedCommandDbStatus = "running" | "completed" | "failed" | "killed";
-type CommandRunResult = { exitCode?: number; stdout?: string; stderr?: string };
+type CommandRunResult = { exitCode?: number; stdout?: string; stderr?: string; error?: string };
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -198,7 +198,12 @@ function statusFromDbRow(row: DetachedCommand, tailLineCount: number): DetachedC
   };
 }
 
-export function buildDetachedScript(id: string, command: string, startedAtEpoch: number): string {
+export function buildDetachedScript(
+  id: string,
+  command: string,
+  startedAtEpoch: number,
+  cwd = "/home/user",
+): string {
   const stdoutPath = backgroundPath(id, "out");
   const stderrPath = backgroundPath(id, "err");
   const pidPath = backgroundPath(id, "pid");
@@ -207,12 +212,13 @@ export function buildDetachedScript(id: string, command: string, startedAtEpoch:
   const payloadPath = `${BACKGROUND_COMMAND_DIR}/${id}.callback.json`;
   const signaturePath = `${BACKGROUND_COMMAND_DIR}/${id}.callback.sig`;
   const callbackUrl = `${getPublicUrl()}/api/webhook/sandbox-command`;
+  const commandInCwd = `cd ${shellQuote(cwd)} && exec bash -c ${shellQuote(command)}`;
 
   return [
     `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)} || exit $?`,
     `rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)} || exit $?`,
     `printf '%s\\n' ${shellQuote(String(startedAtEpoch))} > ${shellQuote(startedAtPath)} || exit $?`,
-    `nohup bash -c ${shellQuote(command)} > ${shellQuote(stdoutPath)} 2> ${shellQuote(stderrPath)} &`,
+    `nohup bash -c ${shellQuote(commandInCwd)} > ${shellQuote(stdoutPath)} 2> ${shellQuote(stderrPath)} &`,
     "pid=$!",
     `printf '%s\\n' "$pid" > ${shellQuote(pidPath)} || exit $?`,
     "wait \"$pid\"",
@@ -259,7 +265,12 @@ export function buildDetachedScript(id: string, command: string, startedAtEpoch:
   ].join("\n");
 }
 
-export function buildDetachedLaunchScript(id: string, command: string, startedAtEpoch: number): string {
+export function buildDetachedLaunchScript(
+  id: string,
+  command: string,
+  startedAtEpoch: number,
+  cwd = "/home/user",
+): string {
   const stdoutPath = backgroundPath(id, "out");
   const stderrPath = backgroundPath(id, "err");
   const pidPath = backgroundPath(id, "pid");
@@ -274,16 +285,26 @@ export function buildDetachedLaunchScript(id: string, command: string, startedAt
   const heredocMarker = `AURA_DETACHED_${id.toUpperCase()}_SCRIPT`;
 
   return [
-    "set -eu",
-    `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)}`,
-    `rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)} ${shellQuote(launchOutPath)} ${shellQuote(launchErrPath)} ${shellQuote(launchPidPath)} ${shellQuote(launchScriptPath)}`,
+    "set -u",
+    `if ! mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)}; then echo "failed to create ${BACKGROUND_COMMAND_DIR}" >&2; exit 1; fi`,
+    `if ! rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)} ${shellQuote(launchOutPath)} ${shellQuote(launchErrPath)} ${shellQuote(launchPidPath)} ${shellQuote(launchScriptPath)}; then echo "failed to clear previous command files in ${BACKGROUND_COMMAND_DIR}" >&2; exit 1; fi`,
     `cat > ${shellQuote(launchScriptPath)} <<'${heredocMarker}'`,
-    buildDetachedScript(id, command, startedAtEpoch),
+    buildDetachedScript(id, command, startedAtEpoch, cwd),
     heredocMarker,
-    `chmod 700 ${shellQuote(launchScriptPath)}`,
-    `nohup bash ${shellQuote(launchScriptPath)} > ${shellQuote(launchOutPath)} 2> ${shellQuote(launchErrPath)} < /dev/null &`,
-    "launcher_pid=$!",
-    `printf '%s\\n' "$launcher_pid" > ${shellQuote(launchPidPath)}`,
+    `if ! chmod 700 ${shellQuote(launchScriptPath)}; then echo "failed to chmod launch script ${launchScriptPath}" >&2; exit 1; fi`,
+    "if command -v setsid >/dev/null 2>&1; then",
+    `  if ! setsid -f bash ${shellQuote(launchScriptPath)} > ${shellQuote(launchOutPath)} 2> ${shellQuote(launchErrPath)} < /dev/null; then`,
+    `    echo "setsid failed to launch supervisor: $(cat ${shellQuote(launchErrPath)} 2>/dev/null)" >&2`,
+    "    exit 1",
+    "  fi",
+    `  printf '%s\\n' "setsid" > ${shellQuote(launchPidPath)}`,
+    "else",
+    `  nohup bash ${shellQuote(launchScriptPath)} > ${shellQuote(launchOutPath)} 2> ${shellQuote(launchErrPath)} < /dev/null &`,
+    "  launcher_pid=$!",
+    "  disown \"$launcher_pid\" 2>/dev/null || true",
+    `  printf '%s\\n' "$launcher_pid" > ${shellQuote(launchPidPath)}`,
+    "fi",
+    "exit 0",
   ].join("\n");
 }
 
@@ -291,11 +312,54 @@ function formatCommandRunResult(result: CommandRunResult | undefined): string {
   if (!result) return "";
   const parts: string[] = [];
   if (typeof result.exitCode === "number") parts.push(`exit code ${result.exitCode}`);
+  const error = truncateOutput((result.error || "").trim(), 1000);
   const stderr = truncateOutput((result.stderr || "").trim(), 1000);
   const stdout = truncateOutput((result.stdout || "").trim(), 1000);
+  if (error) parts.push(`error: ${error}`);
   if (stderr) parts.push(`stderr: ${stderr}`);
   if (stdout) parts.push(`stdout: ${stdout}`);
   return parts.join("; ");
+}
+
+function commandRunResultFromError(error: any): CommandRunResult {
+  return {
+    exitCode: typeof error?.exitCode === "number" ? error.exitCode : undefined,
+    stdout: typeof error?.stdout === "string" ? error.stdout : "",
+    stderr: typeof error?.stderr === "string" ? error.stderr : "",
+    error: error?.message ? String(error.message) : String(error),
+  };
+}
+
+async function runCommandWithCapturedOutput(
+  sandbox: Sandbox,
+  command: string,
+  options: {
+    cwd?: string;
+    timeoutMs?: number;
+    envs: CommandEnv;
+  },
+): Promise<CommandRunResult> {
+  let stdout = "";
+  let stderr = "";
+  try {
+    return await sandbox.commands.run(command, {
+      ...options,
+      onStdout: (chunk: string) => {
+        stdout += chunk;
+      },
+      onStderr: (chunk: string) => {
+        stderr += chunk;
+      },
+    } as any);
+  } catch (error: any) {
+    const result = commandRunResultFromError(error);
+    result.stdout ||= stdout;
+    result.stderr ||= stderr;
+    throw Object.assign(
+      new Error(formatCommandRunResult(result) || result.error || "command failed"),
+      result,
+    );
+  }
 }
 
 async function readDetachedLaunchDiagnostics(
@@ -412,14 +476,27 @@ async function startDetachedCommand(options: {
   const startedAtEpoch = Math.floor(Date.now() / 1000);
   const started_at = new Date(startedAtEpoch * 1000).toISOString();
 
-  const launchResult = await options.sandbox.commands.run(
-    buildDetachedLaunchScript(id, options.command, startedAtEpoch),
-    {
-      cwd: options.cwd,
-      timeoutMs: 5_000,
+  const launchCommand = buildDetachedLaunchScript(id, options.command, startedAtEpoch, options.cwd);
+  let launchResult: CommandRunResult;
+  try {
+    launchResult = await runCommandWithCapturedOutput(options.sandbox, launchCommand, {
+      cwd: "/tmp",
+      timeoutMs: 10_000,
       envs: options.envs,
-    },
-  );
+    });
+  } catch (error: any) {
+    const launchError = commandRunResultFromError(error);
+    let diagnostics = "";
+    try {
+      diagnostics = await readDetachedLaunchDiagnostics(options.sandbox, id, options.envs);
+    } catch (diagnosticError: any) {
+      diagnostics = `diagnostics failed: ${diagnosticError.message}`;
+    }
+    const detail = [formatCommandRunResult(launchError), diagnostics].filter(Boolean).join("; ");
+    throw new Error(
+      `Detached command ${id} launch command failed${detail ? ` (${detail})` : ""}`,
+    );
+  }
   if (typeof launchResult.exitCode === "number" && launchResult.exitCode !== 0) {
     const detail = formatCommandRunResult(launchResult);
     throw new Error(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Incident: Aura sandbox command execution failed at launch for every command because the detached supervisor never produced `/tmp/aura-bg/<id>.pid`; the first #1157 preview changed that into a foreground launcher / command `exit status 1`, so this PR now fixes both the launcher and its diagnostics.

## Latest live-preview follow-up

Preview evidence showed the first #1157 change still failed every command with `Command execution failed: exit status 1` and no stderr. I inspected the generated launcher. For `echo hello`, the relevant command string was:

```sh
set -u
if ! mkdir -p '/tmp/aura-bg'; then echo "failed to create /tmp/aura-bg" >&2; exit 1; fi
if ! rm -f '/tmp/aura-bg/deadbeef.out' '/tmp/aura-bg/deadbeef.err' '/tmp/aura-bg/deadbeef.pid' '/tmp/aura-bg/deadbeef.status' '/tmp/aura-bg/deadbeef.started_at' '/tmp/aura-bg/deadbeef.callback.json' '/tmp/aura-bg/deadbeef.callback.sig' '/tmp/aura-bg/deadbeef.launch.out' '/tmp/aura-bg/deadbeef.launch.err' '/tmp/aura-bg/deadbeef.launch.pid' '/tmp/aura-bg/deadbeef.launch.sh'; then echo "failed to clear previous command files in /tmp/aura-bg" >&2; exit 1; fi
cat > '/tmp/aura-bg/deadbeef.launch.sh' <<'AURA_DETACHED_DEADBEEF_SCRIPT'
mkdir -p '/tmp/aura-bg' || exit $?
rm -f '/tmp/aura-bg/deadbeef.out' '/tmp/aura-bg/deadbeef.err' '/tmp/aura-bg/deadbeef.pid' '/tmp/aura-bg/deadbeef.status' '/tmp/aura-bg/deadbeef.started_at' '/tmp/aura-bg/deadbeef.callback.json' '/tmp/aura-bg/deadbeef.callback.sig' || exit $?
printf '%s\n' '1' > '/tmp/aura-bg/deadbeef.started_at' || exit $?
nohup bash -c 'cd '\''/home/user'\'' && exec bash -c '\''echo hello'\''' > '/tmp/aura-bg/deadbeef.out' 2> '/tmp/aura-bg/deadbeef.err' &
pid=$!
printf '%s\n' "$pid" > '/tmp/aura-bg/deadbeef.pid' || exit $?
wait "$pid"
exit_code=$?
printf '%s\n' "$exit_code" > '/tmp/aura-bg/deadbeef.status' || exit $?
...
AURA_DETACHED_DEADBEEF_SCRIPT
if ! chmod 700 '/tmp/aura-bg/deadbeef.launch.sh'; then echo "failed to chmod launch script /tmp/aura-bg/deadbeef.launch.sh" >&2; exit 1; fi
if command -v setsid >/dev/null 2>&1; then
  if ! setsid -f bash '/tmp/aura-bg/deadbeef.launch.sh' > '/tmp/aura-bg/deadbeef.launch.out' 2> '/tmp/aura-bg/deadbeef.launch.err' < /dev/null; then
    echo "setsid failed to launch supervisor: $(cat '/tmp/aura-bg/deadbeef.launch.err' 2>/dev/null)" >&2
    exit 1
  fi
  printf '%s\n' "setsid" > '/tmp/aura-bg/deadbeef.launch.pid'
else
  nohup bash '/tmp/aura-bg/deadbeef.launch.sh' > '/tmp/aura-bg/deadbeef.launch.out' 2> '/tmp/aura-bg/deadbeef.launch.err' < /dev/null &
  launcher_pid=$!
  disown "$launcher_pid" 2>/dev/null || true
  printf '%s\n' "$launcher_pid" > '/tmp/aura-bg/deadbeef.launch.pid'
fi
exit 0
```

Concrete exit-1 path:

- The user command was not just `echo hello`; it was wrapped as `cd '/home/user' && exec bash -c 'echo hello'`.
- If `/home/user` is not initialized/usable in the live sandbox, `cd '/home/user'` exits 1 before the user command runs. That makes even a no-op look like a command failure.
- `run_command` already called `ensureUserHome(...)`; `run_command_detached` still hard-coded `const userHome = "/home/user"`. The latest commit makes detached use the same `ensureUserHome(...)` path before building the command env and workdir.
- Foreground launch failures are separately captured via `onStdout`/`onStderr`, `CommandExitError.stdout`, `CommandExitError.stderr`, `CommandExitError.exitCode`, and `/tmp/aura-bg/<id>.launch.*` diagnostics, then wired into the tool error string.

Current behavior expected:

- Outer launcher runs from safe `cwd: "/tmp"`.
- User process runs in initialized `userHome` or explicit workdir via `cd '<workdir>' && exec bash -c '<user command>'`.
- `echo hello` should produce status `0` and stdout `hello\n`.
- A failing command should return non-zero exit code plus its real stderr.

## Phase 1 findings

- Throw site: `apps/api/src/tools/sandbox.ts`, in `readDetachedPid()`, threw `Detached command <id> did not write a pid file` after polling `/tmp/aura-bg/<id>.pid`.
- Pre-fix launch sequence:
  - `run_command` and `run_command_detached` both call `startDetachedCommand()`.
  - `startDetachedCommand()` invoked `sandbox.commands.run(buildDetachedScript(...), { cwd, background: true, envs })`.
  - The background wrapper script created `/tmp/aura-bg`, removed stale `<id>.*` files, wrote `<id>.started_at`, started `nohup bash -c <user command> > <id>.out 2> <id>.err &`, wrote `<id>.pid`, waited, wrote `<id>.status`, then optionally posted the webhook.
  - `readDetachedPid()` polled with a short fixed retry list (`0, 50, 100, 200, 400, 800ms`) and swallowed all read errors, so failures surfaced only as the opaque pid-file error.
- Regression-window history:
  - No sandbox runner changes in the June 11-13 window.
  - PR #1122 / commit `f404664c` only changed Slack streaming behavior in `respond.ts`.
  - PR #1034 / commit `d2335eaa` added detached-command webhook suspend/resume bookkeeping but did not alter launch mechanics.
  - PR #980 / commit `3eabed2e` introduced `run_command_detached`, `check_command`, the `background: true` outer wrapper launch, pid-file polling, and the exact throw site.

## E2B SDK version check

- No confirmed E2B SDK bump occurred in the Jun 8-14 committed deploy history.
- Current/pre-incident committed versions were already:
  - `apps/api/package.json`: `"e2b": "^2.12.1"`
  - `pnpm-lock.yaml`: resolved `version: 2.14.1`
- `e2b@2.14.1` was introduced much earlier by `b7f97269` / PR #696.
- npm metadata shows `e2b@2.29.1` was published Jun 11 and became `latest`, but Aura's committed pnpm lockfile still pins `2.14.1`. A package pin/revert is not supported by repo evidence.

## Verification

- `pnpm --filter aura-api test -- src/tools/sandbox.test.ts` (Vitest ran API suite: 44 files / 328 tests passed)
- `pnpm --filter aura-api typecheck`
- `pnpm typecheck`
- `npx tsc --noEmit` from `apps/api`
- Pre-push hook: API + dashboard typecheck passed

## Tests added/updated

- launch command creates `/tmp/aura-bg` when missing and still writes pid/status/output;
- slow pid-file appearance waits and succeeds;
- missing pid-file diagnostics include launch stderr;
- foreground launcher `CommandExitError` surfaces exit code, stdout, stderr, and launch diagnostics;
- `run_command({ command: "echo hello" })` returns exit code 0 and stdout `hello\n`;
- failing `run_command` returns non-zero exit code and real stderr.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e62ba94f-a0a3-4fd5-8bdc-4e30c4153ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e62ba94f-a0a3-4fd5-8bdc-4e30c4153ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

