### PR TITLE
Fix #1185: NO_OP sentinel hard contract for silent no-op recurring job runs

### DIFF
--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -388,6 +388,7 @@ describe("executeJob reply-routing prompt", () => {
     expect(prompt).toContain('send_thread_reply(channel="C123", thread_ts="111.222")');
     expect(prompt).toContain(SILENT_SUCCESS_CLAUSE);
     expect(prompt).toContain("post NOTHING");
+    expect(prompt).toContain("output exactly `NO_OP`");
   });
 
   it("includes the silent-success clause in the channel-routing variant", async () => {
@@ -397,6 +398,7 @@ describe("executeJob reply-routing prompt", () => {
     expect(prompt).toContain('Post your results to channel "C123" using send_channel_message');
     expect(prompt).toContain(SILENT_SUCCESS_CLAUSE);
     expect(prompt).toContain("post NOTHING");
+    expect(prompt).toContain("output exactly `NO_OP`");
   });
 
   it("does not inject reply-routing for jobs without a channel", async () => {
@@ -404,6 +406,223 @@ describe("executeJob reply-routing prompt", () => {
 
     expect(prompt).not.toContain("Post your results");
     expect(prompt).not.toContain("post NOTHING");
+    expect(prompt).not.toContain("NO_OP");
+  });
+});
+
+describe("executeJob NO_OP sentinel contract", () => {
+  beforeEach(() => {
+    dbMock.results = [];
+    dbMock.operations = [];
+    vi.clearAllMocks();
+  });
+
+  function mockAgentGenerate(text: string, steps: Array<Record<string, unknown>> = []) {
+    createHeadlessAgentMock.mockResolvedValue({
+      agent: {
+        generate: vi.fn(async () => ({ text, steps, totalUsage: {} })),
+      },
+      modelId: "test-model",
+      getStepModelIds: () => [],
+    });
+  }
+
+  function updateSetArgs() {
+    return dbMock.operations
+      .filter((operation) => operation.kind === "update")
+      .map((operation) => operation.setArg ?? {});
+  }
+
+  function jobOutcomeInsert() {
+    return insertValues().find((values) => "outcomeStatus" in values) as
+      | Record<string, any>
+      | undefined;
+  }
+
+  async function runLlmJob(jobOverrides: Record<string, unknown> = {}) {
+    queueDbResults([{ id: "job-1" }], [{ id: "exec-1" }]);
+    const { executeJob } = await import("./execute-job.js");
+    return executeJob(
+      baseJob({
+        script: null,
+        playbook: "Check for new signups. Stay silent when there is nothing new.",
+        channelId: "C123",
+        cronSchedule: "0 9 * * *",
+        ...jobOverrides,
+      }) as any,
+      "heartbeat",
+    );
+  }
+
+  it("completes a clean no-op (final text exactly NO_OP, no posting tools) with the honest marker", async () => {
+    const { NO_OP_RESULT_MARKER } = await import("./execute-job.js");
+    mockAgentGenerate("NO_OP", [
+      {
+        finishReason: "stop",
+        text: "NO_OP",
+        toolCalls: [{ toolName: "bigquery_query", input: { query: "select 1" } }],
+        toolResults: [{ toolName: "bigquery_query", output: { rows: [] } }],
+      },
+    ]);
+
+    await expect(runLlmJob()).resolves.toBe(true);
+
+    const setArgs = updateSetArgs();
+    expect(setArgs.find((arg) => "summary" in arg)).toMatchObject({
+      status: "completed",
+      summary: NO_OP_RESULT_MARKER,
+    });
+    expect(setArgs.find((arg) => "lastResult" in arg)).toMatchObject({
+      status: "pending",
+      lastResult: NO_OP_RESULT_MARKER,
+    });
+
+    expect(jobOutcomeInsert()).toMatchObject({
+      outcomeStatus: "succeeded",
+      output: expect.objectContaining({
+        type: "llm",
+        final_message: "NO_OP",
+        no_op: true,
+      }),
+    });
+
+    const { logger } = await import("../lib/logger.js");
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalledWith(
+      expect.stringContaining("NO_OP sentinel contract violation"),
+      expect.anything(),
+    );
+  });
+
+  it("supports the NO_OP: <reason> variant and records the reason", async () => {
+    const { NO_OP_RESULT_MARKER } = await import("./execute-job.js");
+    mockAgentGenerate("NO_OP: no new signups today", [
+      { finishReason: "stop", text: "NO_OP: no new signups today", toolCalls: [], toolResults: [] },
+    ]);
+
+    await expect(runLlmJob()).resolves.toBe(true);
+
+    const expectedMarker = `${NO_OP_RESULT_MARKER} (no new signups today)`;
+    const setArgs = updateSetArgs();
+    expect(setArgs.find((arg) => "summary" in arg)).toMatchObject({ summary: expectedMarker });
+    expect(setArgs.find((arg) => "lastResult" in arg)).toMatchObject({ lastResult: expectedMarker });
+
+    expect(jobOutcomeInsert()?.output).toMatchObject({
+      no_op: true,
+      no_op_reason: "no new signups today",
+    });
+  });
+
+  it("does not suppress narration text without the sentinel (sentinel-only contract)", async () => {
+    const narration = "Checked signups, nothing new to report today.";
+    mockAgentGenerate(narration, [
+      { finishReason: "stop", text: narration, toolCalls: [], toolResults: [] },
+    ]);
+
+    await expect(runLlmJob()).resolves.toBe(true);
+
+    const setArgs = updateSetArgs();
+    expect(setArgs.find((arg) => "summary" in arg)).toMatchObject({ summary: narration });
+    expect(setArgs.find((arg) => "lastResult" in arg)).toMatchObject({ lastResult: narration });
+
+    const outcome = jobOutcomeInsert();
+    expect(outcome?.output.final_message).toBe(narration);
+    expect(outcome?.output.no_op).toBeUndefined();
+    expect(outcome?.output.no_op_violation).toBeUndefined();
+  });
+
+  it("logs a contract violation when the model posts to Slack and then declares NO_OP", async () => {
+    mockAgentGenerate("NO_OP", [
+      {
+        finishReason: "tool-calls",
+        text: "",
+        toolCalls: [
+          { toolName: "send_channel_message", input: { channel: "C123", text: "nothing new" } },
+        ],
+        toolResults: [{ toolName: "send_channel_message", output: { ok: true } }],
+      },
+      { finishReason: "stop", text: "NO_OP", toolCalls: [], toolResults: [] },
+    ]);
+
+    await expect(runLlmJob()).resolves.toBe(true);
+
+    const { logger } = await import("../lib/logger.js");
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining("NO_OP sentinel contract violation"),
+      expect.objectContaining({
+        jobId: "job-1",
+        executionId: "exec-1",
+        postingToolCalls: ["send_channel_message"],
+      }),
+    );
+
+    // No suppression on violation: result/summary keep the raw final text.
+    const setArgs = updateSetArgs();
+    expect(setArgs.find((arg) => "summary" in arg)).toMatchObject({ summary: "NO_OP" });
+    expect(setArgs.find((arg) => "lastResult" in arg)).toMatchObject({ lastResult: "NO_OP" });
+
+    const outcome = jobOutcomeInsert();
+    expect(outcome?.output.no_op_violation).toBe(true);
+    expect(outcome?.output.no_op).toBeUndefined();
+  });
+});
+
+describe("parseNoOpSentinel", () => {
+  it("matches exactly NO_OP (with surrounding whitespace allowed)", async () => {
+    const { parseNoOpSentinel } = await import("./execute-job.js");
+    expect(parseNoOpSentinel("NO_OP")).toEqual({ reason: null });
+    expect(parseNoOpSentinel("  NO_OP\n")).toEqual({ reason: null });
+  });
+
+  it("captures the optional one-line reason", async () => {
+    const { parseNoOpSentinel } = await import("./execute-job.js");
+    expect(parseNoOpSentinel("NO_OP: no new signups today")).toEqual({
+      reason: "no new signups today",
+    });
+    expect(parseNoOpSentinel("NO_OP:")).toEqual({ reason: null });
+  });
+
+  it("rejects anything that is not the bare sentinel", async () => {
+    const { parseNoOpSentinel } = await import("./execute-job.js");
+    expect(parseNoOpSentinel("Checked X, nothing new. NO_OP")).toBeNull();
+    expect(parseNoOpSentinel("NO_OPS")).toBeNull();
+    expect(parseNoOpSentinel("no_op")).toBeNull();
+    expect(parseNoOpSentinel("NO_OP: reason\nsecond line")).toBeNull();
+    expect(parseNoOpSentinel("")).toBeNull();
+    expect(parseNoOpSentinel(null)).toBeNull();
+  });
+});
+
+describe("findSlackPostingToolCalls", () => {
+  it("flags all direct Slack-posting tools and ignores non-posting tools", async () => {
+    const { findSlackPostingToolCalls } = await import("./execute-job.js");
+    const steps = [
+      {
+        toolCalls: [
+          { toolName: "bigquery_query", input: {} },
+          { toolName: "send_thread_reply", input: { channel: "C1", thread_ts: "1.2" } },
+          { toolName: "draw_chart", input: {} },
+        ],
+      },
+      { toolCalls: [{ toolName: "send_direct_message", input: { user: "U1" } }] },
+      {},
+    ];
+    expect(findSlackPostingToolCalls(steps)).toEqual([
+      "send_thread_reply",
+      "draw_chart",
+      "send_direct_message",
+    ]);
+  });
+
+  it("counts upload_file only when it targets a channel (explicit or job fallback)", async () => {
+    const { findSlackPostingToolCalls } = await import("./execute-job.js");
+    const uploadWithout = [{ toolCalls: [{ toolName: "upload_file", input: { filename: "a.csv" } }] }];
+    const uploadWith = [
+      { toolCalls: [{ toolName: "upload_file", input: { filename: "a.csv", channel: "C1" } }] },
+    ];
+
+    expect(findSlackPostingToolCalls(uploadWithout)).toEqual([]);
+    expect(findSlackPostingToolCalls(uploadWithout, "C_JOB")).toEqual(["upload_file"]);
+    expect(findSlackPostingToolCalls(uploadWith)).toEqual(["upload_file"]);
   });
 });
 

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -77,9 +77,79 @@ You are resuming a multi-step task. Your accumulated progress and context are be
 /**
  * Appended to both injected reply-routing prompts so playbooks that specify
  * silent success are not overridden by a forced "post your results" rule.
+ *
+ * The second half states the hard NO_OP sentinel contract (issue #1185):
+ * silent runs must be declared mechanically via the sentinel, not narrated.
  */
 export const SILENT_SUCCESS_CLAUSE =
-  " However, if your playbook or task instructions say to stay silent on success, or this run produced no user-facing deliverable, post NOTHING — do not post status updates, receipts, or confirmations that the job ran.";
+  " However, if your playbook or task instructions say to stay silent on success, or this run produced no user-facing deliverable, post NOTHING — do not post status updates, receipts, or confirmations that the job ran." +
+  " If your playbook says to stay silent on no-op/no-finding runs and this run has nothing to report: make ZERO Slack-posting tool calls (no send_channel_message, send_thread_reply, send_direct_message, draw_table, draw_chart, draw_cards, or upload_file to a channel) and output exactly `NO_OP` (optionally `NO_OP: <one-line reason>`) as your ENTIRE final message. Never post narration like 'Checked X, nothing new' — the `NO_OP` sentinel is how you report a quiet run.";
+
+// ── NO_OP sentinel (hard silent-run contract, issue #1185) ──────────────────
+
+/** Stored in result/lastResult/summary for a clean no-op run. */
+export const NO_OP_RESULT_MARKER = "No-op run: nothing to report";
+
+/**
+ * Trimmed final text must be exactly `NO_OP`, optionally followed by a
+ * one-line reason after a colon (`NO_OP: no new signups today`).
+ */
+const NO_OP_SENTINEL_RE = /^NO_OP(?::[ \t]*(.*))?$/;
+
+/** Tool calls that always produce user-visible Slack output. */
+const SLACK_POSTING_TOOL_NAMES = new Set([
+  "send_channel_message",
+  "send_thread_reply",
+  "send_direct_message",
+  "draw_table",
+  "draw_chart",
+  "draw_cards",
+]);
+
+type StepWithToolCalls = {
+  toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }>;
+};
+
+/**
+ * Detects the NO_OP sentinel in the model's final message. Sentinel-only
+ * contract: narration prose ("Checked X, nothing new") is never treated as a
+ * no-op declaration.
+ */
+export function parseNoOpSentinel(
+  text: string | null | undefined,
+): { reason: string | null } | null {
+  const trimmed = (text ?? "").trim();
+  const match = trimmed.match(NO_OP_SENTINEL_RE);
+  if (!match) return null;
+  const reason = (match[1] ?? "").trim();
+  return { reason: reason ? reason.slice(0, 200) : null };
+}
+
+/**
+ * Returns the names of Slack-posting tool calls made during generation.
+ * `upload_file` counts when it targets a channel — explicitly via its input,
+ * or implicitly through the job's channel (the tool falls back to
+ * context.channelId when no channel is passed).
+ */
+export function findSlackPostingToolCalls(
+  steps: ReadonlyArray<StepWithToolCalls>,
+  fallbackChannelId?: string | null,
+): string[] {
+  const postingCalls: string[] = [];
+  for (const step of steps) {
+    for (const toolCall of step.toolCalls ?? []) {
+      if (SLACK_POSTING_TOOL_NAMES.has(toolCall.toolName)) {
+        postingCalls.push(toolCall.toolName);
+      } else if (toolCall.toolName === "upload_file") {
+        const channel = (toolCall.input as { channel?: unknown } | null | undefined)?.channel;
+        const targetsChannel =
+          (typeof channel === "string" && channel.length > 0) || !!fallbackChannelId;
+        if (targetsChannel) postingCalls.push(toolCall.toolName);
+      }
+    }
+  }
+  return postingCalls;
+}
 
 // ── Continuation Detection ───────────────────────────────────────────────────
 
