### PR TITLE
docs(jobs): fix jobs.mdx drift (phantom notify_on_success param, admin-only dispatch_headless, cancel_job scope)

### DIFF
--- a/content/docs/tools/jobs.mdx
+++ b/content/docs/tools/jobs.mdx
@@ -33,6 +33,8 @@ After every job execution finishes (success, error, or interruption), the heartb
 
 Each outcome can be processed up to **3 times** (`MAX_SUPERVISOR_ATTEMPTS`). After that the outcome is marked `skipped` and the requester gets a fallback DM.
 
+`notify_on_success` is a per-job database flag (`jobs.notify_on_success`, default `false`) read by the supervisor. It is not currently exposed as a parameter on `create_job` or `update_job` -- it can only be set directly in the database.
+
 ### Orphan sweeps
 
 The heartbeat also reaps supervisor invocations that never completed:
@@ -61,7 +63,6 @@ Create a one-shot task, recurring job, or follow-up.
 | `priority` | enum | no | `high`, `normal` (default), or `low` |
 | `max_per_day` | number | no | Max executions per day (recurring jobs) |
 | `min_interval_hours` | number | no | Minimum hours between executions |
-| `notify_on_success` | boolean | no | If `true`, the supervisor reports successful runs via DM. Defaults to `false` -- routine recurring successes are silent. |
 | `script` | string | no | Shell command to run before/instead of LLM. See [execution modes](#execution-modes) below. |
 
 ---
@@ -94,7 +95,7 @@ List jobs by status.
 
 ## `cancel_job`
 
-Cancel a pending one-shot job, or disable a recurring job (preserves its definition).
+Cancel a pending or failed one-shot job, or disable a recurring job (preserves its definition for re-enabling later).
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -128,7 +129,7 @@ When a cron schedule or timezone is updated, the next execution time is automati
 
 ## `dispatch_headless`
 
-Dispatch a task for immediate headless execution. Creates a job and triggers it NOW — no waiting for the heartbeat. Use for heavy work: backfills, data processing, multi-step investigations. Results are posted to the callback channel/thread when done.
+**Admin-only** (requires the `admin_access` credential). Dispatch a task for immediate headless execution. Creates a job and triggers it NOW — no waiting for the heartbeat. Use for heavy work: backfills, data processing, multi-step investigations. Results are posted to the callback channel/thread when done.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|


### PR DESCRIPTION
Daily docs-maintenance run (Jul 23). Audited `content/docs/tools/jobs.mdx` against live code at `3718765`.

## P0 — phantom parameter
- `create_job` table documented a `notify_on_success` param. The tool schema (`apps/api/src/tools/jobs.ts`) has no such input, and neither does `update_job`. The flag exists only as a DB column (`jobs.notify_on_success`, `packages/db/src/schema.ts:575`) read by the supervisor. Removed the row and added a clarification in the supervisor section so readers know it's DB-only today.

## P1 — missing access constraint
- `dispatch_headless` is gated by `requiredCredentials: ["admin_access"]` in code but the docs presented it as generally available. Marked admin-only.

## P2 — stale scope
- `cancel_job` docs said "pending one-shot" only; the tool also cancels **failed** one-shots and re-enabling of disabled recurring jobs is preserved. Aligned wording.

Everything else verified accurate against code: retry (`MAX_RETRIES=3`, `RETRY_DELAY_MS=30min`), stale recovery split, supervisor decisions + `MAX_SUPERVISOR_ATTEMPTS=3`, orphan sweeps, execution modes, scratchpad semantics, `read_job_trace` params.