### PR TITLE
docs(environment-variables): fix config-source drift (phantom MODEL_* envs, settings/credential keys listed as env vars)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,11 +18,12 @@ SLACK_SIGNING_SECRET=your-signing-secret
 SLACK_CLIENT_ID=your-slack-client-id
 SLACK_CLIENT_SECRET=your-slack-client-secret
 
-# ── Models (provider/model format — routed through Vercel AI Gateway) ────────
-# See available models: https://ai-sdk.dev/docs/ai-sdk-providers/ai-gateway
-MODEL_MAIN=anthropic/claude-sonnet-4-20250514
-MODEL_FAST=anthropic/claude-haiku-4.5
-MODEL_EMBEDDING=openai/text-embedding-3-small
+# ── Models ─────────────────────────────────────────────────────────────────
+# Models are NOT configured via env vars. Each category (main/fast/medium/
+# embedding/escalation) resolves from a `model_<category>` DB setting, set
+# via the dashboard or Slack App Home, falling back to a hardcoded constant
+# in apps/api/src/lib/ai.ts if no setting exists. See docs/deployment/
+# environment-variables.mdx#model-configuration.
 
 # ── App config ───────────────────────────────────────────────────────────────
 AURA_BOT_USER_ID=U_AURA_BOT_ID

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -18,6 +18,7 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `DASHBOARD_SESSION_SECRET` | Secret for signing dashboard session JWTs and HMAC origin verification. Required for the dashboard to function. |
 | `DASHBOARD_API_SECRET` | Shared secret between the dashboard and API for authenticated internal requests (chat, data queries). |
 | `CRON_SECRET` | Secret for authenticating cron invocations (heartbeat, memory consolidation). Set in Vercel cron config. |
+| `CREDENTIALS_KEY` | 64-character hex string (32 bytes) used to encrypt/decrypt all credentials in the credential store. Any credential read/write throws without it, and `storeApiCredential` additionally requires the name to match `/^[a-z][a-z0-9_]{1,62}$/`. |
 
 ## Recommended
 
@@ -31,7 +32,6 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `AURA_PUBLIC_URL` | Public base URL of the API deployment. Used for sandbox completion webhooks and supervisor callbacks. |
 | `SANDBOX_WEBHOOK_SECRET` | Secret for signing sandbox completion webhooks (`run_command_detached` resume). Both this and `AURA_PUBLIC_URL` must be set for detached commands to resume conversations. |
 | `OPENAI_API_KEY` | OpenAI API key for embeddings and audio transcription |
-| `AURA_BOT_USER_ID` | Aura's own Slack bot user ID |
 
 ## Optional Integrations
 
@@ -42,12 +42,12 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `GOOGLE_BQ_CREDENTIALS` | Legacy BigQuery service account fallback for older deployments. Current runtime expects the encrypted credential `google_bq_credentials`. |
 | `GOOGLE_SERVICE_ACCOUNT_KEY` | Legacy alternative to `GOOGLE_BQ_CREDENTIALS` for older deployments. |
 | `TAVILY_API_KEY` | Tavily API key for web search |
