### PR TITLE
docs(cursor-agent): fix param drift vs tool schema

### DIFF
--- a/content/docs/tools/cursor-agent.mdx
+++ b/content/docs/tools/cursor-agent.mdx
@@ -23,12 +23,10 @@ Dispatch an async agent to work on a code task. Returns immediately with an agen
 | `branch_prefix` | string | no | Branch prefix (default `cursor`) — agent creates `cursor/{slug}` |
 | `ref` | string | no | Git ref to base work on (default `main`) |
 | `key_files` | string[] | no | Key files for the agent to focus on |
-| `cursor_rules` | string | no | Additional `.cursor/rules` content injected for this task |
-| `repo` | string | no | GitHub repo (default: `AuraHQ-ai/aura`) |
+| `repository` | string | no | GitHub repo in `owner/repo` format (default: the `default_github_repo` workspace setting, falling back to `AuraHQ-ai/aura`) |
 
 **Best practices:**
 - Always specify `key_files` to reduce agent wandering
-- Include `cursor_rules` for project-specific conventions (e.g. Drizzle migration breakpoints)
 - Say "create a PR" explicitly in the description — agents sometimes finish without opening one
 
 ---
@@ -47,12 +45,12 @@ Returns status (`running`, `completed`, `failed`), elapsed time, and result deta
 
 ## `followup_cursor_agent`
 
-Send a follow-up message to a running or completed agent — like a code review comment. The agent will continue working based on your feedback.
+Send follow-up instructions to a finished agent — like a code review comment. The agent continues working on the same branch/PR. Use this instead of dispatching a new agent when iterating on the same task.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `agent_id` | string | **yes** | Agent ID |
-| `message` | string | **yes** | Follow-up instruction or review feedback |
+| `prompt` | string | **yes** | Follow-up instruction or review feedback |
 
 ---
 


### PR DESCRIPTION
Daily docs-maintenance audit of cursor-agent.mdx vs `apps/api/src/tools/cursor-agent.ts` (main @ d0d3f81).

Fixes:
- **P1**: remove phantom `cursor_rules` param from `dispatch_cursor_agent` — not in the zod schema, never was implemented
- **P1**: `repo` → `repository` — actual param name in schema; also correct the default (workspace setting `default_github_repo`, falling back to `AuraHQ-ai/aura`)
- **P1**: `followup_cursor_agent` param `message` → `prompt` — actual zod param name
- **P2**: followup scope — doc said "running or completed", tool description says finished agents only (Cursor API `/followup` semantics)

Verified against tool source: all other param tables (check, get_conversation, stop, list) match zod schemas. Webhook/tracking-note behavior confirmed in code.