### PR TITLE
docs: fix dashboard.mdx drift vs current dashboard code

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -5,9 +5,17 @@ description: "Monitor and manage your Aura instance through the admin dashboard.
 
 # Dashboard
 
-The admin dashboard is a Vite + React application (with TanStack Router and TanStack Query) that provides full visibility into Aura's operation. It's deployed alongside the API as a single Vercel project and accessible to workspace admins.
+The admin dashboard is a Vite + React application (with TanStack Router and TanStack Query) that provides full visibility into Aura's operation. It's deployed alongside the API as a single Vercel project. Access requires the `power_user` role or higher (see [Access & Authentication](#access--authentication)).
 
 ## Pages
+
+### Overview
+
+The landing page shows at-a-glance instance health:
+
+- Count cards: notes, memories, users, active jobs, errors in the last 24h
+- Recent errors list with resolution status
+- Recent job executions with trigger and status
 
 ### Conversations
 
@@ -98,18 +106,19 @@ Track production errors:
 
 ### Users
 
-View workspace member profiles:
+View and manage workspace member profiles:
 
-- Communication preferences Aura has learned
-- Interaction history and frequency
-- Timezone and language settings
+- Interaction count, last-active time, timezone, and learned communication style (verbosity, formality, emoji usage, preferred format)
+- **Role management**: assign `owner`, `admin`, `power_user`, or `member` directly from the user detail page -- this is how new members get dashboard access
+- Editable person fields: job title, preferred language, gender, and free-form notes
+- A Memories tab listing every memory linked to that user
 
 ### Resources
 
 Manage ingested content:
 
-- URLs, PDFs, and YouTube videos Aura has processed
-- Extraction status and content previews
+- Source types: web pages, GitHub, docs, YouTube, Notion, PDFs, and Slack content
+- Filter by source and extraction status (ready / error / pending), with content previews
 
 ### Settings
 
@@ -137,6 +146,8 @@ The callback issues a session JWT (HS256, `DASHBOARD_SESSION_TTL` or `365d` by d
 ## Chat
 
 The dashboard includes an embedded chat interface for interacting with Aura directly from the admin UI -- useful for testing and debugging without switching to Slack.
+
+Chat streams are resumable: if the page reloads, the network drops, or a serverless function times out mid-response, the client reconnects to the in-flight run's stream and replays it, continuing with the live tail instead of losing the response.
 
 The model picker in the chat panel uses the same searchable autocomplete as the Settings page, grouped by provider. Both stay in sync -- changing the model in one place updates the other.
 


### PR DESCRIPTION
Daily docs-maintenance run (Jul 14). Main frozen since Jul 8, so audited `dashboard.mdx` against `apps/dashboard/src/routes/` and components.

## Fixes

**P0 -- wrong access claim in intro**: said the dashboard is "accessible to workspace admins"; actual gate is `power_user`+ (per `ALLOWED_ROLES`, already correct in the Access section further down). Intro now matches.

**P1 -- Overview page had zero docs**: the landing page (`/` -- stat cards, recent errors, recent job executions) wasn't documented at all. Added.

**P2 -- Users section understated the page**: it's not read-only. Role assignment (owner/admin/power_user/member) happens here -- which is how new members get dashboard access -- plus editable person fields (job title, preferred language, gender, notes) and a per-user Memories tab. Verified against `routes/users/$slackUserId.tsx`.

**P2 -- Resources source list wrong**: docs said "URLs, PDFs, and YouTube videos"; actual source enum is youtube/notion/github/web/docs/pdf/slack (`tools/resources.ts` `RESOURCE_SOURCES`), with source + status (ready/pending/error) filters in the UI.

**P2 -- Chat missing resumable streams**: #1116 (WDK adoption) made dashboard chat streams resumable (reconnect after reload/network drop/function timeout replays the in-flight run). Verified against `chat-panel.tsx`.

Deliberately NOT added here: the Evals page -- open PR #1117 already adds that section to dashboard.mdx; no overlap with these hunks.

Part of the daily docs-maintenance job. Every claim verified against code, not memory.