@@ -416,6 +486,31 @@ export async function executeJob(
 
     const { text, steps, totalUsage: usage } = generateResult;
 
+    // NO_OP sentinel contract (issue #1185): a clean no-op (sentinel + zero
+    // Slack-posting tool calls) completes normally but records an honest
+    // marker instead of narration. Sentinel + Slack posts is a contract
+    // violation: log it so it's measurable; never suppress or delete posts.
+    const noOpSentinel = parseNoOpSentinel(text);
+    let isCleanNoOp = false;
+    if (noOpSentinel) {
+      const postingToolCalls = findSlackPostingToolCalls(steps, job.channelId);
+      isCleanNoOp = postingToolCalls.length === 0;
+      if (!isCleanNoOp) {
+        logger.warn(
+          "executeJob: NO_OP sentinel contract violation — model posted to Slack and declared NO_OP",
+          {
+            jobId,
+            executionId,
+            jobName: job.name,
+            postingToolCalls,
+          },
+        );
+      }
+    }
+    const noOpMarker = noOpSentinel?.reason
+      ? `${NO_OP_RESULT_MARKER} (${noOpSentinel.reason})`
+      : NO_OP_RESULT_MARKER;
+
     // Phase 2a: persist assistant steps now that generate succeeded
     const stepModelIds = getStepModelIds();
     const conversationSteps = buildConversationSteps(steps, stepModelIds, modelId);
@@ -467,11 +562,13 @@ export async function executeJob(
           ? { steps: serializedSteps, scratchpad: scratchpadContents }
           : serializedSteps,
         tokenUsage,
-        summary: (text || "").substring(0, 500) || null,
+        summary: isCleanNoOp ? noOpMarker.substring(0, 500) : (text || "").substring(0, 500) || null,
       })
       .where(eq(jobExecutions.id, executionId));
 
