### PR TITLE
docs: charts tool page + credential provenance section

### DIFF
--- a/content/docs/docs.json
+++ b/content/docs/docs.json
@@ -75,6 +75,7 @@
               "tools/people",
               "tools/lists",
               "tools/tables",
+              "tools/charts",
               "tools/subagents",
               "tools/voice",
               "tools/cursor-agent",

--- a/content/docs/tools/charts.mdx
+++ b/content/docs/tools/charts.mdx
@@ -1,0 +1,37 @@
+---
+title: "Charts"
+description: "Render native Slack charts (line, bar, area, pie) for data visualization."
+---
+
+# Slack Charts
+
+When Aura needs to visualize data -- trends, comparisons, distributions -- she renders native Slack charts (`data_visualization` blocks) with the `draw_chart` tool instead of generating PNG images in the sandbox.
+
+## Why Native Charts?
+
+Native Slack charts render instantly, look correct on mobile, and require no file uploads. Sandbox-generated images are only needed for charts that exceed Slack's native limits or need custom styling and annotations.
+
+## Chart Types and Limits
+
+| Type | Data Input | Limits |
+|------|-----------|--------|
+| `line`, `bar`, `area` | `series` + `axis_config` | Up to 6 series, 20 x-axis categories |
+| `pie` | `segments` | 1--6 segments |
+
+Titles are capped at 50 characters; series names, segment labels, and category labels at 20 characters. Every series must include exactly one data point per axis category.
+
+## Delivery Modes
+
+Same three modes as [tables](/tools/tables):
+
+| Mode | When to Use |
+|------|-------------|
+| **Inline** (default) | Single chart attached to the current reply |
+| **Reply** (`send_as_reply`) | Multiple charts in a thread |
+| **Targeted** (`target_channel` / `target_user`) | Post a chart to a different channel or DM |
+
+Inline mode supports one native chart or table block per reply. For anything beyond that, Aura falls back to thread replies.
+
+## When Aura Uses the Sandbox Instead
+
+Requests that don't fit the native limits -- more than 6 series, custom color schemes, annotations, scatter plots, heatmaps -- are rendered as images with Python/matplotlib in the sandbox and shared via file upload.

--- a/content/docs/tools/credentials.mdx
+++ b/content/docs/tools/credentials.mdx
@@ -87,6 +87,12 @@ When Aura executes a sandbox command tool (`run_command`, `run_command_detached`
 
 Each user gets their own sandbox instance (see [Sandbox](/tools/sandbox)) -- filesystem and process state are isolated per user, and credential injection runs per-command against the calling user's grants.
 
+### Ownership Provenance in Context
+
+Aura's system context lists the env names available in the sandbox. For caller-scoped credentials (`owner` or `per_user` scope), the name carries provenance metadata, e.g. `GITHUB_TOKEN (owner-scoped, resolved for caller: Jane Doe)`. Shared credentials render as bare names.
+
+This matters for debugging: because the same env name resolves to a different secret depending on who initiated the conversation, an auth failure (401/403) on a caller-scoped credential means *that caller's* credential is broken -- not a shared token. The provenance label lets Aura attribute the failure to the right owner and route the fix to them.
+
 ## Making Authenticated Requests from the Sandbox
 
 There is no credential-retrieval or HTTP-wrapper tool. Authenticated API calls should run in the sandbox with the scoped env vars listed in Aura's system context:


### PR DESCRIPTION
Docs maintenance run (Jul 8). Covers two merged features with no docs:

- **New page tools/charts.mdx** for the native draw_chart tool (#1168): chart types, native limits (6 series / 20 categories / 50-char titles), delivery modes, and when the sandbox fallback applies. Added to docs.json nav after Tables.
- **tools/credentials.mdx**: new 'Ownership Provenance in Context' section for #1177 -- caller-scoped credentials now render provenance in the capabilities block, and auth failures should be attributed to the caller's credential owner.

Also updated separately today: PR #1173 trimmed to match the #1171 TTL revert.