### PR TITLE
eval: newest-first scoring, not_scorable prefilter, gold-set ratification CLI

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "content:index:no-embeddings": "tsx scripts/index-content.ts --skip-embeddings",
     "backfill:canonical-model-ids": "tsx scripts/backfill-canonical-model-ids.ts",
     "backfill:response-scores": "tsx src/scripts/backfill-response-scores.ts",
+    "ratify:gold-set": "tsx src/scripts/ratify-gold-set.ts",
     "bench:memory": "tsx src/scripts/bench-memory.ts",
     "bench:memory:i": "tsx src/scripts/bench-memory.ts --interactive",
     "bench:fetch-corpus": "tsx bench/scripts/fetch-corpus.ts",

--- a/apps/api/src/cron/eval-responses.test.ts
+++ b/apps/api/src/cron/eval-responses.test.ts
@@ -58,7 +58,7 @@ vi.mock("../eval/judge.js", () => ({
   judgeWindow: judgeWindowMock,
 }));
 
-import { scoreGroup } from "./eval-responses.js";
+import { scoreGroup, splitGroupBudget } from "./eval-responses.js";
 
 function traceRow(id: string, minute: number) {
   return {
@@ -120,7 +120,7 @@ describe("scoreGroup", () => {
       ],
       // parts
       [
-        { id: "pt-a1", messageId: "a1", type: "text", orderIndex: 0, textValue: "done", toolName: null },
+        { id: "pt-a1", messageId: "a1", type: "text", orderIndex: 0, textValue: "Here is the completed analysis.", toolName: null },
       ],
       // already-scored rows
       [],
@@ -134,7 +134,7 @@ describe("scoreGroup", () => {
 
     const result = await scoreGroup(GROUP, Date.now() + 60_000);
 
-    expect(result).toEqual({ windowsJudged: 1, responsesScored: 1, omitted: 0 });
+    expect(result).toEqual({ windowsJudged: 1, responsesScored: 1, prefiltered: 0, omitted: 0 });
     expect(dbMock.insertedRows).toHaveLength(1);
     expect(dbMock.insertedRows[0]).toMatchObject({
       workspaceId: "default",
@@ -200,7 +200,7 @@ describe("scoreGroup", () => {
     const result = await scoreGroup(GROUP, Date.now() + 60_000);
 
     expect(judgeWindowMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ windowsJudged: 0, responsesScored: 0, omitted: 0 });
+    expect(result).toEqual({ windowsJudged: 0, responsesScored: 0, prefiltered: 0, omitted: 0 });
     expect(dbMock.insertedRows).toHaveLength(0);
   });
 
@@ -221,5 +221,54 @@ describe("scoreGroup", () => {
 
     expect(judgeWindowMock).not.toHaveBeenCalled();
     expect(result.responsesScored).toBe(0);
+  });
+
+  it("prefilters obvious non-scorable acks but keeps them as judge context", async () => {
+    dbMock.results = [
+      [traceRow("t1", 0)],
+      [
+        messageRow("u1", "t1", "user", 1, "start this"),
+        messageRow("a1", "t1", "assistant", 2),
+        messageRow("u2", "t1", "user", 3, "any update?"),
+        messageRow("a2", "t1", "assistant", 4),
+      ],
+      [
+        { id: "pt-a1", messageId: "a1", type: "text", orderIndex: 0, textValue: "On it.", toolName: null },
+        { id: "pt-a2", messageId: "a2", type: "text", orderIndex: 0, textValue: "The migration is ready in PR 123.", toolName: null },
+      ],
+      [],
+    ];
+    judgeWindowMock.mockImplementation(async (window: { ownedPartIds: string[] }) => ({
+      judged: new Map(window.ownedPartIds.map((id: string) => [id, fulfilledVerdict(id)])),
+      judgeModel: "judge-model",
+      unknownIds: [],
+      omittedIds: [],
+    }));
+
+    const result = await scoreGroup(GROUP, Date.now() + 60_000);
+
+    expect(judgeWindowMock).toHaveBeenCalledTimes(1);
+    const windowArg = judgeWindowMock.mock.calls[0][0];
+    expect(windowArg.ownedPartIds).toEqual(["pt-a2"]);
+    expect(windowArg.turns.map((turn: { text: string }) => turn.text)).toContain("On it.");
+    expect(dbMock.insertedRows).toHaveLength(2);
+    expect(dbMock.insertedRows[0]).toMatchObject({
+      messageId: "a1",
+      partId: "pt-a1",
+      scorable: false,
+      verdict: null,
+      failureClass: "none",
+      judgeModel: "prefilter-v1",
+      note: "prefilter-v1: pure_ack",
+    });
+    expect(result).toEqual({ windowsJudged: 1, responsesScored: 2, prefiltered: 1, omitted: 0 });
+  });
+});
+
+describe("eval-responses group budgeting", () => {
+  it("allocates 80 percent to newest-first scoring and 20 percent to backfill", () => {
+    expect(splitGroupBudget(40)).toEqual({ newest: 32, oldest: 8 });
+    expect(splitGroupBudget(10)).toEqual({ newest: 8, oldest: 2 });
+    expect(splitGroupBudget(1)).toEqual({ newest: 1, oldest: 0 });
   });
 });

--- a/apps/api/src/cron/eval-responses.ts
+++ b/apps/api/src/cron/eval-responses.ts
@@ -1,17 +1,17 @@
 /**
  * Overnight eval batch (Machine A of the eval funnel).
  *
- * Walks forward from the start of the conversation corpus and scores every
- * not-yet-scored assistant response exactly once: thread → turns → 20-turn
- * sliding windows → one fast-tier judge call per window → one
- * eval_response_scores row per response, mapped by echoed part_id.
+ * Scores settled, not-yet-scored assistant responses exactly once. The nightly
+ * cron prioritizes newest threads while trickling historical backfill:
+ * thread -> turns -> 20-turn sliding windows -> one fast-tier judge call per
+ * window -> one eval_response_scores row per response, mapped by echoed part_id.
  *
  * Idempotent: a unique (workspace_id, message_id) index + onConflictDoNothing
  * means re-runs never duplicate or overwrite verdicts. Re-scoring happens only
  * via explicit human/harness action (delete the rows), never on read.
  */
 import { Hono } from "hono";
-import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   conversationMessages,
   conversationParts,
@@ -22,6 +22,7 @@ import {
 import { db } from "../db/client.js";
 import { logger } from "../lib/logger.js";
 import { judgeWindow } from "../eval/judge.js";
+import { PREFILTER_JUDGE_MODEL, prefilterNotScorable } from "../eval/prefilter.js";
 import { buildTurns, buildWindows, type EvalTurn } from "../eval/windowing.js";
 
 export const evalResponsesApp = new Hono();
@@ -41,12 +42,30 @@ interface UnscoredGroup {
   firstAt: Date;
 }
 
+type ScoringDirection = "asc" | "desc";
+
+function groupIdentity(group: UnscoredGroup): string {
+  return `${group.channelId ?? ""}::${group.threadTs ?? group.soleTraceId}`;
+}
+
+export function splitGroupBudget(maxGroups: number): {
+  newest: number;
+  oldest: number;
+} {
+  const newest = Math.max(1, Math.floor(maxGroups * 0.8));
+  return { newest, oldest: Math.max(0, maxGroups - newest) };
+}
+
 /**
  * Find thread groups (channel_id + thread_ts, or the bare trace for
  * thread-less invocations like job executions) that still contain unscored
- * assistant responses, oldest first — the forward walk from corpus start.
+ * assistant responses, newest first for the daily scorer or oldest first for
+ * the historical backfill trickle.
  */
-export async function findUnscoredGroups(limit: number): Promise<UnscoredGroup[]> {
+export async function findUnscoredGroups(
+  limit: number,
+  direction: ScoringDirection = "asc",
+): Promise<UnscoredGroup[]> {
   const groupKey = sql<string>`coalesce(${conversationTraces.channelId}, '') || '::' || coalesce(${conversationTraces.threadTs}, ${conversationTraces.id}::text)`;
   const settledBefore = new Date(Date.now() - SETTLE_MS);
 
@@ -80,7 +99,11 @@ export async function findUnscoredGroups(limit: number): Promise<UnscoredGroup[]
     )
     .groupBy(groupKey)
     .having(sql`max(${conversationMessages.createdAt}) < ${settledBefore.toISOString()}`)
-    .orderBy(sql`min(${conversationTraces.createdAt}) asc`)
+    .orderBy(
+      direction === "asc"
+        ? asc(sql`min(${conversationTraces.createdAt})`)
+        : desc(sql`min(${conversationTraces.createdAt})`),
+    )
     .limit(limit);
 
   return rows.map((row) => ({
@@ -91,9 +114,30 @@ export async function findUnscoredGroups(limit: number): Promise<UnscoredGroup[]
   }));
 }
 
+export async function findUnscoredGroupsForRun(
+  maxGroups: number,
+): Promise<UnscoredGroup[]> {
+  const { newest, oldest } = splitGroupBudget(maxGroups);
+  const [newestGroups, oldestGroups] = await Promise.all([
+    findUnscoredGroups(newest, "desc"),
+    oldest > 0 ? findUnscoredGroups(oldest, "asc") : Promise.resolve([]),
+  ]);
+
+  const seen = new Set<string>();
+  const groups: UnscoredGroup[] = [];
+  for (const group of [...newestGroups, ...oldestGroups]) {
+    const key = groupIdentity(group);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    groups.push(group);
+  }
+  return groups;
+}
+
 interface GroupResult {
   windowsJudged: number;
   responsesScored: number;
+  prefiltered: number;
   omitted: number;
 }
 
@@ -118,7 +162,8 @@ export async function scoreGroup(
         .from(conversationTraces)
         .where(eq(conversationTraces.id, group.soleTraceId));
 
-  if (traces.length === 0) return { windowsJudged: 0, responsesScored: 0, omitted: 0 };
+  if (traces.length === 0)
+    return { windowsJudged: 0, responsesScored: 0, prefiltered: 0, omitted: 0 };
   const traceById = new Map(traces.map((t) => [t.id, t]));
   const traceIds = traces.map((t) => t.id);
 
@@ -134,7 +179,8 @@ export async function scoreGroup(
     .orderBy(asc(conversationMessages.orderIndex));
 
   const messageIds = messages.map((m) => m.id);
-  if (messageIds.length === 0) return { windowsJudged: 0, responsesScored: 0, omitted: 0 };
+  if (messageIds.length === 0)
+    return { windowsJudged: 0, responsesScored: 0, prefiltered: 0, omitted: 0 };
 
   const parts = await db
     .select({
@@ -169,7 +215,42 @@ export async function scoreGroup(
     ? `${group.channelId ?? ""}::${group.threadTs}`
     : group.soleTraceId;
 
-  const result: GroupResult = { windowsJudged: 0, responsesScored: 0, omitted: 0 };
+  const result: GroupResult = {
+    windowsJudged: 0,
+    responsesScored: 0,
+    prefiltered: 0,
+    omitted: 0,
+  };
+
+  const prefilterRows: NewEvalResponseScore[] = [];
+  for (const turn of turns) {
+    if (!turn.partId || scoredMessageIds.has(turn.messageId)) continue;
+    const prefilter = prefilterNotScorable(turn);
+    if (!prefilter) continue;
+
+    const trace = traceById.get(turn.traceId);
+    prefilterRows.push({
+      workspaceId: trace?.workspaceId ?? "default",
+      messageId: turn.messageId,
+      partId: turn.partId,
+      traceId: turn.traceId,
+      threadTs: trace?.threadTs ?? null,
+      servingIntent: null,
+      resolvedInWindow: false,
+      verdict: null,
+      scorable: false,
+      failureClass: "none",
+      note: prefilter.note,
+      judgeModel: PREFILTER_JUDGE_MODEL,
+    });
+  }
+
+  if (prefilterRows.length > 0) {
+    await db.insert(evalResponseScores).values(prefilterRows).onConflictDoNothing();
+    for (const row of prefilterRows) scoredMessageIds.add(row.messageId);
+    result.responsesScored += prefilterRows.length;
+    result.prefiltered += prefilterRows.length;
+  }
 
   for (const window of buildWindows(turns)) {
     // Only score responses that don't already own a verdict; previously
@@ -244,12 +325,13 @@ evalResponsesApp.get("/api/cron/eval-responses", async (c) => {
   const deadline = start + TIME_BUDGET_MS;
 
   try {
-    const groups = await findUnscoredGroups(maxGroups);
+    const groups = await findUnscoredGroupsForRun(maxGroups);
     logger.info("Cron: eval-responses starting", { groups: groups.length, maxGroups });
 
     let groupsProcessed = 0;
     let windowsJudged = 0;
     let responsesScored = 0;
+    let prefiltered = 0;
     let omitted = 0;
 
     for (const group of groups) {
@@ -259,6 +341,7 @@ evalResponsesApp.get("/api/cron/eval-responses", async (c) => {
         groupsProcessed += 1;
         windowsJudged += result.windowsJudged;
         responsesScored += result.responsesScored;
+        prefiltered += result.prefiltered;
         omitted += result.omitted;
       } catch (error) {
         // One broken thread must not block the forward walk.
@@ -282,6 +365,7 @@ evalResponsesApp.get("/api/cron/eval-responses", async (c) => {
       groupsProcessed,
       windowsJudged,
       responsesScored,
+      prefiltered,
       omitted,
       done,
     });
@@ -293,6 +377,7 @@ evalResponsesApp.get("/api/cron/eval-responses", async (c) => {
       groupsProcessed,
       windowsJudged,
       responsesScored,
+      prefiltered,
       omitted,
       done,
     });

--- a/apps/api/src/eval/judge.test.ts
+++ b/apps/api/src/eval/judge.test.ts
@@ -174,4 +174,44 @@ describe("judgeWindow verdict normalization", () => {
     expect(callArgs.prompt).toContain("[R:bbb]");
     expect(callArgs.temperature).toBe(0);
   });
+
+  it("supports honest capability-boundary refusals as partial/fulfilled instead of failed", async () => {
+    const window: EvalWindow = {
+      turns: [
+        {
+          role: "user",
+          messageId: "u1",
+          partId: null,
+          traceId: "t1",
+          text: "Can you pull the private payroll report?",
+          userId: "U123",
+          createdAt: null,
+          toolNames: [],
+        },
+        {
+          ...assistantTurn("aaa"),
+          text: "I can't access payroll because I don't have the required credentials.",
+        },
+      ],
+      ownedPartIds: ["aaa"],
+    };
+    const generate = generateReturning([
+      entry("aaa", {
+        verdict: "partial",
+        failure_class: "missing_cred",
+        note: "Aura honestly identified the missing credential instead of pretending the report was available.",
+      }),
+    ]);
+
+    const result = await judgeWindow(window, { generate });
+
+    expect(result.judged.get("aaa")).toMatchObject({
+      scorable: true,
+      verdict: "partial",
+      failureClass: "missing_cred",
+    });
+    const callArgs = generate.mock.calls[0][0];
+    expect(callArgs.system).toContain("Honest refusals and capability boundaries");
+    expect(callArgs.system).toContain("Use failed only for incorrect, silent, or confabulated behavior");
+  });
 });

--- a/apps/api/src/eval/judge.ts
+++ b/apps/api/src/eval/judge.ts
@@ -89,6 +89,8 @@ Per response, decide:
 
 4. **resolved_in_window** — true when THIS turn hedged or said it couldn't do something yet, but the intent visibly closed later within the window (e.g. the user supplied missing context two turns later and the work got done). An honest hedge that resolves is fulfilled/partial, NOT failed. A confident answer that sounds fine but is unsupported is failed even if nobody complained.
 
+Honest refusals and capability boundaries are not failures by themselves. When Aura accurately says it cannot do something because it lacks a visible credential, permission, tool, or capability, score the turn as fulfilled or partial with failure_class = missing_cred or missing_tool as appropriate. Use failed only for incorrect, silent, or confabulated behavior: claiming the task was done when it was not, refusing something the visible tools could do, or hiding the real limitation.
+
 5. **failure_class** (for partial/failed):
    - missing_cred — lacked credentials/permissions/access to a system it needed.
    - bad_memory — forgot, misremembered, or failed to recall context it had been given.

--- a/apps/api/src/eval/prefilter.test.ts
+++ b/apps/api/src/eval/prefilter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { prefilterNotScorable } from "./prefilter.js";
+import type { EvalTurn } from "./windowing.js";
+
+function assistantTurn(text: string, overrides: Partial<EvalTurn> = {}): EvalTurn {
+  return {
+    role: "assistant",
+    messageId: "m1",
+    partId: "p1",
+    traceId: "t1",
+    text,
+    userId: null,
+    createdAt: null,
+    toolNames: [],
+    ...overrides,
+  };
+}
+
+describe("prefilterNotScorable", () => {
+  it("catches pure acknowledgement turns", () => {
+    expect(prefilterNotScorable(assistantTurn("On it."))).toMatchObject({
+      rule: "pure_ack",
+    });
+    expect(prefilterNotScorable(assistantTurn("thanks"))).toMatchObject({
+      rule: "pure_ack",
+    });
+  });
+
+  it("catches obvious progress/status pings", () => {
+    expect(prefilterNotScorable(assistantTurn("I'll take a look and get back to you."))).toMatchObject({
+      rule: "progress_ping",
+    });
+    expect(prefilterNotScorable(assistantTurn("Looking into this now"))).toMatchObject({
+      rule: "progress_ping",
+    });
+    expect(
+      prefilterNotScorable(
+        assistantTurn("Now let me compose and send the digest.", {
+          toolNames: ["search_slack"],
+        }),
+      ),
+    ).toMatchObject({
+      rule: "operational_status",
+    });
+  });
+
+  it("catches pure reaction emoji without treating substantive text as a reaction", () => {
+    expect(prefilterNotScorable(assistantTurn(":white_check_mark:"))).toMatchObject({
+      rule: "pure_reaction",
+    });
+    expect(prefilterNotScorable(assistantTurn("\u2705"))).toMatchObject({
+      rule: "pure_reaction",
+    });
+    expect(prefilterNotScorable(assistantTurn(":white_check_mark: deployed"))).toBeNull();
+  });
+
+  it("keeps terse completed work and tool-backed status visible to the judge", () => {
+    expect(prefilterNotScorable(assistantTurn("yes, merged, commit be511f4"))).toBeNull();
+    expect(
+      prefilterNotScorable(
+        assistantTurn("Done", { toolNames: ["github_create_pull_request"] }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/eval/prefilter.ts
+++ b/apps/api/src/eval/prefilter.ts
@@ -1,0 +1,148 @@
+import type { EvalTurn } from "./windowing.js";
+
+export const PREFILTER_JUDGE_MODEL = "prefilter-v1";
+
+export interface PrefilterResult {
+  scorable: false;
+  rule: string;
+  note: string;
+}
+
+const PURE_ACKS = new Set([
+  "done",
+  "got it",
+  "ok",
+  "okay",
+  "on it",
+  "sure",
+  "sure thing",
+  "thanks",
+  "thank you",
+  "will do",
+]);
+
+const WAITING_PHRASES = new Set([
+  "give me a minute",
+  "give me a moment",
+  "hang on",
+  "one moment",
+  "one sec",
+  "one second",
+]);
+
+function trimForMatching(text: string): string {
+  return text
+    .trim()
+    .replace(/\s+/g, " ")
+    .replace(/^[\s"'`*_~.,!?:;()[\]{}<>-]+|[\s"'`*_~.,!?:;()[\]{}<>-]+$/g, "")
+    .toLowerCase();
+}
+
+function hasToolEvidence(turn: EvalTurn): boolean {
+  return turn.toolNames.length > 0;
+}
+
+function isPureReaction(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > 80) return false;
+
+  const slackEmoji = /:[a-z0-9_+\-]+:/gi;
+  const withoutSlackEmoji = trimmed.replace(slackEmoji, "");
+  if (withoutSlackEmoji.trim().length === 0) return true;
+
+  return /^(?:[\s.,!?+\-_*~`'"()[\]{}<>]|\p{Extended_Pictographic}|\p{Emoji_Presentation}|\uFE0F|\u200D)+$/u.test(
+    withoutSlackEmoji,
+  );
+}
+
+function isProgressPing(normalized: string): boolean {
+  return (
+    /^(?:i(?:'|\u2019)?m |im )?(?:on it|checking|checking now|looking|looking now|looking into it|looking into this|taking a look|working on it)(?: now)?$/.test(
+      normalized,
+    ) ||
+    /^(?:i(?:'|\u2019)?ll|i will) (?:check|look into|take a look|dig into|investigate)(?: it| this| that)?(?: and (?:get back to you|report back|follow up))?$/.test(
+      normalized,
+    ) ||
+    /^let me (?:check|look|take a look|dig in|investigate)(?: it| this| that)?(?: and (?:i(?:'|\u2019)?ll )?(?:get back to you|report back|follow up))?$/.test(
+      normalized,
+    )
+  );
+}
+
+function isOperationalStatus(normalized: string): boolean {
+  if (normalized.length > 120) return false;
+
+  return (
+    /^(?:now )?let me (?:check|read|compose|send|build|compile|dispatch|commit|push|post|update|report|brief|dm|file|deploy|test|open|create|run)\b.+[:.]?$/.test(
+      normalized,
+    ) ||
+    /^(?:now )?(?:checking|reading|composing|sending|building|compiling|dispatching|committing|pushing|posting|updating|reporting|deploying|testing)\b.*[:.]?$/.test(
+      normalized,
+    ) ||
+    /^(?:good|clean|looks good|pr created|deployed|good data|there it is)\. (?:now )?(?:let me )?(?:commit|push|post|update|report|deploy|test|send|compile|dispatch)\b.+[:.]?$/.test(
+      normalized,
+    ) ||
+    /^i see .+\blet me check\b.+$/.test(normalized) ||
+    /^generic slackbot notification(?: again)? -- .*(?:nothing actionable|ignoring)\.?$/.test(
+      normalized,
+    )
+  );
+}
+
+/**
+ * Cheap, conservative not_scorable detector for obvious acks/progress pings.
+ *
+ * It intentionally avoids broad "short answer" rules: terse completions such
+ * as "yes, merged, commit be511f4" should keep going to the judge.
+ */
+export function prefilterNotScorable(turn: EvalTurn): PrefilterResult | null {
+  if (turn.role !== "assistant" || !turn.partId) return null;
+
+  const text = turn.text.trim();
+  if (!text) return null;
+
+  if (!hasToolEvidence(turn) && isPureReaction(text)) {
+    return {
+      scorable: false,
+      rule: "pure_reaction",
+      note: "prefilter-v1: pure_reaction",
+    };
+  }
+
+  const normalized = trimForMatching(text);
+  if (!normalized) return null;
+
+  if (!hasToolEvidence(turn) && PURE_ACKS.has(normalized)) {
+    return {
+      scorable: false,
+      rule: "pure_ack",
+      note: "prefilter-v1: pure_ack",
+    };
+  }
+
+  if (!hasToolEvidence(turn) && WAITING_PHRASES.has(normalized)) {
+    return {
+      scorable: false,
+      rule: "waiting_ping",
+      note: "prefilter-v1: waiting_ping",
+    };
+  }
+
+  if (isProgressPing(normalized)) {
+    return {
+      scorable: false,
+      rule: "progress_ping",
+      note: "prefilter-v1: progress_ping",
+    };
+  }
+
+  if (isOperationalStatus(normalized)) {
+    return {
+      scorable: false,
+      rule: "operational_status",
+      note: "prefilter-v1: operational_status",
+    };
+  }
+
+  return null;
+}

--- a/apps/api/src/scripts/backfill-response-scores.ts
+++ b/apps/api/src/scripts/backfill-response-scores.ts
@@ -62,12 +62,13 @@ let batch = 0;
 let totalGroups = 0;
 let totalWindows = 0;
 let totalScored = 0;
+let totalPrefiltered = 0;
 let totalOmitted = 0;
 let totalErrors = 0;
 
 while (batch < maxBatches) {
   batch++;
-  const groups = await findUnscoredGroups(groupsPerBatch);
+  const groups = await findUnscoredGroups(groupsPerBatch, "asc");
   if (groups.length === 0) {
     console.log("\nBacklog exhausted — every settled response is scored.");
     break;
@@ -94,9 +95,11 @@ while (batch < maxBatches) {
       totalGroups++;
       totalWindows += result.windowsJudged;
       totalScored += result.responsesScored;
+      totalPrefiltered += result.prefiltered;
       totalOmitted += result.omitted;
       console.log(
         `  ${label}: ${result.responsesScored} scored across ${result.windowsJudged} window(s)` +
+          (result.prefiltered > 0 ? ` (${result.prefiltered} prefiltered)` : "") +
           (result.omitted > 0 ? ` (${result.omitted} omitted)` : ""),
       );
     } catch (error) {
@@ -113,6 +116,7 @@ console.log(`Batches: ${batch}`);
 console.log(`Thread groups processed: ${totalGroups}`);
 console.log(`Windows judged: ${totalWindows}`);
 console.log(`Responses scored: ${totalScored}`);
+console.log(`Prefiltered non-scorable: ${totalPrefiltered}`);
 console.log(`Judge omissions (stored non-scorable): ${totalOmitted}`);
 console.log(`Group errors: ${totalErrors}`);
 

--- a/apps/api/src/scripts/ratify-gold-set.ts
+++ b/apps/api/src/scripts/ratify-gold-set.ts
@@ -1,0 +1,312 @@
+/**
+ * Human ratification CLI for the eval response gold set (Machine A -> Machine B).
+ *
+ * Usage:
+ *   pnpm ratify:gold-set --list --limit 25
+ *   pnpm ratify:gold-set --list --failure-class bad_memory
+ *   pnpm ratify:gold-set --ratify <row_id> --gold "Expected answer" --rubric '{"must_do":["..."]}' --by "Name"
+ *   pnpm ratify:gold-set --export > ratified-eval-cases.json
+ */
+import { config } from "dotenv";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+import type { EvalFailureClass, EvalRubric } from "@aura/db/schema";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const isProd = process.argv.includes("--prod");
+config({ path: resolve(repoRoot, isProd ? ".env.production" : ".env.local") });
+if (isProd) console.error("Using .env.production (--prod)");
+
+function usage(): never {
+  console.error(`Usage:
+  pnpm ratify:gold-set --list [--failure-class bad_memory] [--limit N] [--prod]
+  pnpm ratify:gold-set --ratify <row_id> --gold "answer" --rubric '{"must_do":["..."]}' --by <name> [--prod]
+  pnpm ratify:gold-set --export [--prod]`);
+  process.exit(1);
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function readFlag(name: string): string | undefined {
+  const exact = `--${name}`;
+  const prefix = `${exact}=`;
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+    if (arg === exact) return process.argv[i + 1];
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  return undefined;
+}
+
+function readLimit(): number {
+  const value = Number(readFlag("limit") ?? 25);
+  return Number.isFinite(value) && value > 0 ? Math.min(Math.floor(value), 200) : 25;
+}
+
+function parseRubric(raw: string): EvalRubric {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    console.error(`Invalid --rubric JSON: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    console.error("--rubric must be a JSON object");
+    process.exit(1);
+  }
+  return parsed as EvalRubric;
+}
+
+function truncate(text: string | null | undefined, max = 180): string {
+  const normalized = (text ?? "").replace(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 3)}...`;
+}
+
+function slackThreadLink(channelId: string | null, threadTs: string | null): string | null {
+  if (!channelId || !threadTs) return null;
+  const domain = process.env.SLACK_WORKSPACE_DOMAIN || "realadvisor";
+  return `https://${domain}.slack.com/archives/${channelId}/p${threadTs.replace(/\D/g, "")}`;
+}
+
+const actionCount =
+  (hasFlag("list") ? 1 : 0) + (readFlag("ratify") ? 1 : 0) + (hasFlag("export") ? 1 : 0);
+if (actionCount !== 1) usage();
+
+const { and, asc, desc, eq, inArray, isNotNull, isNull, sql } = await import(
+  "drizzle-orm"
+);
+const {
+  conversationMessages,
+  conversationParts,
+  conversationTraces,
+  evalFailureClasses,
+  evalResponseScores,
+} = await import("@aura/db/schema");
+const { db } = await import("../db/client.js");
+const { buildTurns } = await import("../eval/windowing.js");
+
+function readFailureClass(): EvalFailureClass | undefined {
+  const raw = readFlag("failure-class");
+  if (!raw) return undefined;
+  if (!(evalFailureClasses as readonly string[]).includes(raw)) {
+    console.error(`Invalid --failure-class: ${raw}`);
+    process.exit(1);
+  }
+  return raw as EvalFailureClass;
+}
+
+async function listQueue() {
+  const failureClass = readFailureClass();
+  const conditions = [
+    eq(evalResponseScores.scorable, true),
+    sql`${evalResponseScores.verdict} in ('failed', 'partial')`,
+    isNull(evalResponseScores.ratifiedBy),
+  ];
+  if (failureClass) conditions.push(eq(evalResponseScores.failureClass, failureClass));
+
+  const rows = await db
+    .select({
+      id: evalResponseScores.id,
+      verdict: evalResponseScores.verdict,
+      failureClass: evalResponseScores.failureClass,
+      note: evalResponseScores.note,
+      servingIntent: evalResponseScores.servingIntent,
+      channelId: conversationTraces.channelId,
+      threadTs: evalResponseScores.threadTs,
+      traceCreatedAt: conversationTraces.createdAt,
+      text: conversationParts.textValue,
+    })
+    .from(evalResponseScores)
+    .innerJoin(conversationTraces, eq(evalResponseScores.traceId, conversationTraces.id))
+    .innerJoin(conversationParts, eq(evalResponseScores.partId, conversationParts.id))
+    .where(and(...conditions))
+    .orderBy(desc(conversationTraces.createdAt), desc(evalResponseScores.createdAt))
+    .limit(readLimit());
+
+  for (const row of rows) {
+    const link = slackThreadLink(row.channelId, row.threadTs);
+    console.log([
+      `id: ${row.id}`,
+      `verdict: ${row.verdict}/${row.failureClass}`,
+      `created: ${row.traceCreatedAt.toISOString()}`,
+      `thread: ${link ?? "(no Slack thread link)"}`,
+      `intent: ${truncate(row.servingIntent, 240) || "(none)"}`,
+      `note: ${truncate(row.note, 300) || "(none)"}`,
+      `excerpt: ${truncate(row.text, 300) || "(empty)"}`,
+    ].join("\n"));
+    console.log("");
+  }
+  console.error(`Listed ${rows.length} ratification candidate(s).`);
+}
+
+async function ratifyOne() {
+  const rowId = readFlag("ratify");
+  const gold = readFlag("gold");
+  const rubricRaw = readFlag("rubric");
+  const by = readFlag("by");
+  if (!rowId || !gold || !rubricRaw || !by) usage();
+
+  const [updated] = await db
+    .update(evalResponseScores)
+    .set({
+      goldAnswer: gold,
+      rubric: parseRubric(rubricRaw),
+      ratifiedBy: by,
+    })
+    .where(
+      and(
+        eq(evalResponseScores.id, rowId),
+        eq(evalResponseScores.scorable, true),
+        sql`${evalResponseScores.verdict} in ('failed', 'partial')`,
+      ),
+    )
+    .returning({
+      id: evalResponseScores.id,
+      goldAnswer: evalResponseScores.goldAnswer,
+      rubric: evalResponseScores.rubric,
+      ratifiedBy: evalResponseScores.ratifiedBy,
+    });
+
+  if (!updated) {
+    console.error(`No failed/partial scorable eval_response_scores row found for ${rowId}`);
+    process.exit(1);
+  }
+  console.log(JSON.stringify(updated, null, 2));
+}
+
+type RatifiedRow = Awaited<ReturnType<typeof loadRatifiedRows>>[number];
+
+async function loadRatifiedRows() {
+  return db
+    .select({
+      score: evalResponseScores,
+      trace: conversationTraces,
+    })
+    .from(evalResponseScores)
+    .innerJoin(conversationTraces, eq(evalResponseScores.traceId, conversationTraces.id))
+    .where(
+      and(
+        eq(evalResponseScores.scorable, true),
+        sql`${evalResponseScores.verdict} in ('failed', 'partial')`,
+        isNotNull(evalResponseScores.ratifiedBy),
+        isNotNull(evalResponseScores.goldAnswer),
+      ),
+    )
+    .orderBy(desc(evalResponseScores.createdAt));
+}
+
+async function loadTurnsForRow(row: RatifiedRow) {
+  const traces = row.trace.threadTs
+    ? await db
+        .select()
+        .from(conversationTraces)
+        .where(
+          and(
+            sql`coalesce(${conversationTraces.channelId}, '') = ${row.trace.channelId ?? ""}`,
+            eq(conversationTraces.threadTs, row.trace.threadTs),
+          ),
+        )
+        .orderBy(asc(conversationTraces.createdAt))
+    : [row.trace];
+
+  const traceIds = traces.map((trace) => trace.id);
+  const messages = await db
+    .select()
+    .from(conversationMessages)
+    .where(
+      and(
+        inArray(conversationMessages.conversationId, traceIds),
+        inArray(conversationMessages.role, ["user", "assistant"]),
+      ),
+    )
+    .orderBy(asc(conversationMessages.orderIndex));
+
+  if (messages.length === 0) return [];
+
+  const parts = await db
+    .select()
+    .from(conversationParts)
+    .where(
+      and(
+        inArray(
+          conversationParts.messageId,
+          messages.map((message) => message.id),
+        ),
+        inArray(conversationParts.type, ["text", "tool-invocation"]),
+      ),
+    )
+    .orderBy(asc(conversationParts.orderIndex));
+
+  return buildTurns(traces, messages, parts);
+}
+
+async function exportRatified() {
+  const rows = await loadRatifiedRows();
+  const cases = [];
+
+  for (const row of rows) {
+    const turns = await loadTurnsForRow(row);
+    const targetIndex = turns.findIndex((turn) => turn.partId === row.score.partId);
+    const history = targetIndex >= 0 ? turns.slice(0, targetIndex) : turns;
+    let questionIndex = -1;
+    for (let i = history.length - 1; i >= 0; i--) {
+      if (history[i].role === "user") {
+        questionIndex = i;
+        break;
+      }
+    }
+
+    const questionTurn = questionIndex >= 0 ? history[questionIndex] : null;
+    const sessionTurns = history
+      .filter((_, idx) => idx !== questionIndex)
+      .map((turn) => ({
+        role: turn.role,
+        speaker: turn.role === "assistant" ? "Aura" : (turn.userId ?? "User"),
+        content: turn.text,
+      }));
+
+    const question = questionTurn
+      ? questionTurn.text
+      : (row.score.servingIntent ?? "Provide the correct Aura response for the ratified eval case.");
+
+    cases.push({
+      id: `eval-response-${row.score.id}`,
+      source: "eval_response",
+      category: row.score.failureClass,
+      question,
+      goldAnswer: row.score.goldAnswer ?? "",
+      abstention: false,
+      sessions: [
+        {
+          id: row.trace.threadTs ?? row.trace.id,
+          timestamp: row.trace.createdAt.toISOString(),
+          turns: sessionTurns,
+        },
+      ],
+      rubric: row.score.rubric,
+      metadata: {
+        evalResponseScoreId: row.score.id,
+        verdict: row.score.verdict,
+        failureClass: row.score.failureClass,
+        servingIntent: row.score.servingIntent,
+        ratifiedBy: row.score.ratifiedBy,
+        threadLink: slackThreadLink(row.trace.channelId, row.score.threadTs),
+      },
+    });
+  }
+
+  process.stdout.write(`${JSON.stringify(cases, null, 2)}\n`);
+}
+
+if (hasFlag("list")) {
+  await listQueue();
+} else if (readFlag("ratify")) {
+  await ratifyOne();
+} else if (hasFlag("export")) {
+  await exportRatified();
+}


### PR DESCRIPTION
Fixes #1163

Restores agent bc-a722b8ec's work (commit 2febfa0e) which was reverted when two later agents pushed to the same branch and hijacked PR #1164. Clean cherry-pick onto main.