### PR TITLE
docs(voice): fix env-var drift (credential store + workspace settings), document send_voice_note hourly quota

### DIFF
--- a/content/docs/tools/voice.mdx
+++ b/content/docs/tools/voice.mdx
@@ -7,7 +7,16 @@ description: "Outbound phone calls, SMS, and voice notes via ElevenLabs and Twil
 
 Aura can make outbound phone calls using [ElevenLabs](https://elevenlabs.io) voice agents and [Twilio](https://twilio.com) for PSTN routing. She can also send SMS messages and generate voice notes (text-to-speech audio) in Slack.
 
-**Required env vars:** `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`, `ELEVENLABS_VOICE_ID`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`
+**Configuration** — API keys are encrypted credentials (Dashboard > Credentials); IDs and numbers are workspace settings (Dashboard > Settings). There is no environment-variable fallback for the API keys.
+
+| Name | Where | Used by |
+|------|-------|---------|
+| `elevenlabs_api_key` | credential store | `list_voice_agents`, `place_call`, `send_voice_note` |
+| `twilio_account_sid`, `twilio_auth_token` | credential store | `send_sms` |
+| `elevenlabs_agent_id` | workspace setting | `place_call` (default agent) |
+| `elevenlabs_voice_id` | workspace setting | `place_call`, `send_voice_note` (default voice) |
+| `elevenlabs_from_number` | workspace setting | `place_call` (default caller number) |
+| `twilio_phone_number` | workspace setting | `send_sms` (sender number) |
 
 ---
 
@@ -61,3 +70,6 @@ Generate a voice note from text using ElevenLabs TTS and upload it to Slack as a
 | `thread_ts` | string | no | Thread timestamp to post in a specific thread |
 | `language` | string | no | Language hint for the TTS model |
 | `voice_id` | string | no | ElevenLabs voice ID override |
+
+**Rate limit:** `send_voice_note` is quota-limited per hour (default **10 voice notes per hour**, workspace-configurable via the `voice_note_hourly_limit` setting). When the quota is exhausted the tool returns an error with `quota` details plus `retry_after_seconds` / `retry_after_at` indicating when the oldest note in the window expires. Usage is counted from the `voice_calls` table over a rolling 1-hour window.
+


### PR DESCRIPTION
Audit of voice.mdx vs `apps/api/src/tools/voice.ts` (daily docs-maintenance, Aug 4).

**P0** — the preamble listed `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`, `ELEVENLABS_VOICE_ID`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` as required env vars. Actual resolution:
- API keys: `resolveCredentialValue()` → encrypted credential store, **no env fallback** (same drift class as browser.mdx #1271, resources.mdx #1278).
- IDs/numbers: `getConfig()` → settings table (workspace settings).

Replaced with a config table mapping each name to where it lives and which tools use it.

**P2** — the `send_voice_note` hourly quota shipped in #1114 is undocumented: default 10/hour, configurable via the `voice_note_hourly_limit` setting, error includes `quota` + `retry_after_seconds`/`retry_after_at`, rolling 1h window over `voice_calls`. Added to the `send_voice_note` section.

All claims verified against source. Docs-only change.