### PR TITLE
docs: absorb still-valid fixes from stale CONFLICTING PRs #874/#930

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -64,7 +64,7 @@ When a Slack message arrives:
 5. **LLM reasoning** — The selected model (Claude, Grok, etc.) processes the message with full context and available tools. Extended thinking captures the reasoning trace (Claude models).
 6. **Response streaming** — The response streams back to Slack in real-time via the Vercel AI SDK.
 7. **Conversation persistence** — The full conversation trace (messages, tool calls, reasoning, token usage) is stored with cost tracking.
-8. **Memory extraction** — Facts, decisions, and sentiments are extracted from the conversation and stored as new memories.
+8. **Memory extraction** — Thread-scoped reconciliation compares the full conversation against existing memories and produces create, update, and delete operations, storing facts, decisions, preferences, events, and open threads.
 
 ## Conversation Traces
 

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -43,7 +43,7 @@ Browse and search Aura's extracted memories:
 - View category, importance, relevance score, status, and creation time
 - Open a detail dialog or delete stale memories
 
-The **Entities** sub-tab (`/memories/entities`) lists resolved entities (people, companies, projects, technologies) that Aura has extracted from conversations. Each entity has a canonical name, type, alias list, and count of linked memories.
+The **Entities** sub-tab (`/memories/entities`) lists resolved entities (people, companies, projects, products, channels, technologies, concepts, and locations) that Aura has extracted from conversations. Each entity has a canonical name, type, alias list, and count of linked memories.
 
 ### Notes
 


### PR DESCRIPTION
## What

Two surviving fixes rescued from the pre-April CONFLICTING docs PR backlog, re-verified against current code:

- **architecture.mdx** pipeline step 8 still said memory extraction pulls "facts, decisions, and sentiments" -- neither the taxonomy nor the mechanism is right anymore. Now describes thread-scoped reconciliation (create/update/delete ops, per #872) with the real type enum (fact/decision/preference/event/open_thread, verified in `packages/db/src/schema.ts` + `extract.ts`).
- **dashboard.mdx** Entities sub-tab listed 4 entity types; the `entity_type` enum has 8 (adds product, channel, concept, location).

## Stale-PR triage (context)

- #874 (thread-scoped reconciliation): memory-system.mdx half already covered by #1196; architecture.mdx half absorbed here → close once this merges.
- #930: memory-type filter fix already on main; entity-type fix absorbed here; also carries an unrelated `test_live.mjs` debug script that shouldn't merge → close.
- #905: dashboard consumption/catalog claims already on main; documents a `backfill-entity-summaries` script that **does not exist** in `apps/api/scripts/` → close, don't merge.
- #778 (usage stats injection): already on main verbatim (architecture.mdx step 4) → close.

Docs-only, no code changes.