### PR TITLE
fix(sandbox): self-heal full sandbox disk (real cause of the outage)

### DIFF
--- a/apps/api/src/lib/sandbox.ts
+++ b/apps/api/src/lib/sandbox.ts
@@ -11,6 +11,35 @@ const sandboxTemplateKey = (userId?: string) =>
   userId ? `e2b_sandbox_template_id:${userId}` : "e2b_sandbox_template_id";
 const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour -- autoPause handles inactivity
 const TOOLS_REPO_SETTING_KEY = "tools_repo";
+
+// Background-command bookkeeping dir (mirrors BACKGROUND_COMMAND_DIR in tools/sandbox.ts).
+// The launcher writes ~7 files per command here; without pruning it accumulates tens of
+// thousands of stale files over the lifetime of a long-lived sandbox.
+const BACKGROUND_COMMAND_DIR = "/tmp/aura-bg";
+
+// Disk-space self-heal thresholds for the persistent per-user sandbox. The root
+// filesystem is ~11 GiB; over weeks the pnpm store, package caches, repo checkouts and
+// /tmp bookkeeping fill it to 100%, after which every command fails at launch with
+// "No space left on device" (it can't even write the launcher script). On resume we
+// reclaim space when free disk drops below SOFT, and recreate the sandbox from scratch
+// if reclaim can't get it back above HARD.
+const DISK_RECLAIM_SOFT_KB = 1.5 * 1024 * 1024; // < 1.5 GiB free -> run reclaim
+const DISK_RECLAIM_HARD_KB = 512 * 1024; // < 512 MiB free after reclaim -> recreate
+
+// Best-effort, non-destructive disk reclamation. Only removes regenerable caches,
+// unreferenced pnpm store entries, apt artifacts, and stale background-command files.
+// User data under /home/user (repos, projects) and the GCS mount are left untouched.
+const DISK_RECLAIM_SCRIPT = [
+  "set +e",
+  `find ${BACKGROUND_COMMAND_DIR} -maxdepth 1 -type f -mmin +720 -delete 2>/dev/null`,
+  `rm -rf "$HOME/.cache/pip" "$HOME/.cache/pnpm" "$HOME/.cache/node" "$HOME/.cache/uv" "$HOME/.cache/ms-playwright" "$HOME/.cache/puppeteer" "$HOME/.npm/_cacache" 2>/dev/null`,
+  "if command -v pnpm >/dev/null 2>&1; then pnpm store prune >/dev/null 2>&1; fi",
+  "if command -v npm >/dev/null 2>&1; then npm cache clean --force >/dev/null 2>&1; fi",
+  "sudo apt-get clean >/dev/null 2>&1",
+  "sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /var/log/*.gz /var/log/*.1 2>/dev/null",
+  "true",
+].join("\n");
+
 const TOOLS_REPO_CHECKOUT_DIR_NAME = ["aura", "tools"].join("-");
 const TOOLS_REPO_CHECKOUT_PATH = `/home/user/${TOOLS_REPO_CHECKOUT_DIR_NAME}`;
 
