### PR TITLE
docs: fix deployment docs drift after WDK/Nitro migration

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -5,14 +5,14 @@ description: "How Aura's message pipeline, memory system, tools, and self-improv
 
 # Architecture
 
-Aura is a Hono-based application deployed on Vercel serverless functions. She processes Slack events, maintains long-term memory in PostgreSQL, and uses LLMs (Claude, Grok) for reasoning via the Vercel AI SDK.
+Aura is a Nitro-based application with Hono routing, deployed on Vercel serverless functions. She processes Slack events, maintains long-term memory in PostgreSQL, and uses LLMs (Claude, Grok) for reasoning via the Vercel AI SDK.
 
 ## Monorepo Structure
 
 ```
 aura/
 ├── apps/
-│   ├── api/            # Core agent (Hono + Vercel Functions)
+│   ├── api/            # Core agent (Nitro + Hono, Vercel Functions)
 │   │   └── src/
 │   │       ├── pipeline/    # Message processing, prompt assembly
 │   │       ├── tools/       # 25 tool modules (Slack, email, BigQuery, etc.)
@@ -43,7 +43,7 @@ aura/
 ## System Overview
 
 ```
-Slack Event → Vercel Function → Hono Router → Message Pipeline → LLM (Vercel AI SDK)
+Slack Event → Vercel Function → Nitro + Hono Router → Message Pipeline → LLM (Vercel AI SDK)
                                                       ↕
                                               PostgreSQL + pgvector
                                       (memories, messages, conversations, notes, jobs)
@@ -77,6 +77,10 @@ Every conversation is persisted with full detail:
 - **Metadata** — Channel, thread, user, model, duration
 
 The [Dashboard](/dashboard) provides a UI for browsing conversation traces, filtering by user/channel, and analyzing costs.
+
+## Durable Execution (Vercel Workflow DevKit)
+
+Aura uses the Vercel Workflow DevKit for durable execution in the Nitro API, with `"use workflow"` and `"use step"` directives defining resumable workflow boundaries. Dashboard chat always runs as a workflow in `apps/api/workflows/dashboard-chat.ts`: the server owns generation, the browser is only a stream reader, and streams can be resumed after disconnects. Slack respond has a flag-gated durable path in `apps/api/workflows/slack-respond.ts`, enabled by `AURA_WDK_SLACK_RESPOND=1` or the `wdk_slack_respond` dashboard setting. This path lets Slack message responses resume after function interruption while the legacy in-process responder remains the default when the flag is off.
 
 ## Tool System
 

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -28,6 +28,8 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `AURA_ADMIN_USER_IDS` | Comma-separated Slack user IDs with admin access. Fallback for users without a DB role — see [Permissions](/permissions) |
 | `DASHBOARD_SESSION_TTL` | Optional dashboard session JWT lifetime. Defaults to `365d`; accepts duration strings like `30d`, `365d`, or `12h`. |
 | `E2B_API_KEY` | E2B API key for sandbox access |
+| `AURA_PUBLIC_URL` | Public base URL of the API deployment. Used for sandbox completion webhooks and supervisor callbacks. |
+| `SANDBOX_WEBHOOK_SECRET` | Secret for signing sandbox completion webhooks (`run_command_detached` resume). Both this and `AURA_PUBLIC_URL` must be set for detached commands to resume conversations. |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings and audio transcription |
 | `AURA_BOT_USER_ID` | Aura's own Slack bot user ID |
 
@@ -84,13 +86,25 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 
 Models are normally resolved from database settings first, then the DB-backed model catalog defaults. The environment variable defaults are legacy/local-development references; admins can refresh the live catalog from Vercel AI Gateway in Settings without redeploying.
 
