### PR TITLE
docs(email): fix email.mdx drift (sender claim, draft threading params, OAuth scopes)

### DIFF
--- a/content/docs/tools/email.mdx
+++ b/content/docs/tools/email.mdx
@@ -5,14 +5,14 @@ description: "Gmail reading, drafting, sending, triage, calendar management, and
 
 # Email & Calendar Tools
 
-Aura integrates with Gmail and Google Calendar via the Google Workspace APIs. All email and calendar tools respect a hard security boundary: **they always use the requesting user's OAuth token, never Aura's own**. Users must connect their Google account before these tools work.
+Aura integrates with Gmail and Google Calendar via the Google Workspace APIs. User-scoped tools respect a hard security boundary: **they always use the requesting user's OAuth token** (callers can only access their own account; admins can act for others). `send_email`/`reply_to_email` default to sending from Aura's configured address and only use a user's account when `user_name` is set. Users must connect their Google account before user-scoped tools work.
 
 ---
 
 ## Gmail — Sending
 
 ### `send_email`
-Send an email from `aura@realadvisor.com` (default) or from a specific user's account.
+Send an email. Defaults to Aura's configured sending address; pass `user_name` to send from a specific user's account (caller must be that user or an admin).
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -93,6 +93,9 @@ Create a draft email in a user's Gmail account.
 | `cc` | string | no | CC address |
 | `bcc` | string | no | BCC address |
 | `thread_id` | string | no | Gmail thread ID to add the draft to |
+| `in_reply_to` | string | no | Message-ID to reply to (threading) |
+| `references` | string | no | References header (threading) |
+| `quoted_message` | string | no | Original message text to quote in the reply |
 | `attachments` | array | no | Base64-encoded attachments |
 
 ---
@@ -118,11 +121,11 @@ Delete a draft from a Gmail account.
 ---
 
 ### `generate_gmail_auth_url`
-Generate a Google OAuth consent URL so a user can connect their Gmail account. DM the URL to the user — they click it and authorize.
+Generate a Google OAuth consent URL so a user can connect their Gmail account to Aura. DM the link to the user — they click it, authorize in Google, and their Gmail is connected for reading and drafting.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `user_name` | string | no | Whose account to connect (defaults to caller) |
+| `user_name` | string | no | Account owner (defaults to caller; admins may generate for others) |
 
 ---
 
@@ -292,11 +295,15 @@ Find available meeting slots across multiple people's calendars.
 ## Required Google OAuth Scopes
 
 ```
-gmail.readonly
 gmail.send
 gmail.compose
+gmail.readonly
 gmail.modify
+directory.readonly
 calendar.readonly
 calendar.events
-admin.directory.user.readonly
+spreadsheets.readonly
+drive.readonly
 ```
+
+The Sheets and Drive scopes are shared with the Google Sheets / Drive tools.


### PR DESCRIPTION
## Drift found in daily docs audit (Aug 2)

Verified every claim against `apps/api/src/tools/email.ts`, `email-sync.ts`, and `apps/api/src/lib/gmail.ts`.

**P0 (factually wrong):**
- Intro claimed *all* email/calendar tools always use the requesting user's OAuth token and `send_email` defaults to `aura@realadvisor.com`. Source: `send_email`/`reply_to_email` default to Aura's configured sending address; user OAuth is only used when `user_name` is set (caller must be that user or admin). Hard-coded `aura@realadvisor.com` also doesn't exist in source.
- OAuth scopes: `admin.directory.user.readonly` is not a real Google scope name; actual is `directory.readonly`. `spreadsheets.readonly` and `drive.readonly` were missing (both in `gmail.ts` SCOPES).

**P2 (underdocumented):**
- `create_gmail_draft`: `in_reply_to`, `references`, `quoted_message` threading params in schema but absent from docs.
- `generate_gmail_auth_url`: aligned wording with tool description (caller default, admin exception).

Rest of the page audited clean: read_user_emails (incl. page_token/unread_only), read_user_email, download_email_attachment, list/delete_gmail_drafts, workspace directory tools, lookup_contact, all 5 calendar tools, and the full triage suite (sync_emails, email_digest, update_email_thread(s), search_emails) — params, defaults, and enums match source.