### PR TITLE
eval cron: fill time budget, judge concurrently, run hourly

### DIFF
--- a/apps/api/src/cron/eval-responses.test.ts
+++ b/apps/api/src/cron/eval-responses.test.ts
@@ -58,7 +58,14 @@ vi.mock("../eval/judge.js", () => ({
   judgeWindow: judgeWindowMock,
 }));
 
-import { scoreGroup, splitGroupBudget } from "./eval-responses.js";
+import {
+  DEFAULT_MAX_GROUPS,
+  evalResponsesApp,
+  scoreGroup,
+  scoreGroupsWithBudget,
+  splitGroupBudget,
+  type UnscoredGroup,
+} from "./eval-responses.js";
 
 function traceRow(id: string, minute: number) {
   return {
@@ -267,8 +274,98 @@ describe("scoreGroup", () => {
 
 describe("eval-responses group budgeting", () => {
   it("allocates 80 percent to newest-first scoring and 20 percent to backfill", () => {
-    expect(splitGroupBudget(40)).toEqual({ newest: 32, oldest: 8 });
+    expect(DEFAULT_MAX_GROUPS).toBe(200);
+    expect(splitGroupBudget(DEFAULT_MAX_GROUPS)).toEqual({ newest: 160, oldest: 40 });
     expect(splitGroupBudget(10)).toEqual({ newest: 8, oldest: 2 });
     expect(splitGroupBudget(1)).toEqual({ newest: 1, oldest: 0 });
+  });
+});
+
+describe("scoreGroupsWithBudget", () => {
+  it("does not dispatch a new group after the deadline has passed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    const groups: UnscoredGroup[] = Array.from({ length: 12 }, (_, index) => ({
+      channelId: "C123",
+      threadTs: `1700000000.${String(index).padStart(6, "0")}`,
+      soleTraceId: `t${index}`,
+      firstAt: new Date(0),
+    }));
+    const started: string[] = [];
+    const resolveCalls: Array<() => void> = [];
+    const score = vi.fn((group: UnscoredGroup) => {
+      started.push(group.soleTraceId);
+      return new Promise<{
+        windowsJudged: number;
+        responsesScored: number;
+        prefiltered: number;
+        omitted: number;
+      }>((resolve) => {
+        resolveCalls.push(() =>
+          resolve({ windowsJudged: 1, responsesScored: 1, prefiltered: 0, omitted: 0 }),
+        );
+      });
+    });
+
+    try {
+      const run = scoreGroupsWithBudget(groups, 100, score);
+
+      expect(score).toHaveBeenCalledTimes(8);
+      vi.setSystemTime(101);
+      resolveCalls.forEach((resolve) => resolve());
+      const result = await run;
+
+      expect(score).toHaveBeenCalledTimes(8);
+      expect(started).toEqual(groups.slice(0, 8).map((group) => group.soleTraceId));
+      expect(result).toEqual({
+        groupsProcessed: 8,
+        windowsJudged: 8,
+        responsesScored: 8,
+        prefiltered: 0,
+        omitted: 0,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("eval-responses cron handler", () => {
+  it("exits before judging when no settled unscored groups are found", async () => {
+    const previousCronSecret = process.env.CRON_SECRET;
+    process.env.CRON_SECRET = "test-secret";
+    try {
+      dbMock.results = [
+        // newest groups
+        [],
+        // oldest groups
+        [],
+      ];
+
+      const response = await evalResponsesApp.request(
+        "/api/cron/eval-responses",
+        {
+          headers: { authorization: "Bearer test-secret" },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: true,
+        groupsFound: 0,
+        groupsProcessed: 0,
+        windowsJudged: 0,
+        responsesScored: 0,
+        done: true,
+      });
+      expect(judgeWindowMock).not.toHaveBeenCalled();
+    } finally {
+      if (previousCronSecret === undefined) {
+        delete process.env.CRON_SECRET;
+      } else {
+        process.env.CRON_SECRET = previousCronSecret;
+      }
+    }
   });
 });

--- a/apps/api/src/cron/eval-responses.ts
+++ b/apps/api/src/cron/eval-responses.ts
@@ -1,7 +1,7 @@
 /**
- * Overnight eval batch (Machine A of the eval funnel).
+ * Eval response batch scorer (Machine A of the eval funnel).
  *
- * Scores settled, not-yet-scored assistant responses exactly once. The nightly
+ * Scores settled, not-yet-scored assistant responses exactly once. The hourly
  * cron prioritizes newest threads while trickling historical backfill:
  * thread -> turns -> 20-turn sliding windows -> one fast-tier judge call per
  * window -> one eval_response_scores row per response, mapped by echoed part_id.
@@ -27,15 +27,17 @@ import { buildTurns, buildWindows, type EvalTurn } from "../eval/windowing.js";
 
 export const evalResponsesApp = new Hono();
 
-/** Max thread groups processed per nightly invocation. */
-const DEFAULT_MAX_GROUPS = 40;
+/** Max thread groups considered per invocation; wall-clock budget is the real safety rail. */
+export const DEFAULT_MAX_GROUPS = 200;
+/** Max thread groups judged concurrently. */
+const JUDGE_CONCURRENCY = 8;
 /** Soft wall-clock budget; Vercel maxDuration is 800s, leave headroom. */
 const TIME_BUDGET_MS = 11 * 60_000;
 /** Don't judge threads that were active in the last 30 minutes — a turn that
  * just hedged may resolve in a moment; let the thread settle first. */
 const SETTLE_MS = 30 * 60_000;
 
-interface UnscoredGroup {
+export interface UnscoredGroup {
   channelId: string | null;
   threadTs: string | null;
   soleTraceId: string;
@@ -59,7 +61,7 @@ export function splitGroupBudget(maxGroups: number): {
 /**
  * Find thread groups (channel_id + thread_ts, or the bare trace for
  * thread-less invocations like job executions) that still contain unscored
- * assistant responses, newest first for the daily scorer or oldest first for
+ * assistant responses, newest first for the hourly scorer or oldest first for
  * the historical backfill trickle.
  */
 export async function findUnscoredGroups(
@@ -135,6 +137,14 @@ export async function findUnscoredGroupsForRun(
 }
 
 interface GroupResult {
+  windowsJudged: number;
+  responsesScored: number;
+  prefiltered: number;
+  omitted: number;
+}
+
+interface ScoringTotals {
+  groupsProcessed: number;
   windowsJudged: number;
   responsesScored: number;
   prefiltered: number;
@@ -301,9 +311,56 @@ export async function scoreGroup(
   return result;
 }
 
+export async function scoreGroupsWithBudget(
+  groups: UnscoredGroup[],
+  deadline: number,
+  score: (group: UnscoredGroup, deadline: number) => Promise<GroupResult> = scoreGroup,
+): Promise<ScoringTotals> {
+  const totals: ScoringTotals = {
+    groupsProcessed: 0,
+    windowsJudged: 0,
+    responsesScored: 0,
+    prefiltered: 0,
+    omitted: 0,
+  };
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      if (Date.now() > deadline) return;
+      const group = groups[nextIndex++];
+      if (!group) return;
+
+      try {
+        const result = await score(group, deadline);
+        totals.groupsProcessed += 1;
+        totals.windowsJudged += result.windowsJudged;
+        totals.responsesScored += result.responsesScored;
+        totals.prefiltered += result.prefiltered;
+        totals.omitted += result.omitted;
+      } catch (error) {
+        // One broken thread must not block the forward walk.
+        logger.error("eval-responses: group failed", {
+          channelId: group.channelId,
+          threadTs: group.threadTs,
+          soleTraceId: group.soleTraceId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(JUDGE_CONCURRENCY, groups.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return totals;
+}
+
 /**
- * Vercel Cron handler for the overnight eval batch.
- * Runs daily at 2:00 AM UTC (configured in vercel.json).
+ * Vercel Cron handler for the eval response batch.
+ * Runs hourly (configured in vercel.json).
  * Protected by CRON_SECRET. Optional `?limit=` caps thread groups per run.
  */
 evalResponsesApp.get("/api/cron/eval-responses", async (c) => {
@@ -328,31 +385,33 @@ evalResponsesApp.get("/api/cron/eval-responses", async (c) => {
     const groups = await findUnscoredGroupsForRun(maxGroups);
     logger.info("Cron: eval-responses starting", { groups: groups.length, maxGroups });
 
-    let groupsProcessed = 0;
-    let windowsJudged = 0;
-    let responsesScored = 0;
-    let prefiltered = 0;
-    let omitted = 0;
+    if (groups.length === 0) {
+      const duration = Date.now() - start;
+      logger.info("Cron: eval-responses finished", {
+        duration,
+        groupsProcessed: 0,
+        windowsJudged: 0,
+        responsesScored: 0,
+        prefiltered: 0,
+        omitted: 0,
+        done: true,
+      });
 
-    for (const group of groups) {
-      if (Date.now() > deadline) break;
-      try {
-        const result = await scoreGroup(group, deadline);
-        groupsProcessed += 1;
-        windowsJudged += result.windowsJudged;
-        responsesScored += result.responsesScored;
-        prefiltered += result.prefiltered;
-        omitted += result.omitted;
-      } catch (error) {
-        // One broken thread must not block the forward walk.
-        logger.error("eval-responses: group failed", {
-          channelId: group.channelId,
-          threadTs: group.threadTs,
-          soleTraceId: group.soleTraceId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      return c.json({
+        ok: true,
+        duration,
+        groupsFound: 0,
+        groupsProcessed: 0,
+        windowsJudged: 0,
+        responsesScored: 0,
+        prefiltered: 0,
+        omitted: 0,
+        done: true,
+      });
     }
+
+    const { groupsProcessed, windowsJudged, responsesScored, prefiltered, omitted } =
+      await scoreGroupsWithBudget(groups, deadline);
 
     // "done" only when the backlog is exhausted (nothing settled remains
     // unscored) — lets a backfill driver loop until the walk completes.

--- a/apps/api/src/scripts/backfill-response-scores.ts
+++ b/apps/api/src/scripts/backfill-response-scores.ts
@@ -1,10 +1,10 @@
 /**
  * Manual backfill driver for the eval response funnel.
  *
- * Runs the same forward walk as the overnight cron (oldest unscored thread
+ * Runs the same forward walk as the scheduled cron (oldest unscored thread
  * groups first), but loops batch after batch until the backlog is exhausted —
  * useful for the initial walk from corpus start (March 12) without waiting
- * for nightly cron invocations. Fully idempotent: safe to interrupt and
+ * for scheduled cron invocations. Fully idempotent: safe to interrupt and
  * re-run; already-scored responses are never re-judged.
  *
  * Usage:

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -11,7 +11,7 @@
     },
     {
       "path": "/api/cron/eval-responses",
-      "schedule": "0 2 * * *"
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/cron/heartbeat",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Raise the eval response cron default group cap from 40 to 200 while preserving the existing `?limit=` override and hard cap behavior.
- Score thread groups with a budget-aware concurrency-8 worker pool; each dispatch checks the deadline, in-flight groups are allowed to finish, and per-group errors remain isolated.
- Run the eval response cron hourly and return early when no settled unscored groups are found.

## Throughput math
- Before: 1 run/day x 40 groups sequential ~260 msgs/day, versus ~600 assistant messages/day produced, so backlog grew structurally.
- After: 24 runs/day x time-budget-filled groups at concurrency 8, with capacity in the thousands of judge calls/day versus ~200/day scorable inflow after prefilter.

## Tests
- `pnpm --filter aura-api exec vitest run src/cron/eval-responses.test.ts`
- `npx tsc --noEmit` (from `apps/api`)
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9a3943c-5153-4ef3-b2c4-7b2e575151ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9a3943c-5153-4ef3-b2c4-7b2e575151ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