+## Observability (Langfuse)
+
+| Variable | Description |
+|----------|-------------|
+| `LANGFUSE_PUBLIC_KEY` | Langfuse public key. Tracing is disabled unless both keys are set. |
+| `LANGFUSE_SECRET_KEY` | Langfuse secret key |
+| `LANGFUSE_BASE_URL` | Langfuse instance base URL |
+| `LANGFUSE_TRACING_ENVIRONMENT` | Environment label for traces (defaults from Vercel env) |
+| `LANGFUSE_RELEASE` | Release identifier (defaults to `VERCEL_GIT_COMMIT_SHA`) |
+| `LANGFUSE_DROP_ORPHAN_EMBEDDINGS` | Set to `"true"` to skip exporting orphaned embedding spans |
+
 ## Debugging
 
 | Variable | Description |
 |----------|-------------|
 | `LOG_LEVEL` | Logging verbosity |
 | `SHOW_REASONING_IN_SLACK` | Set to `"true"` to post extended thinking traces as thread replies |
-| `AURA_WDK_SLACK_RESPOND` | Set to `1`/`true` to route Slack responses through the durable Workflow DevKit pipeline (off by default; also settable via the `wdk_slack_respond` workspace setting) |
+| `AURA_WDK_SLACK_RESPOND` | Set to `1`/`true` to force the durable Workflow DevKit Slack respond pipeline (highest priority; otherwise resolved from the `wdk_slack_respond` workspace setting) |
+| `TRUSTED_ORIGINS` | Extra comma-separated origins allowed for dashboard OAuth callbacks (preview deploys) |
 
 ## Adding Variables via CLI
 