-    const result = (text || "Job completed (no text output)").substring(0, 2000);
+    const result = (
+      isCleanNoOp ? noOpMarker : text || "Job completed (no text output)"
+    ).substring(0, 2000);
     const now = new Date();
     const todayStr = now.toISOString().slice(0, 10);
     const isNewDay = job.lastExecutionDate !== todayStr;
@@ -523,6 +620,13 @@ export async function executeJob(
       output: {
         type: "llm",
         final_message: text || null,
+        ...(isCleanNoOp
+          ? {
+              no_op: true,
+              ...(noOpSentinel?.reason ? { no_op_reason: noOpSentinel.reason } : {}),
+            }
+          : {}),
+        ...(noOpSentinel && !isCleanNoOp ? { no_op_violation: true } : {}),
         scratchpad: scratchpadContents ?? null,
         ...(scriptExecutionOutput ? { script: scriptExecutionOutput } : {}),
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1185

## Problem

Recurring jobs whose playbooks say "stay silent on no-op runs" still post narration ("Checked X, nothing new") on quiet runs — 566 of 769 June reasoning-eval failures across 3 recurring job families. The existing `SILENT_SUCCESS_CLAUSE` in `apps/api/src/cron/execute-job.ts` is soft prompting: a trailing "However…" that loses to the imperative "IMPORTANT: Post your results" it contradicts, with no enforcement if the model narrates anyway.

## Fix: keep the soft clause, add a hard contract

**Prompt (activation):** `SILENT_SUCCESS_CLAUSE` is extended (additively — the routing lines that inject it are untouched) to state the contract precisely: on a silent no-op run, make ZERO Slack-posting tool calls and output exactly `NO_OP` (optionally `NO_OP: <one-line reason>`) as the ENTIRE final message. Jobs whose playbooks don't ask for silence are unaffected.

**Enforcement (post-generation, in `executeJob`):** after `agent.generate()` returns, `parseNoOpSentinel()` checks whether the trimmed final text is exactly `NO_OP` / `NO_OP: <reason>` (sentinel-only — no fuzzy prose detection). When detected, `findSlackPostingToolCalls()` scans `steps` for `send_channel_message`, `send_thread_reply`, `send_direct_message`, `draw_table`, `draw_chart`, `draw_cards`, and `upload_file` targeting a channel (explicit input or the job-channel fallback the tool uses at runtime):

- **Clean no-op** (sentinel, zero posts): the job completes normally (execution row completed, `persistJobOutcome`, recurring reschedule), but the outcome output records `no_op: true` (+ `no_op_reason` when given) and `result`/`lastResult`/`summary` store the honest marker `No-op run: nothing to report` instead of narration.
- **Contract violation** (sentinel after Slack posts): `logger.warn` with `jobId`/`executionId`/`postingToolCalls` so violations are measurable, and `no_op_violation: true` recorded in the outcome output. Already-posted messages are never deleted; nothing is suppressed.

This makes silence the mechanical default outcome on no-op runs — zero Slack output — without editing any of the 3 existing job-family playbooks.

## Out of scope (per issue)

No playbook storage/schema changes (no migration), no judge/eval changes, no fuzzy no-op prose detection, no `heartbeat.ts` changes.

## Collision note

Changes are strictly additive in the `SILENT_SUCCESS_CLAUSE` region and the post-generation block, deliberately avoiding the `triggeredBy` metadata block that open PR #1286 touches.

## Testing

- `pnpm typecheck` — clean (API + dashboard).
- `pnpm --filter aura-api test src/cron/execute-job.test.ts` — 30/30 pass. New coverage: (a) exact `NO_OP` with no posting tools → completes with honest marker + `no_op: true`; (b) `NO_OP: reason` variant; (c) narration without the sentinel → untouched behavior; (d) sentinel + `send_channel_message` → violation logged, no suppression; plus unit tests for `parseNoOpSentinel` (multiline/`NO_OPS`/lowercase rejected) and `findSlackPostingToolCalls` (incl. `upload_file` channel fallback).
- Full API suite: 440 pass; the 5 failures in `src/eval/judge.test.ts` and `src/pipeline/respond.test.ts` reproduce on unmodified `main` (ba620fe2, native-blocks commit) and are unrelated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1fb5a7b-30ad-4450-9511-e7a355bede80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1fb5a7b-30ad-4450-9511-e7a355bede80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

