### PR TITLE
docs(bigquery): fix auth-section drift (no env fallback) + strengthen read-only wording

### DIFF
--- a/content/docs/tools/bigquery.mdx
+++ b/content/docs/tools/bigquery.mdx
@@ -5,7 +5,7 @@ description: "Query your data warehouse, inspect schemas, browse sheets, and sea
 
 # BigQuery & Data Tools
 
-Aura connects to Google BigQuery using a base64-encoded service account JSON stored as the encrypted credential `google_bq_credentials`. Access is **read-only by default** — no DML or DDL is allowed. BigQuery tools use **Standard SQL** (`useLegacySql: false`) and a step-by-step recovery ladder to avoid malformed queries and false permission diagnoses.
+Aura connects to Google BigQuery using a base64-encoded service account JSON stored as the encrypted credential `google_bq_credentials`. Access is **strictly read-only** — only `SELECT`/`WITH` statements are accepted; DML, DDL, CALL, EXPORT, and multi-statement queries are always rejected. BigQuery tools use **Standard SQL** (`useLegacySql: false`) and a step-by-step recovery ladder to avoid malformed queries and false permission diagnoses.
 
 **BigQuery recovery ladder (follow in order):**
 1. `bq_list_datasets`
@@ -143,6 +143,8 @@ List all shared drives in the Google Workspace organization.
 
 ## Authentication
 
-BigQuery uses a base64-encoded service account JSON stored in Aura's encrypted credential store under the name `google_bq_credentials`. Legacy environment variables such as `GOOGLE_BQ_CREDENTIALS` are listed for older deployments, but the current runtime resolves the encrypted credential first.
+BigQuery uses a base64-encoded service account JSON stored in Aura's encrypted credential store under the name `google_bq_credentials`. This is the **only** resolution path — there is no environment-variable fallback for this credential. If the credential row is missing, BigQuery tools report themselves as unavailable (the error message mentions `GOOGLE_BQ_CREDENTIALS` for historical reasons, but setting that env var has no effect — the runtime only reads the encrypted credential row).
+
+The client also auto-resolves the **dataset location** from the first `FROM`/`JOIN` reference in your query, so queries against non-US datasets (e.g. EU) work without specifying a location.
 
 Google Drive/Sheets/Calendar use **per-user OAuth tokens** stored in the `oauth_tokens` table. Users must connect their Google account first. Aura's own token is only for Aura's own internal work, never for accessing another user's data.


### PR DESCRIPTION
Daily docs-maintenance run (Jul 24). Main still frozen at 3718765, so this is backlog work: bigquery.mdx audit vs live code.

## Fixes
- **P0** -- Authentication section claimed `GOOGLE_BQ_CREDENTIALS` env var works as a legacy fallback. It doesn't: `resolveCredentialValue()` in `lib/credentials.ts` reads only the encrypted `credentials` table (the `ENV_FALLBACKS` map covers `github_token` only). A reader following the doc would set the env var and get a silently non-functional deployment.
- **P2** -- "read-only by default" understated the guarantee: the SQL validator hard-rejects anything that isn't a single `SELECT`/`WITH` (DML, DDL, CALL, EXPORT, multi-statement). Reworded to "strictly read-only".
- **P2** -- Documented dataset-location auto-resolution (`extractDatasetFromSQL` + `resolveDatasetLocation`), so EU-dataset users don't assume extra config is needed.

## Verified accurate (no change needed)
- All 9 tool param tables match zod schemas exactly (defaults, maxes, requireds)
- 1 GB scan limit (`maximumBytesBilled: 1e9`)
- Recovery ladder + table-reference guidance match in-code tool descriptions
- Drive/Sheets per-user OAuth via `oauth_tokens` table claim matches `getOAuth2Client` path

One PR per run per playbook.