--- a/content/docs/deployment/one-click-deploy.mdx
+++ b/content/docs/deployment/one-click-deploy.mdx
@@ -23,7 +23,7 @@ Deploy your own instance of Aura with Vercel's one-click deploy button.
 ### Set Up Your Database
 
 1. Create a PostgreSQL database with pgvector support ([Neon](https://neon.tech) recommended)
-2. Run migrations: the first deploy will run them automatically via the `vercel-build` script
+2. Run migrations: the first deploy runs them automatically via the `buildCommand` in `apps/api/vercel.json`
 
 ### Configure Your Slack App
 

--- a/content/docs/deployment/vercel.mdx
+++ b/content/docs/deployment/vercel.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Vercel Deployment"
-description: "How Aura runs on Vercel serverless functions with automatic deploys from main."
+description: "How Aura runs on Vercel with Nitro + the Workflow DevKit, with automatic deploys from main."
 ---
 
 # Vercel Deployment
 
-Aura's backend runs on Vercel serverless functions. Merging to `main` triggers an automatic production deploy.
+Aura's backend runs on Vercel. Merging to `main` triggers an automatic production deploy.
 
 ## Monorepo Structure
 
@@ -14,8 +14,9 @@ Aura is a pnpm monorepo with multiple packages:
 ```
 aura/
 ├── apps/
-│   ├── api/          # Backend API (Hono, serverless functions)
-│   ├── dashboard/    # Admin dashboard (Next.js)
+│   ├── api/          # Backend API (Hono, built with Nitro)
+│   │   └── workflows/  # Durable workflows (Workflow DevKit)
+│   ├── dashboard/    # Admin dashboard (Vite + React SPA)
 │   └── web/          # Landing page + blog (Next.js)
 ├── packages/
 │   └── db/           # Shared database schema (Drizzle ORM)
@@ -23,31 +24,52 @@ aura/
     └── docs/         # Documentation (Mintlify)
 ```
 
-Each `apps/*` project deploys as a separate Vercel project.
+The API and the dashboard deploy together as **one** Vercel project; only `apps/web` is a separate project.
 
 ## Architecture
 
-- **Runtime:** Node.js serverless functions, emitted via the Build Output API by a Nitro build
-- **Framework:** Hono for HTTP routing
-- **Entry point:** `apps/api/src/app.ts` exports the Hono app; `apps/api/src/nitro-app.ts` is the Nitro server entry that routes all HTTP traffic to it (`apps/api/nitro.config.ts`)
-- **Workflows:** the `workflow/nitro` module compiles `"use workflow"` / `"use step"` directives in `apps/api/workflows/` (durable Slack respond, dashboard chat) into dedicated queue-triggered functions and registers the `/.well-known/workflow/v1/*` handler routes
-- **Build:** the `buildCommand` in `apps/api/vercel.json` runs migrations, builds the dashboard into `public/`, then `nitro build --preset vercel` followed by `scripts/patch-vercel-output.mjs` (restores the SPA fallback rewrite in `.vercel/output/config.json`)
+- **Runtime:** Node.js serverless functions, region `fra1`, max duration 800 seconds
+- **Framework:** Hono for HTTP routing, compiled and served by [Nitro](https://nitro.build)
+- **Entry point:** `apps/api/src/app.ts` exports the Hono app; `apps/api/src/nitro-app.ts` is the Nitro server entry that routes all HTTP traffic (`/**`) to it (see `apps/api/nitro.config.ts`)
+- **Workflows:** the `workflow/nitro` module compiles `apps/api/workflows/**` (`"use workflow"` / `"use step"` directives) and emits them as dedicated queue-triggered functions via the Build Output API. Current workflows: `slack-respond.ts` (durable Slack respond pipeline, gated by `AURA_WDK_SLACK_RESPOND`) and `dashboard-chat.ts` (resumable dashboard streams)
+- **Dashboard:** built with Vite and copied into the API's `public/` directory as static files; an SPA fallback route (inserted by `scripts/patch-vercel-output.mjs`) serves `index.html` for non-API browser paths
 
-There are no filesystem function entrypoints anymore -- the legacy `apps/api/api/index.ts` and `apps/api/api/cron/*` handlers were removed when the Nitro build landed (PR #1116). Cron schedules live **only** in `apps/api/vercel.json`; defining the same cron in the Build Output config too makes Vercel reject the deployment ("duplicated cron job").
+There are no filesystem function entrypoints anymore -- the legacy `apps/api/api/index.ts` and `apps/api/api/cron/*` handlers were removed when the Nitro build landed (PR #1116).
 
 ## Deployment Flow
 
+The `buildCommand` in `apps/api/vercel.json` runs the whole pipeline:
+
 ```
-Push to main → Vercel Build → Run Migrations → Dashboard Build → nitro build (Build Output API) → Deploy
+Push to main
+  → build @aura/db → run Drizzle migrations
+  → build dashboard (Vite) → copy dist into public/
+  → nitro build --preset vercel
+  → patch-vercel-output.mjs (SPA fallback route)
+  → Deploy
 ```
 
-The `buildCommand` in `apps/api/vercel.json`:
+The full `buildCommand` in `apps/api/vercel.json`:
 
 ```json
 {
   "buildCommand": "pnpm --filter @aura/db build && pnpm --filter @aura/db db:migrate && pnpm --filter aura-dashboard build && rm -rf public && cp -r ../dashboard/dist public && pnpm build:vercel"
 }
 ```
+
+## Cron Jobs
+
+Defined in `apps/api/vercel.json`:
+
+| Path | Schedule |
+|------|----------|
+| `/api/cron/heartbeat` | `*/30 * * * *` (every 30 min) |
+| `/api/cron/eval-responses` | `0 * * * *` (hourly) |
+| `/api/cron/consolidate` | `0 4 * * *` (daily 4 AM UTC) |
+
+<Warning>
+Crons must live **only** in `vercel.json`. Vercel merges crons from `vercel.json` and the Build Output config, and rejects the deployment when the same path+schedule appears in both ("duplicated cron job"). Never add crons to the Nitro/Build Output config.
+</Warning>
 
 Local development: `pnpm dev` in `apps/api` runs `nitro dev` (workflows run in the Local World); the legacy tsx watcher is still available as `pnpm dev:node`.
 
@@ -56,15 +78,14 @@ Local development: `pnpm dev` in `apps/api` runs `nitro dev` (workflows run in t
 1. **Never push directly to `main`.** Vercel auto-deploys, so any push goes straight to production. Always use feature branches and PRs.
 2. **Migrations run on every deploy.** Drizzle handles idempotency — running the same migration twice is safe.
 3. **Drizzle migration format:** Always include `-->statement-breakpoint` between SQL statements in migration files.
-4. **Serverless = stateless.** In-memory state only lasts for one request. Don't rely on module-level caches persisting.
+4. **Serverless = stateless.** In-memory state only lasts for one request. Don't rely on module-level caches persisting. Durable multi-step work belongs in a workflow (`apps/api/workflows/`).
 5. **Function timeout:** 800 seconds max. Plan long-running tasks accordingly.
 
-## Multiple Projects
+## Vercel Projects
 
 | Project | Domain | Contents |
 |---------|--------|----------|
-| `aura` | `api.aurahq.ai` | Backend API, Slack events, cron |
-| `aura-dashboard` | Dashboard domain | Admin UI (conversations, memories, credentials, errors) |
+| `aura` | `api.aurahq.ai` | Backend API, Slack events, cron, workflow functions, admin dashboard (static SPA) |
 | `aurahq-web` | `aurahq.ai` | Landing page + blog (Next.js) |
 | Mintlify | `docs.aurahq.ai` | Documentation |
 

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -35,7 +35,7 @@ Aura is organized as a monorepo with three main packages:
 ```
 aura/
 ├── apps/
-│   ├── api/          # Core agent — Hono API, message pipeline, tools, cron
+│   ├── api/          # Core agent — Nitro + Hono API, message pipeline, tools, cron
 │   ├── dashboard/    # Admin dashboard — Vite + React SPA for monitoring & management
 │   └── web/          # Marketing site — aurahq.ai
 ├── packages/

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -36,7 +36,7 @@ Aura is organized as a monorepo with three main packages:
 aura/
 ├── apps/
 │   ├── api/          # Core agent — Hono API, message pipeline, tools, cron
-│   ├── dashboard/    # Admin dashboard — Next.js app for monitoring & management
+│   ├── dashboard/    # Admin dashboard — Vite + React SPA for monitoring & management
 │   └── web/          # Marketing site — aurahq.ai
 ├── packages/
 │   └── db/           # Shared database layer — Drizzle ORM schema & migrations


### PR DESCRIPTION
Daily docs maintenance run (Jul 15).

Main frozen since Jul 8, so audited `deployment/` docs vs actual config as planned.

**P0s fixed (vercel.mdx was describing the pre-#1116 world):**
- Entry point: claimed `apps/api/api/index.ts` Vercel handler — that file doesn't exist anymore. Real entry: Nitro (`src/nitro-app.ts` routing `/**` to the Hono app, `nitro.config.ts`).
- Deploy flow: claimed `tsc` + `vercel-build` script — real pipeline is the `buildCommand` in `apps/api/vercel.json` (db build → migrate → dashboard Vite build → copy to public/ → `nitro build --preset vercel` → SPA-fallback patch script).
- Projects table: claimed a separate `aura-dashboard` Vercel project — dashboard is a Vite SPA served statically from the API project.
- Dashboard called "Next.js" here and in getting-started.mdx — it's Vite + React (architecture.mdx already had it right).

**P1 added:**
- Workflow DevKit section (workflows/, queue-triggered functions, `AURA_WDK_SLACK_RESPOND` gate).
- Cron table from vercel.json + the duplicated-cron deploy-rejection warning documented in `patch-vercel-output.mjs`.
- env vars missing from environment-variables.mdx: `AURA_PUBLIC_URL`, `SANDBOX_WEBHOOK_SECRET` (detached-command resume depends on them), Langfuse block, `TRUSTED_ORIGINS`.

**P2:** one-click-deploy.mdx migration mechanism corrected.

All claims verified against `apps/api/vercel.json`, `nitro.config.ts`, `scripts/patch-vercel-output.mjs`, `workflows/`, and grep of `process.env.*` usage.