### PR TITLE
fix(cron): pick up requeued recurring jobs within one heartbeat cycle

### DIFF
--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -552,6 +552,147 @@ describe("heartbeat stale running recovery", () => {
     );
   });
 
+  it("marks stale-running recovered jobs for immediate pickup via executeAt (issue #1244)", async () => {
+    queueDbResults(
+      [], // pending jobs
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // orphan pending_review outcomes
+      [], // orphan in_progress outcomes
+      [], // dequeued jobs without execution rows
+      [{ id: "job-stale-recurring", name: "alicia-lista-prospeccion-diaria", workspaceId: "default" }],
+      [], // no stale exhausted jobs
+      [], // running execution cleanup
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    const recoverySet = updateSets().find(
+      (set) => set.status === "pending" && set.executeAt instanceof Date,
+    );
+    expect(recoverySet).toBeDefined();
+    // executeAt = now → due on the very next sweep via the executeAt <= now branch
+    expect((recoverySet!.executeAt as Date).toISOString()).toBe(
+      "2026-05-20T08:59:00.000Z",
+    );
+    // lastExecutedAt is the cron-dedup anchor and must NOT be mutated on recovery
+    expect(recoverySet).not.toHaveProperty("lastExecutedAt");
+  });
+
+  it("picks up a requeued recurring job with a past executeAt even when cron dedup says not due (issue #1244)", async () => {
+    // Cron "0 10 * * *" at 2026-05-20T08:59Z → lastCronTick = 2026-05-19T10:00Z.
+    // lastExecutedAt >= lastCronTick means isRecurringJobDue() returns false,
+    // but the concrete past executeAt (manual requeue / stale recovery) must win.
+    const requeuedJob = baseJob({
+      status: "pending",
+      cronSchedule: "0 10 * * *",
+      name: "alicia-lista-prospeccion-diaria",
+      retries: 0,
+      executeAt: new Date("2026-05-20T08:30:00.000Z"),
+      lastExecutedAt: new Date("2026-05-20T08:00:00.000Z"),
+    });
+
+    executeJobMock.mockResolvedValue(true);
+    queueDbResults(
+      [requeuedJob], // pending jobs
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // orphan pending_review outcomes
+      [], // orphan in_progress outcomes
+      [], // dequeued jobs without execution rows
+      [], // stale running jobs below max retries
+      [], // stale exhausted jobs
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-1", name: "alicia-lista-prospeccion-diaria" }),
+      "heartbeat",
+    );
+    const body = await response.json();
+    expect(body.executed).toBe(1);
+  });
+
+  it("still skips a normal recurring job whose lastExecutedAt covers the current cron tick (regression)", async () => {
+    // executeAt NULL + lastExecutedAt >= lastCronTick → not due; normal cron
+    // scheduling must be unaffected by the requeue-pickup fix.
+    const upToDateJob = baseJob({
+      status: "pending",
+      cronSchedule: "0 10 * * *",
+      name: "already-ran-this-tick",
+      retries: 0,
+      executeAt: null,
+      lastExecutedAt: new Date("2026-05-20T08:00:00.000Z"),
+    });
+
+    queueDbResults(
+      [upToDateJob], // pending jobs
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // orphan pending_review outcomes
+      [], // orphan in_progress outcomes
+      [], // dequeued jobs without execution rows
+      [], // stale running jobs below max retries
+      [], // stale exhausted jobs
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeJobMock).not.toHaveBeenCalled();
+    const body = await response.json();
+    expect(body.executed).toBe(0);
+  });
+
+  it("still picks up a normal cron-due recurring job with executeAt NULL (regression)", async () => {
+    // lastExecutedAt < lastCronTick (2026-05-19T10:00Z) → cron-due as before.
+    const cronDueJob = baseJob({
+      status: "pending",
+      cronSchedule: "0 10 * * *",
+      name: "cron-due-job",
+      retries: 0,
+      executeAt: null,
+      lastExecutedAt: new Date("2026-05-19T09:00:00.000Z"),
+    });
+
+    executeJobMock.mockResolvedValue(true);
+    queueDbResults(
+      [cronDueJob], // pending jobs
+      [], // expired plan notes
+      [], // stale plan notes
+      [], // orphan pending_review outcomes
+      [], // orphan in_progress outcomes
+      [], // dequeued jobs without execution rows
+      [], // stale running jobs below max retries
+      [], // stale exhausted jobs
+    );
+
+    const { heartbeatApp } = await import("./heartbeat.js");
+    const response = await heartbeatApp.request("/api/cron/heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-1", name: "cron-due-job" }),
+      "heartbeat",
+    );
+    const body = await response.json();
+    expect(body.executed).toBe(1);
+  });
+
   it("legacy escalation is no longer called", () => {
     const source = readFileSync(new URL("./heartbeat.ts", import.meta.url), "utf8");
     const legacyFunction = ["maybe", "Escalate", "Consecutive", "Recurring", "Failures"].join("");

--- a/apps/api/src/cron/heartbeat.ts
+++ b/apps/api/src/cron/heartbeat.ts
@@ -421,6 +421,17 @@ heartbeatApp.get("/api/cron/heartbeat", async (c) => {
       .set({
         status: "pending",
         retries: sql`${jobs.retries} + 1`,
+        // Mark for immediate pickup (issue #1244): a concrete past executeAt
+        // makes the job due on the very next sweep via the `executeAt <= now`
+        // branch of the due-job query — the app-side filter short-circuits on
+        // executeAt before evaluating isRecurringJobDue, and `executeAt ASC
+        // NULLS LAST` sorts it ahead of NULL recurring rows. Without this,
+        // recovered recurring jobs stayed invisible until the next cron tick
+        // and then starved behind the MAX_JOBS_PER_SWEEP cap for hours.
+        // Do NOT touch lastExecutedAt here — it is the cron-dedup anchor
+        // (lastExecutedAt >= lastCronTick → not due) and mutating it would
+        // break normal cron scheduling.
+        executeAt: now,
         updatedAt: new Date(),
       })
       .where(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1244

## Problem

Manually requeued recurring jobs were not picked up for 3+ hours (observed twice on `alicia-lista-prospeccion-diaria`: requeued 07:34 UTC, picked up 10:37 UTC — ~6 missed heartbeat cycles). Acceptance: a manual requeue must be picked up within one heartbeat cycle (~30 min), with no regression to normal cron-scheduled pickup.

## Root cause

Two compounding defects, both in `apps/api/src/cron/heartbeat.ts`:

1. **Stale-running recovery left recurring jobs starved.** The recovery UPDATE (`running` → `pending`) set only `status`, `retries`, and `updatedAt` — it did not touch `executeAt`. A recovered recurring job with `executeAt` NULL was invisible to the due-filter until the next cron tick, and then had to compete with 125+ pending recurring jobs under the `MAX_JOBS_PER_SWEEP = 10` cap, starving for hours.
2. **`isRecurringJobDue` has no concept of a manual requeue.** For cron jobs, due-ness is purely `lastExecutedAt < lastCronTick`, so "run it NOW" intent had no signal — unlike the supervisor retry paths (`retry_as_is` / `retry_with_fix` in `supervisor.ts`), which correctly set `executeAt: now` and are picked up immediately.

## Fix

Treat "explicitly re-queued" as `executeAt = now`, which the existing machinery already honors:

- The stale-running recovery UPDATE now also sets `executeAt: now`. The due-job query's `lte(jobs.executeAt, now)` OR-branch matches the job regardless of `isRecurringJobDue` (the app-side filter short-circuits on `job.executeAt` before the recurring eval), and `executeAt ASC NULLS LAST` sorts it ahead of NULL recurring rows — front of the queue, not the back.
- `lastExecutedAt` is deliberately NOT touched — it is the cron-dedup anchor (`lastExecutedAt >= lastCronTick → not due`) and mutating it would break normal cron scheduling.
- No leak into subsequent runs: on successful recurring execution, `execute-job.ts` already resets `executeAt` to NULL, so the immediate-pickup timestamp is consumed by exactly one run.

Verified (per the issue's step 2) that the `executeAt <= now` short-circuit fires for recurring jobs with a concrete past `executeAt` — no code path requires `executeAt` to be NULL to evaluate a recurring job, so no further change was needed there. Pure logic change; no schema change, no migration, no new column.

Out of scope, untouched as required: `isRecurringJobDue` frequency-guard semantics (#1238), `lastExecutedAt` writes in `execute-job.ts`, the dequeued-without-execution sweep, `MAX_JOBS_PER_SWEEP`, per-job stale threshold (#1200).

## Tests

Added four tests to `apps/api/src/cron/heartbeat.test.ts`:

- Stale-running recovery sets `executeAt = now` on the recovered job (and asserts `lastExecutedAt` is not mutated), so it is due on the very next sweep.
- A recurring job with a concrete past `executeAt` is executed via the `executeAt <= now` branch even when `isRecurringJobDue` would return false (`lastExecutedAt >= lastCronTick`) — the manual requeue case.
- Regression guard: a recurring job with `executeAt` NULL and `lastExecutedAt >= lastCronTick` is still NOT due.
- Regression guard: a normal cron-due recurring job (`executeAt` NULL, `lastExecutedAt < lastCronTick`) is still picked up.

Results:

- Full cron suite (`src/cron`): 57/57 pass.
- Full API suite: 352/353 pass. The one failure is **pre-existing and unrelated**: `src/eval/judge.test.ts > supports honest capability-boundary refusals as partial/fulfilled instead of failed` — it fails identically on the unmodified branch (verified via `git stash`), so it was left alone per the issue instructions.
- `pnpm typecheck` (API + dashboard): clean.

## Merge gates

- Pure logic change in `heartbeat.ts`, no migration — safe to merge without a Joan DB gate, but this is the cron-critical path, so it still needs human review.
- Coexists with in-flight PR #1183 (job-notifications routing): this change does not touch `job-notifications.ts`, `supervisor.ts`, or `execute-job.ts`, so no conflict expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6bd1f3b-4ecf-4ff4-b3e2-dd8eb9560d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6bd1f3b-4ecf-4ff4-b3e2-dd8eb9560d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

