### PR TITLE
docs(web): fix Tavily credential drift (web_search/read_url resolve from credential store, not env var)

### DIFF
--- a/content/docs/tools/web.mdx
+++ b/content/docs/tools/web.mdx
@@ -17,7 +17,7 @@ Aura can search the web, read URLs as clean text, and automate browser interacti
 
 Search the web for current information. Powered by [Tavily](https://tavily.com).
 
-**Required env var:** `TAVILY_API_KEY`
+**Required credential:** `tavily_api_key` -- stored as an encrypted credential (Dashboard > Credentials), resolved via the credential store with no environment-variable fallback. The tool description and runtime error still mention `TAVILY_API_KEY` for historical reasons, but setting that env var has no effect on the API runtime.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -28,7 +28,7 @@ Search the web for current information. Powered by [Tavily](https://tavily.com).
 
 ## `read_url`
 
-Fetch a URL and extract its readable text content. Use when someone pastes a link and asks "what does this say?". Faster than `browse` for simple text extraction.
+Fetch a URL and extract its readable text content. Use when someone pastes a link and asks "what does this say?". Faster than `browse` for simple text extraction. When the `tavily_api_key` credential is configured, uses Tavily Extract for cleaner results; otherwise falls back to raw fetch + HTML stripping.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|


### PR DESCRIPTION
Same env-var-vs-credential-store drift class as browser (#1271), resources (#1278), voice (#1285), sandbox (#1288), and environment-variables (#1298) -- 7th instance.

**P1 fix:** web.mdx claimed `TAVILY_API_KEY` was a required env var. In fact both `web_search` and `read_url` resolve the key via `resolveCredentialValue("tavily_api_key")` (apps/api/src/lib/credentials.ts), which reads **only** the encrypted credentials table -- no env fallback exists for this name. A deployer following the old doc would set an env var the API runtime never reads and hit "Web search is not available. tavily_api_key credential is not configured." (web.ts:61).

Changes:
- web_search: 'Required env var' -> 'Required credential', with a note that the tool description/runtime error still mention TAVILY_API_KEY for historical reasons.
- read_url: documented that the Tavily Extract path is credential-gated too, with the raw-fetch fallback noted.

Verified against apps/api/src/tools/web.ts (getTavilyClient -> resolveCredentialValue, lines 11, 42-44, 61, 118) and lib/credentials.ts (resolveCredentialValue: DB-only, no env fallback). max_results (default 5, max 10) and browse param table already accurate.