@@ -101,6 +130,70 @@ export function clearCachedSandbox(): void {
 async function loadE2B() {
   const { Sandbox } = await import("e2b");
   return Sandbox;
+}
+
+/**
+ * Return free space on the sandbox root filesystem in KiB, or null if it
+ * can't be measured (in which case callers must not take destructive action).
+ */
+async function getRootDiskAvailKB(
+  sandbox: any,
+  envs: Record<string, string>,
+): Promise<number | null> {
+  try {
+    const result = await sandbox.commands.run("df -kP / | awk 'NR==2 {print $4}'", {
+      timeoutMs: 8_000,
+      envs,
+    });
+    const kb = Number.parseInt((result.stdout || "").trim(), 10);
+    return Number.isFinite(kb) ? kb : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort reclamation of regenerable disk space (caches, pnpm store,
+ * apt artifacts, stale /tmp/aura-bg bookkeeping). Never touches user data.
+ * Exported for reuse/testing.
+ */
+export async function reclaimSandboxDiskSpace(
+  sandbox: any,
+  envs: Record<string, string>,
+): Promise<void> {
+  try {
+    await sandbox.commands.run(DISK_RECLAIM_SCRIPT, { timeoutMs: 120_000, envs });
+  } catch (error: any) {
+    logger.warn("Sandbox disk reclaim command failed", { error: error.message });
+  }
+}
+
+/**
+ * Ensure the resumed sandbox has usable disk space. Reclaims regenerable space
+ * when free disk is low and reports whether the sandbox is usable afterwards.
+ * Returns false only when, after reclaiming, free space is still critically low
+ * (the caller should then recreate the sandbox from scratch).
+ */
+async function ensureSandboxDiskSpace(
+  sandbox: any,
+  envs: Record<string, string>,
+): Promise<boolean> {
+  const availBefore = await getRootDiskAvailKB(sandbox, envs);
+  if (availBefore === null) return true; // can't measure -> don't destroy a working sandbox
+  if (availBefore >= DISK_RECLAIM_SOFT_KB) return true;
+
+  logger.warn("Sandbox low on disk, reclaiming space", {
+    availMB: Math.round(availBefore / 1024),
+  });
+  await reclaimSandboxDiskSpace(sandbox, envs);
+
+  const availAfter = await getRootDiskAvailKB(sandbox, envs);
+  logger.info("Sandbox disk reclaim complete", {
+    beforeMB: Math.round(availBefore / 1024),
+    afterMB: availAfter === null ? null : Math.round(availAfter / 1024),
+  });
+  if (availAfter === null) return true;
+  return availAfter >= DISK_RECLAIM_HARD_KB;
 }
 
 function resolveSandboxEnvName(row: SandboxCredentialRow): string {
@@ -548,9 +641,28 @@ export async function getOrCreateSandbox(userId?: string): Promise<any> {
     }
 
     if (cachedSandbox) {
-      await setupSandboxFilesystem(cachedSandbox, envs);
-      await bootstrapToolsRepo(cachedSandbox, envs);
-      return cachedSandbox;
+      const diskOk = await ensureSandboxDiskSpace(cachedSandbox, envs);
+      if (diskOk) {
+        await setupSandboxFilesystem(cachedSandbox, envs);
+        await bootstrapToolsRepo(cachedSandbox, envs);
+        return cachedSandbox;
+      }
+
+      // Disk is still critically full after reclaiming regenerable space, so the
+      // resumed sandbox is effectively unusable (commands fail at launch with
+      // "No space left on device"). Discard it and fall through to create a fresh one.
+      logger.warn("Resumed sandbox disk unrecoverable, recreating from scratch", {
+        savedId,
+      });
+      try {
+        await Sandbox.kill(savedId, { apiKey });
+      } catch (e: any) {
+        logger.warn("Failed to kill disk-full sandbox (best-effort)", { error: e.message });
+      }
+      cachedSandbox = null;
+      cachedSandboxUserId = undefined;
+      userHomeReady.clear();
+      savedId = null;
     }
   }
 

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -205,6 +205,10 @@ export function buildDetachedScript(id: string, command: string, startedAtEpoch:
 
   return [
     `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)}`,
+    // Prune stale bookkeeping from prior commands so this dir can't accumulate tens of
+    // thousands of files and exhaust disk/inodes over the sandbox's lifetime. 12h is far
+    // beyond the longest detached job (max 750s) plus any polling/webhook window.
+    `find ${shellQuote(BACKGROUND_COMMAND_DIR)} -maxdepth 1 -type f -mmin +720 -delete 2>/dev/null || true`,
     `rm -f ${shellQuote(stdoutPath)} ${shellQuote(stderrPath)} ${shellQuote(pidPath)} ${shellQuote(statusPath)} ${shellQuote(startedAtPath)} ${shellQuote(payloadPath)} ${shellQuote(signaturePath)}`,
     `printf '%s\\n' ${shellQuote(String(startedAtEpoch))} > ${shellQuote(startedAtPath)}`,
     `nohup bash -c ${shellQuote(command)} > ${shellQuote(stdoutPath)} 2> ${shellQuote(stderrPath)} &`,
@@ -275,7 +279,22 @@ async function readDetachedPid(sandbox: Sandbox, id: string, envs: CommandEnv): 
     }
   }
 
-  throw new Error(`Detached command ${id} did not write a pid file`);
+  // The most common real-world cause of a missing pid file is a full root
+  // filesystem -- the launcher can't even write its bookkeeping. Surface disk
+  // state so the failure is diagnosable instead of opaque.
+  let diskHint = "";
+  try {
+    const df = await sandbox.commands.run(
+      `df -kP / | awk 'NR==2 {print $5" used, "$4" KiB free"}'`,
+      { timeoutMs: 3_000, envs },
+    );
+    const line = (df.stdout || "").trim();
+    if (line) diskHint = ` (sandbox root disk: ${line})`;
+  } catch {
+    // best-effort diagnostics only
+  }
+
+  throw new Error(`Detached command ${id} did not write a pid file${diskHint}`);
 }
 
 async function startDetachedCommand(options: {

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -279,22 +279,36 @@ async function readDetachedPid(sandbox: Sandbox, id: string, envs: CommandEnv): 
     }
   }
 
-  // The most common real-world cause of a missing pid file is a full root
-  // filesystem -- the launcher can't even write its bookkeeping. Surface disk
-  // state so the failure is diagnosable instead of opaque.
-  let diskHint = "";
+  // A missing pid file almost always means the launcher couldn't even write its
+  // bookkeeping (most often a full root filesystem). Surface the *actual* OS
+  // error string -- e.g. "No space left on device" -- instead of an opaque
+  // message, by probing a real write to the background dir and reading disk
+  // state. The probe captures stderr even when the disk is full (output goes to
+  // the pipe, not a file), so it generalizes to any launch failure.
+  const probePath = `${BACKGROUND_COMMAND_DIR}/${id}.probe`;
+  const diagnosticCommand = [
+    `mkdir -p ${shellQuote(BACKGROUND_COMMAND_DIR)} 2>/dev/null`,
+    `write_err=$({ : > ${shellQuote(probePath)}; } 2>&1)`,
+    `rm -f ${shellQuote(probePath)} 2>/dev/null`,
+    `disk=$(df -kP / | awk 'NR==2 {print $5" used, "$4" KiB free"}')`,
+    `printf '%s\\n%s\\n' "$write_err" "$disk"`,
+  ].join("; ");
+
+  let launchError = "";
+  let diskInfo = "";
   try {
-    const df = await sandbox.commands.run(
-      `df -kP / | awk 'NR==2 {print $5" used, "$4" KiB free"}'`,
-      { timeoutMs: 3_000, envs },
-    );
-    const line = (df.stdout || "").trim();
-    if (line) diskHint = ` (sandbox root disk: ${line})`;
+    const diag = await sandbox.commands.run(diagnosticCommand, { timeoutMs: 4_000, envs });
+    const lines = (diag.stdout || "").split("\n");
+    launchError = (lines[0] || "").trim();
+    diskInfo = lines.slice(1).join(" ").trim();
   } catch {
     // best-effort diagnostics only
   }
 
-  throw new Error(`Detached command ${id} did not write a pid file${diskHint}`);
+  const parts = [`Detached command ${id} did not write a pid file`];
+  if (launchError) parts.push(`launch error: ${launchError}`);
+  if (diskInfo) parts.push(`sandbox root disk: ${diskInfo}`);
+  throw new Error(parts.join("; "));
 }
 
 async function startDetachedCommand(options: {


### PR DESCRIPTION
## Summary

Sandboxes recently stopped working. The **real root cause** is that the persistent per-user E2B sandbox filled its ~11 GiB root filesystem to **100%**, after which the detached-command launcher can't even write `/tmp/aura-bg/<id>.launch.sh` and every command fails with **`No space left on device`** (surfacing as `exit status 1` / `did not write a pid file`).

I confirmed this against the live sandbox:

```
/dev/root  11G  10G  0  100% /
```

Top consumers: `~/.local/share/pnpm` (4.8 GiB pnpm store), `~/.cache` (641 MiB), `/home/user/aura` (1.2 GiB), and **16,381** stale `/tmp/aura-bg` bookkeeping files (the launcher writes ~7 files per command and never pruned old ones).

> Note: #1157 chased pid-file / `cd` launch mechanics and missed the disk-full cause. This PR fixes the actual problem.

## What changed

- **`lib/sandbox.ts` — disk self-heal on resume.** When a resumed sandbox has `< 1.5 GiB` free, reclaim regenerable space (package caches, `pnpm store prune`, apt artifacts, stale `aura-bg` files). If it's still `< 512 MiB` free after reclaim, kill it and create a fresh sandbox. User data under `/home/user` and the GCS mount are never touched.
- **`tools/sandbox.ts` — bound `/tmp/aura-bg`.** Prune files older than 12h on each launch (far beyond the 750s max detached job + polling window), so bookkeeping can no longer accumulate and exhaust disk/inodes. Also surface disk state in the pid-file failure message so this is diagnosable instead of opaque.

## Immediate remediation (already applied)

Reclaimed disk on the live incident sandbox so service is restored *now*: `pnpm store prune` + cache/aura-bg cleanup took it from **100% → 68% used (3.3 GiB free)** and `echo` runs cleanly. Once this merges, every other sandbox self-heals on its next resume.

## Test plan

- [x] `pnpm typecheck` (api + dashboard) green
- [x] `pnpm --filter aura-api test` — 320/320 pass (incl. sandbox tool tests with the new launcher prune line)
- [x] End-to-end against **live E2B** via the real `getOrCreateSandbox` + `run_command` path:
  - `echo hello-from-aura` → `{ ok: true, exit_code: 0, stdout: "hello-from-aura\n" }`
  - failing command → `exit_code: 2` with real stderr
  - write+read file → `persisted`
  - `df` parse + reclaim helpers work; `/tmp/aura-bg` stays bounded

Made with [Cursor](https://cursor.com)