### PR TITLE
docs(eval-funnel): correct gold-set export mechanics (no dedup; --corpus-file path into bench)

### DIFF
--- a/content/docs/eval-funnel.mdx
+++ b/content/docs/eval-funnel.mdx
@@ -53,7 +53,9 @@ pnpm ratify:gold-set --ratify <row_id> --gold "Expected answer" \
 pnpm ratify:gold-set --export > ratified-eval-cases.json
 ```
 
-A ratified row carries a human-authored `gold_answer`, an optional `must_do` / `must_not_do` rubric, and `ratified_by`. Ratified failures, deduped by failure class, feed the curated regression bench used to test harness and prompt changes.
+A ratified row carries a human-authored `gold_answer`, an optional `must_do` / `must_not_do` rubric, and `ratified_by`.
+
+`--export` emits every ratified failure or partial (one case per ratified row -- no dedup) in normalized `BenchCase` shape: the last user message before the response becomes the `question`, the prior turns become the session history, and the failure class becomes the `category`. Feed the export to the regression bench with `--corpus-file ratified-eval-cases.json` to test harness and prompt changes. When multiple cases share a failure class, the bench's deterministic stratified sampler caps how many per category a run executes (`toy`/`fast`/`medium` tiers), so a dominant failure class can't crowd out the rest.
 
 ## Dashboard
 


### PR DESCRIPTION
## What

Daily docs-maintenance audit of `eval-funnel.mdx` (4th non-tool backlog page; main still frozen at `ba620fe`).

## Verified accurate (no changes)

- Hourly cron `/api/cron/eval-responses` (vercel.json: `0 * * * *`)
- Settle window: threads active in last 30 min skipped (`SETTLE_MS`)
- `prefilter-v1`: deterministic, zero-LLM, conservative; acks/reactions/waiting/progress/operational-status rules all match `prefilter.ts`
- Windowing: stride 14 + lead 3 + trail 3 ≈ 20 turns (`windowing.ts` constants)
- Judge: one fast-tier structured call per window, `[R:<part_id>]` markers, verdicts mapped by echoed part_id never array position (`judge.ts`)
- Storage: unique `(workspace_id, message_id)` index + `onConflictDoNothing` → idempotent (`schema.ts`, `eval-responses.ts`)
- Verdicts `fulfilled/partial/failed`, failure classes `missing_cred/bad_memory/bad_harness/missing_tool/reasoning/latency/none` — exact match to `schema.ts` enums
- Three data grains (scoring/attribution/filter) — matches schema comments verbatim
- Ratification CLI: all 4 documented commands match `ratify-gold-set.ts` usage exactly
- Dashboard: `/evals` rollups (byFailureClass with cost, byIntent, byUser) + detail pages + inline verdict badges in Conversations timeline (`eval-verdict-badge.tsx`, `unified-timeline.tsx`)

## Fixed (P2 — misrepresented mechanism)

The page claimed ratified failures are **"deduped by failure class"** before feeding the regression bench. No dedup exists anywhere: `ratify-gold-set.ts --export` emits one `BenchCase` per ratified row. What actually exists is the bench's deterministic stratified sampler (`stratifiedSample` in `fixtures.ts`) capping cases per category per run tier (`toy` 2 / `fast` 1 / `medium` 30).

Also documents the previously undocumented handoff: the export feeds the bench via `--corpus-file ratified-eval-cases.json` (`loadExternalCorpus`), and the export's case shape (last user message → `question`, prior turns → session history, failure class → `category`).