### PR TITLE
docs(people): fix people.mdx drift (false admin-only claim, email lookup, fuzzy matches)

### DIFF
--- a/content/docs/tools/people.mdx
+++ b/content/docs/tools/people.mdx
@@ -11,10 +11,11 @@ Aura maintains a structured database of people she interacts with -- team member
 
 For each person, Aura tracks:
 
-- **Identity** — Name, email, Slack ID, role, team
-- **Preferences** — Preferred language, communication style, timezone
+- **Identity** — Name, email, Slack ID, job title, manager, birthdate
+- **Preferences** — Preferred language, communication style, timezone, gender
 - **Notes** — Free-form observations from conversations
-- **Interaction history** — Frequency and recency of conversations
+- **Addresses** — Multiple contact addresses per person (email, phone, slack) with one primary per channel
+- **Interaction history** — Frequency and recency of conversations (workspace messages, Aura DMs, last activity)
 
 ## How It's Used
 
@@ -26,8 +27,18 @@ The people database feeds into every conversation:
 
 ## Tools
 
-- `get_person` — Look up a person's full profile by name or Slack ID
-- `update_person` — Update profile fields (admin only)
+### `get_person`
+
+Look up a person by **name, Slack user ID, or email address**. Returns the full profile: job title, gender, preferred language, birthdate, manager, notes, all known addresses (email, phone, slack), and Slack activity stats (workspace messages, Aura DM messages, last activity, last Aura DM). Ambiguous name searches return up to 3 fuzzy matches.
+
+### `update_person`
+
+Update a person's profile. Not admin-gated — available in all contexts, so Aura is expected to exercise judgment (and always run `get_person` first to verify identity).
+
+- **Identification**: by `person_id` (UUID, preferred) or `query` (fuzzy lookup that must resolve to exactly 1 person)
+- **Fields**: display name, job title, gender, preferred language (`en`/`fr`/`es`/`it`/`de`/`pt`), birthdate (`YYYY-MM-DD`), manager, notes
+- **Shorthands**: `phone` (E.164) and `email` upsert the primary address for that channel
+- **Addresses**: `add_address` / `remove_address` manage non-primary addresses (channel + value)
 
 ## Privacy
 


### PR DESCRIPTION
Daily docs maintenance run (Jul 27).

**P0 — factually wrong**: `people.mdx` claimed `update_person` is "admin only". It isn't — the tool carries no `requiredCredentials: ["admin_access"]` gate (verified against `apps/api/src/tools/people.ts` and `apps/api/src/lib/tool.ts`; only `dispatch_headless`, `list_dm_conversations`, and one jobs tool are gated in the whole codebase). Reworded to state it's available in all contexts with judgment expected.

**P2 — undersold `get_person`**: docs said lookup "by name or Slack ID". Actually also by **email**, returns Slack activity stats (workspace messages, Aura DMs, last activity), and returns up to **3 fuzzy matches** on ambiguous names.

**P2 — undersold `update_person`**: now documents `person_id` vs `query` identification, the full updatable field set (incl. `preferred_language` enum and `YYYY-MM-DD` birthdate), `phone`/`email` primary-upsert shorthands, and `add_address`/`remove_address`.

Also synced "What's Stored" with the real schema (addresses table with one primary per channel; interaction stats; timezone stored but not updatable via the tool).

Audit context: main frozen at `3718765` for 11 days; this run also audited `conversations.mdx` — fully accurate, no changes needed.