### PR TITLE
docs(permissions): flag stale 'owner' option in dashboard role dropdown

### DIFF
--- a/content/docs/permissions.mdx
+++ b/content/docs/permissions.mdx
@@ -81,7 +81,11 @@ Earlier versions had a workspace-scoped `rate_limits` table with per-role quotas
 
 Roles can be set in two ways:
 
-1. **Dashboard** — Navigate to Users → select a user → Profile tab → Role dropdown. Valid options: `admin`, `power_user`, `member`. Requires admin access.
+1. **Dashboard** — Navigate to Users → select a user → Profile tab → Role dropdown. Valid options enforced by the API: `admin`, `power_user`, `member`. Requires admin access.
+
+<Warning>
+The dashboard role dropdown still lists a stale `owner` option (left over from the pre-0048 role system). The API (`VALID_ROLES` in `apps/api/src/routes/dashboard/users.ts`) rejects it with `400 Invalid role`, so selecting `owner` silently fails. This is a dashboard UI bug, not a valid role.
+</Warning>
 2. **Database** — Update `users.role` directly.
 
 ## User Bootstrapping


### PR DESCRIPTION
permissions.mdx audit (3rd non-tool page in backlog cycle). Main still frozen at `ba620fe` — backlog-driven.

**Every claim in permissions.mdx verified against source** (`apps/api/src/lib/permissions.ts`, `packages/db/src/schema.ts`, `apps/api/src/tools/jobs.ts`, `apps/api/src/tools/notes.ts`, `apps/api/src/routes/dashboard/{auth,users}.ts`):

- 3-role hierarchy member/power_user/admin (0/1/2) — matches `ROLE_HIERARCHY`
- `hasRole()` resolution order: `aura` → `AURA_ADMIN_USER_IDS` env → DB `users.role` → default member
- Execution-context userId resolution via AsyncLocalStorage
- Env-before-DB reasoning (0045 never backfilled)
- Credential scopes incl. `owner`/`per_user` (still valid, distinct from removed `owner` *role*), 5-value check constraint, grants override, `google_oauth` synthetic
- Dashboard auth `ALLOWED_ROLES = [admin, power_user]`
- Note scoping: `SYSTEM_TOPICS` = self-directive/business-map/gaps-log + skill category → system; visibility default shared
- Job cap: `MAX_JOBS_PER_USER = 5`, counts pending+enabled, admins + aura exempt
- 0048 (owner role removed) + 0049 (rate_limits removed) migration notes
- Schema block: `users.role` default member, `notes.owner_id/visibility`

**One P1 found:** the dashboard role dropdown (`apps/dashboard/src/routes/users/$slackUserId.tsx`) still lists `owner` as an option, but the API `VALID_ROLES` is `[admin, power_user, member]` — selecting `owner` returns 400. The doc previously said "Valid options: admin, power_user, member" without flagging the stale UI option. Added a `<Warning>` documenting it as a known dashboard UI bug so nobody wastes time on it. (Filing a dashboard fix is out of scope for this docs PR.)

1-PR-per-run cap respected.