### PR TITLE
docs(slack): fix slack.mdx drift (user-token claim, gate fail modes, always_process semantics)

### DIFF
--- a/content/docs/tools/slack.mdx
+++ b/content/docs/tools/slack.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Slack Tools"
-description: "Full reference for all 34 Slack tools — channels, DMs, messages, canvases, lists, files, and workspace management."
+description: "Full reference for all 37 Slack tools — channels, DMs, messages, canvases, lists, files, and workspace management."
 ---
 
 # Slack Tools
 
-Aura's primary interface is Slack. She uses the `@slack/web-api` SDK with both a bot token (`SLACK_BOT_TOKEN`) and a user token (`SLACK_USER_TOKEN`). Most tools use the bot token; search and DM listing require the user token.
+Aura's primary interface is Slack. She uses the `@slack/web-api` SDK with both a bot token (`SLACK_BOT_TOKEN`) and a user token (`SLACK_USER_TOKEN`). Most tools use the bot token; only `search_messages` requires the user token (`list_dm_conversations` uses the bot token and is gated on `admin_access` instead).
 
 Aura must **join a channel** before she can read or post. `list_channels` only shows channels she has already joined — use `search_channels` or `join_channel` to find and enter others.
 
@@ -18,7 +18,7 @@ Aura's response decision happens in `apps/api/src/pipeline/index.ts` before any 
 1. **DM** -- always responds.
 2. **Explicit `@Aura` mention** -- always responds.
 3. **Addressed by name** -- always responds.
-4. **LLM gate (thread participant, recent channel activity, or cold observation)** -- a fast model decides whether a response would add value. Fail-closed when in doubt.
+4. **LLM gate (thread participant, recent channel activity, or cold observation)** -- a fast model decides whether a response would add value. If the gate errors, thread-participant checks fail **open** (better to over-respond than drop a thread Aura is part of); recent-activity and cold-observation checks fail **closed**.
 
 Two workspace settings (in the `settings` table, editable via SQL with no redeploy) override these tiers:
 
@@ -39,7 +39,7 @@ DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
 
 ### `always_process_channels`
 
-A JSON array of channel IDs that **bypass the LLM gate** (Tier 4). Aura still runs the pipeline and the LLM decides whether to send a reply, but the cheap fast-model gate that normally suppresses cold-observation responses is skipped.
+A JSON array of channel IDs that **replace the Tier-4 cold-observation gate with an unconditional respond**. For messages that would otherwise reach cold observation, Aura responds deterministically -- no fast-model gate runs at all. Note the override only applies at Tier 4: if Aura is a thread participant or recently active in the channel, the Tier 2/3 LLM gates still run and can decide not to reply.
 
 Typical use: small high-signal channels where every message is worth full processing.
 
@@ -323,7 +323,7 @@ Upload a file to Slack. Two modes: pass `content` for text files (CSV, JSON, cod
 ---
 
 ### `download_slack_file`
-Download a Slack file by its file ID. Returns base64-encoded content by default. Set `save_to_disk` to write to `/home/user/downloads/` for processing with shell tools.
+Download a Slack file by its file ID. Returns base64-encoded content by default. Set `save_to_disk` to write to `/home/user/downloads/` for processing with shell tools. Files over 20 MB are rejected.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|


### PR DESCRIPTION
Daily docs-maintenance audit of `content/docs/tools/slack.mdx` vs live code (`tools/slack.ts`, `tools/lists.ts`, `pipeline/index.ts`, `pipeline/context.ts`, `lib/files.ts`).

## P0 — factually wrong
- **User token claim**: docs said "search and DM listing require the user token". `list_dm_conversations` uses the **bot** token (`client.conversations.list({types:'im'})`) and is gated on the `admin_access` credential instead. Only `search_messages` needs `SLACK_USER_TOKEN` (slack.ts:1299).
- **Tool count**: header said 34; actual is 37 (34 in slack.ts + 3 list-write tools in lists.ts), all of which the page already documents.

## P2 — misrepresents current behavior
- **LLM gate failure mode**: docs said blanket "fail-closed when in doubt". Code splits it: Tier 2 thread-participant fails **open**, Tiers 3/4 fail **closed** (context.ts:360-369).
- **`always_process_channels` semantics**: docs said the pipeline "still runs and the LLM decides whether to reply". Code returns `{respond: true}` deterministically before the Tier-4 gate — no fast-model call at all. Also clarified the override only applies at Tier 4; Tier 2/3 gates still run first (context.ts:227-230).

## P3
- `download_slack_file`: documented the 20 MB limit (`MAX_FILE_SIZE`, lib/files.ts:5).

Verified accurate (no change needed): all 37 tool param tables vs zod schemas, gated_channels behavior (#921), edit_canvas operations enum, Tier 1 deterministic checks (DM/mention/addressed-by-name), read_dm_history time-window params, share_canvas access levels.

Part of the daily docs-maintenance job. One-file, docs-only change.