### PR TITLE
docs(lists): document create/delete list item tools + field formats

### DIFF
--- a/content/docs/tools/lists.mdx
+++ b/content/docs/tools/lists.mdx
@@ -5,21 +5,25 @@ description: "Interact with Slack Lists for bug tracking, task management, and p
 
 # Slack Lists
 
-Aura can read and interact with [Slack Lists](https://slack.com/features/lists) -- structured databases inside Slack used for bug tracking, task management, and more.
+Aura can read, create, update, and delete items in [Slack Lists](https://slack.com/features/lists) -- structured databases inside Slack used for bug tracking, task management, and more.
 
 ## Capabilities
 
 - **Read list items** — Fetch all items (rows) from a Slack List with their fields
 - **Get item details** — Read a specific item's full fields and metadata
-- **Comment on items** — Each list item has a thread; Aura can post comments using the item's `thread_channel_id` and `thread_ts`
+- **Create items** — Add new rows with initial field values
 - **Update items** — Modify field values on list items (status, assignee, priority, etc.)
+- **Delete items** — Remove rows from a list
+- **Comment on items** — Each list item has a thread; Aura can post comments using the item's `thread_channel_id` and `thread_ts`
 
 ## Tools
 
 - `list_slack_list_items` — Retrieve items from a Slack List (supports pagination)
 - `get_slack_list_item` — Get full details for a specific item
+- `create_slack_list_item` — Create a new item. Takes `list_id` and an optional `fields` object of column_id → value pairs; values must match the exact format returned by `get_slack_list_item`
+- `update_slack_list_item` — Update fields on a list item. Accepts simple formats (string for text, `["value"]` for select/status, `["U01234"]` for users) or typed objects (`{select: ["done"]}`, `{date: ["2025-09-20"]}`). Date fields **must** use typed objects
+- `delete_slack_list_item` — Delete an item from a list
 - `send_thread_reply` — Comment on a list item's thread (using thread_channel_id + thread_ts from the item)
-- `update_slack_list_item` — Update fields on a list item
 
 ## Use Case: Bug Triage
 
@@ -33,6 +37,6 @@ Aura runs recurring bug triage jobs that:
 
 ## Important Notes
 
-- Always call `get_slack_list_item` before `update_slack_list_item` to discover the exact column IDs and value formats
+- Always call `get_slack_list_item` before `create_slack_list_item` or `update_slack_list_item` to discover the exact column IDs and value formats
 - Always check a thread with `read_thread_replies` before posting to avoid duplicate comments
 - List IDs can be found in the Slack List URL or by searching channels


### PR DESCRIPTION
lists.mdx only documented 4 of the 7 Slack List operations. Drift vs `apps/api/src/tools/lists.ts`:

**P1 (undocumented tools):**
- `create_slack_list_item` -- zero docs despite being the only way to add rows
- `delete_slack_list_item` -- zero docs

**P2 (underdocumented behavior):**
- `update_slack_list_item` field value formats (simple vs typed objects, date typed-object requirement) now documented from the tool schema

Docs-only change.