### PR TITLE
docs(browser): fix browser.mdx config drift + document browse tool params

### DIFF
--- a/content/docs/tools/browser.mdx
+++ b/content/docs/tools/browser.mdx
@@ -16,6 +16,27 @@ Aura can browse the web interactively using a headless browser powered by [Brows
 | Interactive browsing (click, scroll, fill forms) | `browse` |
 | Take a screenshot of a page | `browse` |
 
+## The `browse` Tool
+
+Two modes, mutually exclusive:
+
+- **Simple mode** -- provide a `url` to navigate, screenshot, and extract content.
+- **Code mode** -- provide Playwright JS `code` for multi-step automation. Variables `page`, `context`, and `browser` are available; return a result object or void.
+
+Returns a screenshot (base64 PNG), extracted text/HTML/accessibility tree, the final URL and page title, the `session_id`, and console errors (capped at 10 entries). In code mode, the return value is included as `code_result` (JSON-stringified when not a string).
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | conditional | URL to navigate to (simple mode, mutually exclusive with `code`) |
+| `code` | string | conditional | Playwright JS code to execute (code mode, mutually exclusive with `url`) |
+| `extract` | enum | no | `text` (innerText, max 16k chars), `accessibility` (a11y tree, max 16k chars), or `html` (raw HTML, max 32k chars) |
+| `screenshot` | boolean | no | Take a screenshot after navigation (default true) |
+| `session_id` | string | no | Reuse an existing Browserbase session ID. If omitted, a new session is created with `keepAlive=true` and its ID is returned |
+| `release_session` | boolean | no | Close the session after this call (default false; use on the final call in a chain). Sessions are also released automatically if an owned session fails |
+| `headers` | object | no | Custom HTTP headers to set before navigation |
+| `stealth` | boolean | no | Stealth fingerprinting (`en-US` locale) to reduce bot detection (default true) |
+| `timeout_seconds` | number | no | Per-operation timeout in seconds (default 30, min 5, max 120) |
+
 ## Capabilities
 
 - **Navigate** to any URL
@@ -32,8 +53,14 @@ Aura can browse the web interactively using a headless browser powered by [Brows
 - Filling out forms or completing multi-step workflows
 - Scraping content from JavaScript-rendered pages
 - Taking visual screenshots for reporting
-- Navigating authenticated web UIs (with stored credentials)
 
 ## Infrastructure
 
-Browser sessions run on [Browserbase](https://browserbase.com), a managed headless browser service. Each session is isolated and ephemeral. Requires a `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` in environment variables.
+Browser sessions run on [Browserbase](https://browserbase.com), a managed headless browser service. New sessions are created with `keepAlive=true` so they can be reused across a multi-turn chain via the `session_id` / `release_session` params; unreleased sessions are reclaimed by Browserbase after its session timeout.
+
+Two pieces of configuration are required, from two different places:
+
+1. **`browserbase_api_key`** -- stored as an encrypted credential (Dashboard > Credentials). There is no environment-variable fallback; the credential must exist in the credential store.
+2. **`browserbase_project_id`** -- a workspace setting (Dashboard > Settings), not an environment variable.
+
+The tool is hidden from the model unless the `browserbase_api_key` credential is configured.


### PR DESCRIPTION
## Drift found (daily docs-maintenance audit, Jul 28)

Audited `web.mdx` + `browser.mdx` against `apps/api/src/tools/{web,browser}.ts` + `lib/browser.ts` @ `3718765`.

**web.mdx: CLEAN** — requiredCredentials gating, param table, 500-char snippets, basic depth, SSRF guard (10 re-validated hops), 4000-char truncation, 10s timeout, 403 hint, `source` field all match code.

**browser.mdx fixes:**

- **P0 — false config instructions**: docs said `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID` env vars. Reality: `browserbase_api_key` is an encrypted credential (requiredCredentials gate, no env fallback — tool hidden until configured) and `browserbase_project_id` is a workspace setting via `getConfig()`. Following the old docs, the tool would never appear.
- **P2 — `browse` tool undocumented on this page**: no param table, no return fields. Added full param table (all 9 params verified vs zod schema) and return fields incl. console_errors 10-entry cap + code_result JSON-stringification.
- **P2 — false feature claim**: `Navigating authenticated web UIs (with stored credentials)` — no such feature exists. Removed.

Note: `web.mdx` also documents `browse` (duplicate param table, accurate). Flagging the overlap as a structural issue for a future pass — out of scope here.