### PR TITLE
docs(dashboard): fix dashboard.mdx drift (auth, conversations, jobs, settings)

### DIFF
--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -27,7 +27,7 @@ Browse every conversation Aura has had. Each conversation shows:
 - Cost per conversation
 - Channel and user context
 
-Filter by user, channel, date range, or search by content.
+Search by channel or user name, and filter by source type (interactive vs. job execution). Thread detail pages live at `/conversations/threads/$channelId/$threadTs`.
 
 The **Invocations** sub-tab (`/conversations/invocations`) shows each individual LLM invocation with its tool calls, token counts, and timing -- useful for debugging multi-step agent work.
 
@@ -65,9 +65,9 @@ View and manage Aura's knowledge base:
 
 Monitor scheduled and recurring jobs:
 
-- View pending, running, completed, and failed jobs
-- See execution history and logs
-- Check cron schedules and frequency limits
+- Search jobs by name and browse the paginated list (status, cron schedule, requester, run count, last run, priority)
+- Enable or disable recurring jobs with the inline toggle
+- Open a job's detail page for its execution history (per-run status, timing, and output)
 
 ### Adoption
 
@@ -136,15 +136,14 @@ Manage ingested content:
 
 Configure instance behavior:
 
-- Admin user IDs
-- Model selection from the DB-backed Vercel AI Gateway catalog (searchable autocomplete grouped by provider)
+- Model selection (main, fast, and embedding) from the DB-backed Vercel AI Gateway catalog (searchable autocomplete grouped by provider)
 - Manual "Refresh Catalog" sync for newly available gateway models
-- Feature flags
+- Arbitrary key-value instance settings (lowercase keys; create and edit)
 - Theme selection (light/dark/system) -- moved here from the header
 
 ## Access & Authentication
 
-The dashboard uses Slack OAuth for login. Access requires at least the `power_user` role (see [Permissions](/permissions)). The `AURA_ADMIN_USER_IDS` env var serves as a fallback for users without a database role.
+The dashboard uses Slack OAuth for login. Access requires at least the `power_user` role (see [Permissions](/permissions)); the role is read from the `users` table at login. If no admin exists yet, the first Slack user to log in is bootstrapped as `admin` automatically.
 
 ### Slack OIDC
 


### PR DESCRIPTION
Audit of `content/docs/dashboard.mdx` against `apps/dashboard/src/routes/*` and `apps/api/src/routes/dashboard/*` (docs-maintenance run, Aug 3).

## Findings & fixes

**P0 — Access & Authentication:** doc claimed `AURA_ADMIN_USER_IDS` env var serves as a login fallback for users without a database role. Not true: `routes/dashboard/auth.ts` reads the role from the `users` table only, and bootstraps the first user as `admin` when none exists. The env var is only used by tool-call permission gating in `lib/permissions.ts` (explicitly prioritized there because migration 0045 left everyone at `member`). Fixed to describe the actual behavior.

**P0 — Conversations:** doc said filterable by user, channel, date range, or content search. The actual page has a channel/user-name search box and a source-type filter (`interactive` / `job_execution`) — no date-range or full-content filter. Also added the thread detail route (`/conversations/threads/$channelId/$threadTs`).

**P2 — Jobs:** doc described browsing by status (pending/running/completed/failed), execution logs, and frequency limits. Actual page: name search, paginated table (status, cron, requester, run count, last run, priority), inline enable/disable toggle; execution history lives on the job detail page. Rewritten to match.

**P2 — Settings:** doc listed "Admin user IDs" management (doesn't exist in the UI) and "Feature flags". Actual page: model selection (main, fast, embedding) from the gateway catalog, Refresh Catalog sync, arbitrary key-value settings table, theme. Rewritten to match.

## Verified accurate (no change)

Overview stats cards, Consumption (URL-reflected date range, model/user breakdowns), Memories types + Entities sub-tab, Adoption (180-day default, Europe/Amsterdam — confirmed in `adoption.ts`), Credentials (scopes incl. `per_user`, token/OAuth-client types), Evals (hourly cron, 20-turn windows, verdict taxonomy, ratification flow), Errors (bulk resolve), Users (4 roles incl. owner), Resources filters, Slack OIDC env vars, Chat panel (resumable streams, durable workflow runs, JSON export, model picker sync), Navigation (sidebar-footer pattern).