### PR TITLE
docs(use-cases): audit fixes -- anonymize pulse examples, fix BigQuery access method + convention file names

### DIFF
--- a/content/docs/use-cases/code-review.mdx
+++ b/content/docs/use-cases/code-review.mdx
@@ -57,5 +57,5 @@ Aura needs:
 3. Repository context (she builds this automatically by exploring the codebase)
 
 <Tip>
-For best results, keep a `CLAUDE.md` or `CURSOR_RULES` in your repo root. Aura and the agents she dispatches will follow those conventions automatically.
+For best results, keep a `CLAUDE.md`, `AGENTS.md`, or `.cursor/rules` in your repo root. Aura and the agents she dispatches will follow those conventions automatically.
 </Tip>

--- a/content/docs/use-cases/data-analysis.mdx
+++ b/content/docs/use-cases/data-analysis.mdx
@@ -24,7 +24,7 @@ Ask a question in plain language. Aura writes the query, runs it, and gives you 
 - Inspects table schemas before querying (never guesses column names)
 - Handles common traps: cents-to-euros conversion, epoch timestamps, NULL semantics, MRR normalization
 - Cross-references across data sources (BigQuery pipeline data + Stripe billing + Close CRM contacts)
-- Presents results as native Slack tables, not code blocks
+- Presents results as native Slack tables and charts, not code blocks
 - Adds business interpretation ("this is 15% above last month, driven by Spain")
 
 **Built-in guardrails:**
@@ -49,7 +49,7 @@ Not a SQL query. Not a spreadsheet. A business answer.
 
 | Source | Access Method | What You Can Query |
 |--------|--------------|-------------------|
-| BigQuery | Direct SQL via `bq` CLI | Pipeline, leads, valuations, traffic, reviews |
+| BigQuery | `bq_execute_query` tool (read-only SQL) | Pipeline, leads, valuations, traffic, reviews |
 | Stripe | API via stored credentials | Subscriptions, MRR, churn, invoices, failed payments |
 | Close CRM | API via stored credentials | Leads, activities, pipeline stages, rep performance |
 | Google Sheets | Sheets API | Comp models, planning docs, custom trackers |

--- a/content/docs/use-cases/team-pulse.mdx
+++ b/content/docs/use-cases/team-pulse.mdx
@@ -32,7 +32,7 @@ Aura runs async pulse checks: targeted DM questions to each manager, then synthe
 **What makes it different from a form or survey:**
 - Aura adapts questions based on context (she read #sales, she knows about the hiring plan)
 - She follows up if something's unclear, in the manager's language
-- She connects dots across responses ("Fernando needs CSMs; Cecilia just hired one from France")
+- She connects dots across responses ("Spain needs CSMs; Italy just hired one from France")
 - She tracks engagement over time and flags when someone goes silent
 
 ## Real Example
@@ -46,9 +46,9 @@ After 5 rounds across 6 managers in 4 countries:
 > 4. Engineering priorities opaque outside what founders ship themselves
 >
 > **Recommendations:**
-> 1. Talk to Fernando about 2 additional CSMs -- scaling bottleneck
-> 2. Christoph's storytelling point is the sharpest strategic insight -- worth acting on
-> 3. Accept Guillaume won't do pulse checks. Direct technical asks only.
+> 1. Talk to the Spain lead about 2 additional CSMs -- scaling bottleneck
+> 2. The storytelling point from one country lead is the sharpest strategic insight -- worth acting on
+> 3. Accept that one manager won't do pulse checks. Direct technical asks only.
 
 This is the kind of synthesis that normally requires a chief of staff sitting in on every team's calls for a month.
 


### PR DESCRIPTION
Daily docs-maintenance run (Jul 21). First audit of the 9 `use-cases/` pages.

## Fixes

**P0 -- privacy: real employee names in public docs** (`team-pulse.mdx`)
The pulse-check example quoted real colleagues by name (Fernando, Cecilia, Christoph, Guillaume) with per-person assessments sourced from DM pulse rounds. Per-person pulse content is DM-private by hard rule; it shouldn't be in public docs at all. Replaced with role/country descriptions -- the example keeps its punch without naming anyone.

**P1 -- wrong access method** (`data-analysis.mdx`)
Claimed BigQuery is queried "via `bq` CLI". Actual implementation is the `bq_execute_query` tool (`apps/api/src/tools/bigquery.ts`) using the Node client with read-only SQL validation. Also added charts alongside tables (draw_chart shipped in #1168).

**P2 -- nonexistent convention file** (`code-review.mdx`)
Recommended keeping a `CURSOR_RULES` file, which isn't a real convention. Corrected to `CLAUDE.md`, `AGENTS.md`, or `.cursor/rules`.

## Audit notes
All 9 use-cases pages reviewed. Remaining pages (email-triage, bug-triage, sales-ops, candidate-screening, docs-maintenance, overview) are accurate -- narrative style, no verifiable drift found. Verified: email thread states match code, read-only BQ guardrail claim is true, Workable references intentional.