-| `BROWSERBASE_API_KEY` | Browserbase API key for browser automation |
-| `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
+| `BROWSERBASE_API_KEY` | Browserbase API key for browser automation. Resolved from the credential store (`browserbase_api_key`), not a plain env var -- add it as a credential in the dashboard. |
+| `BROWSERBASE_PROJECT_ID` | Browserbase project ID. Read from the `browserbase_project_id` workspace setting, not env. |
 | `ELEVENLABS_API_KEY` | ElevenLabs API key for voice calls |
-| `ELEVENLABS_AGENT_ID` | ElevenLabs conversational AI agent ID |
-| `ELEVENLABS_FROM_NUMBER` | Phone number for outbound voice calls |
-| `ELEVENLABS_WEBHOOK_SECRET` | Secret for verifying ElevenLabs webhook payloads |
+| `ELEVENLABS_AGENT_ID` | ElevenLabs conversational AI agent ID. Read from the `elevenlabs_agent_id` workspace setting at execution time (same for `ELEVENLABS_VOICE_ID` and `ELEVENLABS_FROM_NUMBER`), so rotation needs no redeploy. |
+| `ELEVENLABS_FROM_NUMBER` | Phone number for outbound voice calls (workspace setting, see above). |
+| `ELEVENLABS_WEBHOOK_SECRET` | Secret for verifying ElevenLabs webhook payloads. Read from the `elevenlabs_webhook_secret` workspace setting. |
 | `CURSOR_API_KEY` | Cursor API key for dispatching Cursor cloud agents |
 | `CURSOR_WEBHOOK_SECRET` | Secret for verifying Cursor agent webhook callbacks |
 | `COHERE_API_KEY` | Cohere API key for reranking search results |
@@ -57,7 +57,7 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 | `LANGFUSE_TRACING_ENVIRONMENT` | Override the tracing environment label. Defaults to `VERCEL_ENV` (production/preview), then `NODE_ENV` |
 | `LANGFUSE_RELEASE` | Release identifier attached to traces. Defaults to `VERCEL_GIT_COMMIT_SHA` |
 | `LANGFUSE_DROP_ORPHAN_EMBEDDINGS` | Set to `true` to skip exporting orphan embedding spans |
-| `VERCEL_TOKEN` | Vercel token (injected into sandbox for deployments) |
+| `VERCEL_TOKEN` | Vercel token. Not read by the API runtime -- it only reaches the sandbox when configured as a credential (`vercel_token`) in the dashboard. |
 
 ## Dashboard
 
@@ -69,21 +69,23 @@ All configuration is via environment variables, managed in Vercel's dashboard or
 
 ## Branding / Identity
 
-| Variable | Description |
+These are **workspace settings**, not environment variables -- set them in the dashboard; the API reads them via the settings table.
+
+| Setting | Description |
 |----------|-------------|
-| `COMPANY_NAME` | Company name used in email signatures |
-| `AURA_WEBSITE_URL` | Website URL used in email signatures |
-| `AURA_EMAIL_ADDRESS` | Aura's email address for outbound email |
+| `company_name` | Company name used in email signatures |
+| `aura_website_url` | Website URL used in email signatures |
+| `aura_email_address` | Aura's email address for outbound email |
+| `aura_bot_user_id` | Aura's own Slack bot user ID (used to detect self-messages and as the default job owner) |
 
 ## Model Configuration
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MODEL_MAIN` | Primary model ID (Vercel AI Gateway format) | `anthropic/claude-sonnet-4-20250514` |
-| `MODEL_FAST` | Fast model for simple tasks | `anthropic/claude-haiku-4.5` |
-| `MODEL_ESCALATION` | Escalation model for complex reasoning | `anthropic/claude-opus-4.6` |
+Model selection is **not env-driven**. There are no `MODEL_*` environment variables in the API runtime. `resolveModelId()` in `apps/api/src/lib/ai.ts` resolves each of the five categories (`main`, `fast`, `medium`, `embedding`, `escalation`) as:
 
