### PR TITLE
docs(getting-started): fix deploy instruction — use git push, not vercel --prod

### DIFF
--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -79,9 +79,15 @@ pnpm run db:migrate
 
 ### 6. Deploy to Vercel
 
+Aura deploys automatically when you merge to `main` on GitHub. To trigger your first deploy:
+
 ```bash
-npx vercel --prod
+git push origin main
 ```
+
+<Warning>
+Never run `vercel --prod` from a local checkout — that deploys your local filesystem instead of the reviewed Git commit. See [Environment Variables](/deployment/environment-variables) for details.
+</Warning>
 
 ### 7. Configure Your Slack App
 


### PR DESCRIPTION
## What

Fixes a **P0** in `getting-started.mdx` step 6: it told new deployers to run `npx vercel --prod`, but both `deployment/vercel.mdx` and `deployment/environment-variables.mdx` explicitly warn against this:

> *Do not run `vercel --prod` from a local checkout or sandbox; that deploys the local filesystem instead of the reviewed Git commit.*

## Change

- Replaced `npx vercel --prod` with `git push origin main` (the actual deploy trigger)
- Added a `<Warning>` block explaining why `vercel --prod` from local is wrong
- Cross-linked to `deployment/environment-variables.mdx` for the full rule

## Why P0

A new deployer following this guide would bypass Git review and push unreviewed local state straight to production. This is the exact failure mode the deployment docs were written to prevent.

## Verification

- `deployment/vercel.mdx` line 7: "Merging to `main` triggers an automatic production deploy"
- `deployment/environment-variables.mdx` line 117: "Do not run `vercel --prod` from a local checkout or sandbox"
- `apps/api/vercel.json` has no `git`/`github` config section — Vercel's default Git-connected auto-deploy is the mechanism