### PR TITLE
docs(sandbox): E2B_API_KEY resolves from credentials DB, not process.env

### DIFF
--- a/content/docs/tools/sandbox.mdx
+++ b/content/docs/tools/sandbox.mdx
@@ -7,7 +7,7 @@ description: "Run arbitrary shell commands in an isolated Linux VM."
 
 Aura has access to a sandboxed Linux VM powered by [E2B](https://e2b.dev). This allows her to run shell commands, execute code, process files, and interact with the filesystem safely — without risking the production environment.
 
-**Required env var:** `E2B_API_KEY` (and optionally `E2B_TEMPLATE_ID` for a custom template)
+**Configuration:** `E2B_API_KEY` must be stored as a **credential in the dashboard** (shared scope is enough -- it's resolved once under the `"aura"` identity and used to create/connect every user's sandbox). The sandbox itself does not read `process.env` for this. Optionally set `E2B_TEMPLATE_ID` (credential, or env var fallback) to use a custom E2B template.
 
 ---
 


### PR DESCRIPTION
## What

sandbox.mdx claimed `E2B_API_KEY` is a "required env var". It isn't -- it's resolved from the credentials DB.

## Evidence (apps/api/src/lib/sandbox.ts)

- `getSandbox()` calls `getSandboxEnvs("aura")` and reads `envs.E2B_API_KEY` (lines 661-663) -- never `process.env.E2B_API_KEY`.
- `getSandboxEnvs()` builds the env map exclusively from credential rows (`resolveSandboxCredentialRows` + `decryptCredential`).
- The missing-key error message itself says: *"E2B_API_KEY is not configured. Add it as a credential in the dashboard."*
- `E2B_TEMPLATE_ID` does keep a `process.env` fallback (`envs.E2B_TEMPLATE_ID || process.env.E2B_TEMPLATE_ID`, lines 675/745) -- the new wording notes this.

## Drift class

Fourth instance of the env-var-vs-credential-store drift, after browser.mdx (#1271), resources.mdx (#1278), voice.mdx (#1285). All credential access goes through the dashboard credential store now; docs keep lagging.

Found by the daily docs-maintenance job (Aug 5).