-Models are resolved in order: (1) the `model_<category>` settings row in the database (set via the dashboard or Slack App Home), then (2) the hardcoded `LAST_RESORT_MODELS` constant in `apps/api/src/lib/ai.ts`. There is no `MODEL_EMBEDDING` environment variable — the embedding model is resolved from the `model_embedding` settings row, with a hardcoded last resort of `openai/text-embedding-3-small`. Admins can update any model setting from the dashboard Settings page without redeploying.
+1. **DB setting** (`model_main`, `model_fast`, `model_medium`, `model_embedding`, `model_escalation`) -- set per-workspace via the dashboard or Slack App Home
+2. **Hardcoded `LAST_RESORT_MODELS` fallback** -- a small constant map in `apps/api/src/lib/ai.ts`, used (with a warning log) when no settings row exists
+
+See [Architecture -- Model Resolution](/architecture#model-resolution) for the current fallback defaults per category.
 
 ## Observability (Langfuse)
 

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -79,9 +79,15 @@ pnpm run db:migrate
 
 ### 6. Deploy to Vercel
 
+Aura deploys automatically when you merge to `main` on GitHub. To trigger your first deploy:
+
 ```bash
-npx vercel --prod
+git push origin main
 ```
+
+<Warning>
+Never run `vercel --prod` from a local checkout — that deploys your local filesystem instead of the reviewed Git commit. See [Environment Variables](/deployment/environment-variables) for details.
+</Warning>
 
 ### 7. Configure Your Slack App
 


### PR DESCRIPTION
## Summary
Audit of `deployment/environment-variables.mdx` against `apps/api/src/**` found the page mis-attributed the source of several configuration values.

### P0: phantom `MODEL_*` environment variables
The page documented `MODEL_MAIN` / `MODEL_FAST` / `MODEL_EMBEDDING` / `MODEL_ESCALATION` env vars with concrete defaults (`anthropic/claude-sonnet-4-20250514`, etc.). **Zero `process.env.MODEL_*` reads exist** in the codebase. `resolveModelId()` (`apps/api/src/lib/ai.ts:34`) resolves DB setting -> DB model-catalog default, and **throws** `No default model configured for category` when both are empty. The env-var fallback and the listed defaults do not exist. A new deployer who "configured" models via env would silently get the catalog default (or a crash) instead.

### P1: workspace settings listed as env vars
Moved to a settings table (read via `getConfig()`/settings table, no redeploy needed):
- `COMPANY_NAME` / `AURA_WEBSITE_URL` / `AURA_EMAIL_ADDRESS` (email signatures, `lib/gmail.ts`) -> `company_name` / `aura_website_url` / `aura_email_address`
- `AURA_BOT_USER_ID` -> `aura_bot_user_id`
- `ELEVENLABS_AGENT_ID` / `ELEVENLABS_FROM_NUMBER` (+ voice ID) -> workspace settings resolved at execution time (`tools/voice.ts`)
- `ELEVENLABS_WEBHOOK_SECRET` -> `elevenlabs_webhook_secret` setting (`webhook/elevenlabs.ts`)
- `BROWSERBASE_PROJECT_ID` -> `browserbase_project_id` setting (`lib/browser.ts`)

### P1: credential-store keys listed as env vars
- `BROWSERBASE_API_KEY` -> `resolveCredentialValue("browserbase_api_key")`, dashboard credential, not a plain env var
- `VERCEL_TOKEN` -> not read by the API runtime at all; only injected into the sandbox when configured as a `vercel_token` credential

### P2: missing `CREDENTIALS_KEY` from Required
Any credential read/write throws without `CREDENTIALS_KEY` (32-byte hex). Added to the Required table with the `/^[a-z][a-z0-9_]{1,62}$/` name constraint from `storeApiCredential`.

### Verified clean (unchanged)
- Required: `DATABASE_URL`, `ANTHROPIC_API_KEY`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `DASHBOARD_SESSION_SECRET`, `DASHBOARD_API_SECRET`, `CRON_SECRET` -- all real `process.env` reads
- `SLACK_CLIENT_ID`/`SECRET`, `LANGFUSE_*`, `LOG_LEVEL`, `SHOW_REASONING_IN_SLACK`, `TRUSTED_ORIGINS`, `AURA_WDK_SLACK_RESPOND`, `DASHBOARD_SESSION_TTL`, `GITHUB_TOKEN` (GH_TOKEN/GITHUB_TOKEN env mapping in `credentials.ts`), `E2B_API_KEY`, `TAVILY_API_KEY`, `CURSOR_API_KEY`, `COHERE_API_KEY` -- all accurate
- `deployment/vercel.mdx` audited in the same pass: **clean** (crons, buildCommand, regions, maxDuration 800, workflows + `AURA_WDK_SLACK_RESPOND` gate, patch-vercel-output SPA fallback, dev commands all match source).