### PR TITLE
docs(memory): document extractor durability filter

### DIFF
--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -116,6 +116,7 @@ After every conversation turn, Aura extracts new memories:
 
 1. The recent messages are sent to Claude with a structured extraction prompt
 2. Claude identifies facts, decisions, preferences, events, open threads, and entity mentions
+   - `event` and `open_thread` candidates must pass a **durability test**: "will this still be true and useful in 30 days?" In-flight tasks and current-thread activity are not extracted
 3. Each extraction is checked for duplicates against existing memories
 4. New memories are embedded and stored
 5. Extracted entities are resolved and linked to their memories (see below)
@@ -177,6 +178,8 @@ Each memory carries a `confidence` score (0.0 -- 1.0, default 0.8) representing 
 ### Temporal validity
 
 Memories can have `valid_from` and `valid_until` timestamps to represent time-bounded facts. For example, "Joan is on vacation until March 15" gets a `valid_until` of March 15. By default, `valid_from` is set to the memory's creation time.
+
+Transient memory types also get a **default TTL** at storage time: `event` memories expire 14 days after `valid_from`, and `open_thread` memories expire 30 days after. An explicit `valid_until` from extraction takes precedence, and the extractor can mark an event or open thread as `durable` to skip the TTL entirely (e.g. a launch date with lasting consequence).
 
 ### Supersession chains
 

--- a/content/docs/memory-system.mdx
+++ b/content/docs/memory-system.mdx
@@ -179,8 +179,6 @@ Each memory carries a `confidence` score (0.0 -- 1.0, default 0.8) representing 
 
 Memories can have `valid_from` and `valid_until` timestamps to represent time-bounded facts. For example, "Joan is on vacation until March 15" gets a `valid_until` of March 15. By default, `valid_from` is set to the memory's creation time.
 
-Transient memory types also get a **default TTL** at storage time: `event` memories expire 14 days after `valid_from`, and `open_thread` memories expire 30 days after. An explicit `valid_until` from extraction takes precedence, and the extractor can mark an event or open thread as `durable` to skip the TTL entirely (e.g. a launch date with lasting consequence).
-
 ### Supersession chains
 
 When a new memory replaces an old one (e.g., "the project deadline moved from April to May"), the old memory is marked `superseded` with:


### PR DESCRIPTION
Docs drift fix from the daily docs-maintenance job.

#1101 added default TTLs for transient memories (`event` = 14 days, `open_thread` = 30 days, with a `durable` escape hatch) and a durability test in the extraction prompt. `memory-system.mdx` still described `valid_until` as manual-only.

Changes:
- Temporal validity section: document default TTLs and the `durable` escape hatch
- Memory Extraction section: note the durability test for event/open_thread candidates

Also audited #1164 (AI SDK v7 — docs are version-agnostic, no change needed) and #1169/#1172 (eval scoring — the eval funnel has zero docs coverage, predating these PRs; flagged as P1 for a dedicated docs page next run).