### PR TITLE
Add 'medium' model category tier; default scheduled jobs to it

### DIFF
--- a/apps/api/src/cron/execute-job.test.ts
+++ b/apps/api/src/cron/execute-job.test.ts
@@ -481,16 +481,22 @@ describe("executeJob scoped execution (issue #1302)", () => {
     expect(options.modelCategory).toBe("fast");
   });
 
-  it("defaults to the main category when model is null", async () => {
-    const options = await captureAgentOptions({ model: null });
+  it("keeps an explicit 'main' opt-in on the main category", async () => {
+    const options = await captureAgentOptions({ model: "main" });
 
     expect(options.modelCategory).toBe("main");
   });
 
-  it("falls back to main for a model value outside the routable categories", async () => {
+  it("defaults to the medium category when model is null", async () => {
+    const options = await captureAgentOptions({ model: null });
+
+    expect(options.modelCategory).toBe("medium");
+  });
+
+  it("falls back to medium for a model value outside the routable categories", async () => {
     const options = await captureAgentOptions({ model: "embedding" });
 
-    expect(options.modelCategory).toBe("main");
+    expect(options.modelCategory).toBe("medium");
   });
 
   it("carries the env allowlist into the execution context for the agent loop", async () => {

--- a/apps/api/src/cron/execute-job.ts
+++ b/apps/api/src/cron/execute-job.ts
@@ -173,10 +173,11 @@ export async function executeJob(
     // Scoped execution (issue #1302): prompt_mode 'task' skips the full
     // personality prefix; model routes to a catalog category; env_allowlist
     // narrows the sandbox env (applied below via executionContext + script layer).
+    // Jobs default to 'medium' (Sonnet-class); frontier 'main' is opt-in.
     const isTaskMode = job.promptMode === "task";
     const modelCategory: JobModelCategory = isJobModelCategory(job.model)
       ? job.model
-      : "main";
+      : "medium";
     const envAllowlist = job.envAllowlist ?? undefined;
 
     const stablePrefix = isTaskMode ? buildTaskPrefix() : await buildStablePrefix();

--- a/apps/api/src/lib/agents.ts
+++ b/apps/api/src/lib/agents.ts
@@ -101,15 +101,16 @@ export interface HeadlessAgentOptions {
   context?: ScheduleContext;
   systemPrompt: string;
   invocationId?: string;
-  /** Model catalog category to execute with. Defaults to "main" (legacy behavior). */
+  /** Model catalog category to execute with. Defaults to "medium" (Sonnet-class) for jobs. */
   modelCategory?: JobModelCategory;
 }
 
 export async function createHeadlessAgent(options: HeadlessAgentOptions) {
+  const category: JobModelCategory = options.modelCategory ?? "medium";
   const { modelId, model } =
-    options.modelCategory && options.modelCategory !== "main"
-      ? await getModelByCategory(options.modelCategory)
-      : await getMainModel();
+    category === "main"
+      ? await getMainModel()
+      : await getModelByCategory(category);
   const tools = await createSlackTools(options.slackClient, options.context, modelId, options.invocationId);
   const stepModelIds: string[] = [];
   const systemPrompt = appendDeferredToolsBlock(

--- a/apps/api/src/lib/ai.test.ts
+++ b/apps/api/src/lib/ai.test.ts
@@ -117,12 +117,47 @@ describe("getModelByCategory", () => {
       "No default model configured for category: fast",
     );
   });
+
+  it("resolves the medium category from the DB setting override first", async () => {
+    getSettingMock.mockImplementation(async (key: string) =>
+      key === "model_medium" ? "anthropic/claude-medium-override" : null,
+    );
+
+    const { modelId } = await getModelByCategory("medium");
+
+    expect(modelId).toBe("anthropic/claude-medium-override");
+    expect(getSettingMock).toHaveBeenCalledWith("model_medium");
+    expect(mocks.getDefaultModelId).not.toHaveBeenCalled();
+  });
+
+  it("resolves the medium category from the catalog default", async () => {
+    mocks.getDefaultModelId.mockImplementation(async (category: string) =>
+      category === "medium" ? "anthropic/claude-medium-default" : null,
+    );
+
+    const { modelId } = await getModelByCategory("medium");
+
+    expect(modelId).toBe("anthropic/claude-medium-default");
+    expect(mocks.getDefaultModelId).toHaveBeenCalledWith("medium");
+  });
+
+  it("falls back to the main model when no medium selection exists", async () => {
+    mocks.getDefaultModelId.mockImplementation(async (category: string) =>
+      category === "main" ? "anthropic/claude-main" : null,
+    );
+
+    const { modelId } = await getModelByCategory("medium");
+
+    expect(modelId).toBe("anthropic/claude-main");
+    expect(getSettingMock).toHaveBeenCalledWith("model_main");
+  });
 });
 
 describe("isJobModelCategory", () => {
-  it("accepts the three job-routable categories", () => {
+  it("accepts the four job-routable categories", () => {
     expect(isJobModelCategory("main")).toBe(true);
     expect(isJobModelCategory("fast")).toBe(true);
+    expect(isJobModelCategory("medium")).toBe(true);
     expect(isJobModelCategory("escalation")).toBe(true);
   });
 

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -33,7 +33,7 @@ import type { ModelCapabilities } from "@aura/db/schema";
 
 async function resolveModelId(
   settingKey: string,
-  category: "main" | "fast" | "embedding" | "escalation",
+  category: "main" | "fast" | "medium" | "embedding" | "escalation",
 ): Promise<string> {
   const override = await getSetting(settingKey);
   if (override) return override;
@@ -285,6 +285,33 @@ export async function getFastModelId(): Promise<string> {
 }
 
 /**
+ * Resolve the medium model ID string (no gateway wrapping).
+ * Priority: DB setting > catalog default > main model (never crashes when
+ * no medium selection is configured).
+ */
+export async function getMediumModelId(): Promise<string> {
+  const override = await getSetting("model_medium");
+  if (override) return override;
+
+  const defaultModelId = await getDefaultModelId("medium");
+  if (defaultModelId) return defaultModelId;
+
+  logger.warn("No medium model configured, falling back to main");
+  return getMainModelId();
+}
+
+/**
+ * Get the medium model (Sonnet-class — default tier for scheduled jobs)
+ * with Anthropic fallback support.
+ * Priority: DB setting > catalog default > main model fallback.
+ */
+export async function getMediumModel() {
+  const modelId = await getMediumModelId();
+  const gatewayModel = gateway(modelId);
+  return { modelId, model: withAnthropicFallback(gatewayModel, modelId) };
+}
+
+/**
  * Get the embedding model with Anthropic fallback support.
  * Priority: DB setting > catalog default
  */
@@ -308,7 +335,7 @@ export async function getEscalationModel() {
  * Model categories a job can be routed to (subset of the catalog categories —
  * 'embedding' makes no sense for text generation).
  */
-export const JOB_MODEL_CATEGORIES = ["main", "fast", "escalation"] as const;
+export const JOB_MODEL_CATEGORIES = ["main", "fast", "medium", "escalation"] as const;
 export type JobModelCategory = (typeof JOB_MODEL_CATEGORIES)[number];
 
 export function isJobModelCategory(value: unknown): value is JobModelCategory {
@@ -321,6 +348,7 @@ export function isJobModelCategory(value: unknown): value is JobModelCategory {
 const SETTING_KEY_BY_CATEGORY: Record<JobModelCategory, string> = {
   main: "model_main",
   fast: "model_fast",
+  medium: "model_medium",
   escalation: "model_escalation",
 };
 
@@ -328,8 +356,10 @@ const SETTING_KEY_BY_CATEGORY: Record<JobModelCategory, string> = {
  * Resolve a language model by catalog category. Same resolution order as the
  * dedicated getters (DB setting > catalog default), with Anthropic fallback.
  * Used by scoped job execution to route a job to e.g. the fast model.
+ * 'medium' additionally falls back to the main model when unconfigured.
  */
 export async function getModelByCategory(category: JobModelCategory) {
+  if (category === "medium") return getMediumModel();
   const modelId = await resolveModelId(SETTING_KEY_BY_CATEGORY[category], category);
   const gatewayModel = gateway(modelId);
   return { modelId, model: withAnthropicFallback(gatewayModel, modelId) };

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -19,6 +19,7 @@ import { logger } from "./logger.js";
 export const MODEL_CATEGORIES = [
   "main",
   "fast",
+  "medium",
   "embedding",
   "escalation",
 ] as const;
@@ -47,6 +48,7 @@ export interface ModelCatalogItem {
 export interface ModelCatalogResponse {
   main: ModelOption[];
   fast: ModelOption[];
+  medium: ModelOption[];
   embedding: ModelOption[];
   escalation: ModelOption[];
   defaults: Partial<Record<ModelCategory, string>>;
@@ -427,6 +429,7 @@ export async function getModelCatalogResponse(
   const grouped: Record<ModelCategory, ModelOption[]> = {
     main: [],
     fast: [],
+    medium: [],
     embedding: [],
     escalation: [],
   };
@@ -496,6 +499,7 @@ export async function getModelCatalogResponse(
   return {
     main: grouped.main,
     fast: grouped.fast,
+    medium: grouped.medium,
     embedding: grouped.embedding,
     escalation: grouped.escalation,
     defaults,

--- a/apps/api/src/routes/dashboard/models.ts
+++ b/apps/api/src/routes/dashboard/models.ts
@@ -20,6 +20,7 @@ const listModelsRoute = createRoute({
           schema: z.object({
             main: z.array(z.any()),
             fast: z.array(z.any()),
+            medium: z.array(z.any()),
             embedding: z.array(z.any()),
             escalation: z.array(z.any()),
             defaults: z.record(z.string(), z.string()),

--- a/apps/api/src/tools/jobs.ts
+++ b/apps/api/src/tools/jobs.ts
@@ -87,10 +87,10 @@ export function createJobTools(
           .optional()
           .describe("Max executions per day (recurring jobs)"),
         model: z
-          .enum(["main", "fast", "escalation"])
+          .enum(["main", "fast", "medium", "escalation"])
           .optional()
           .describe(
-            "Model category to execute the job with, resolved from the model catalog. Use 'fast' for simple mechanical tasks (classification, moderation, digests), 'escalation' for exceptionally hard work. Omit for the default main model.",
+            "Model category to execute the job with, resolved from the model catalog. Omit for the default 'medium' (Sonnet-class intelligence — the standard tier for jobs). Use 'fast' for simple mechanical tasks (classification, moderation, digests), 'main' (frontier) only for jobs that genuinely need it, 'escalation' for exceptionally hard work.",
           ),
         env_allowlist: z
           .array(z.string())
@@ -536,11 +536,11 @@ export function createJobTools(
           max_per_day: z.number().optional(),
           min_interval_hours: z.number().optional(),
           model: z
-            .enum(["main", "fast", "escalation"])
+            .enum(["main", "fast", "medium", "escalation"])
             .nullable()
             .optional()
             .describe(
-              "Model category to execute with ('fast' for mechanical tasks). Set to null to reset to the default main model.",
+              "Model category to execute with ('fast' for mechanical tasks, 'main' for frontier opt-in). Set to null to reset to the default 'medium' (Sonnet-class) model.",
             ),
           env_allowlist: z
             .array(z.string())

--- a/packages/db/drizzle/0079_medium_model_category.sql
+++ b/packages/db/drizzle/0079_medium_model_category.sql
@@ -1,0 +1,4 @@
+ALTER TYPE "model_catalog_category" ADD VALUE IF NOT EXISTS 'medium';--> statement-breakpoint
+INSERT INTO "model_catalog_selections" ("workspace_id", "model_id", "category", "enabled", "is_default")
+VALUES ('default', 'anthropic/claude-sonnet-5', 'medium', true, true)
+ON CONFLICT DO NOTHING;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1786958400000,
       "tag": "0078_scoped_job_execution",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1787136960000,
+      "tag": "0079_medium_model_category",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -80,6 +80,7 @@ export const memoryEntityRoleEnum = pgEnum("memory_entity_role", [
 export const modelCatalogCategoryEnum = pgEnum("model_catalog_category", [
   "main",
   "fast",
+  "medium",
   "embedding",
   "escalation",
 ]);
@@ -592,8 +593,8 @@ export const jobs = pgTable(
     archivedAt: timestamptz("archived_at"),
     requiredCredentialIds: jsonb("required_credential_ids").$type<string[]>().default([]),
     // ── Scoped execution (issue #1302) — all nullable so existing jobs run unchanged ──
-    /** Model catalog category to execute with. Null = 'main' (current behavior). */
-    model: text("model").$type<"main" | "fast" | "escalation">(),
+    /** Model catalog category to execute with. Null = 'medium' (job default). */
+    model: text("model").$type<"main" | "fast" | "medium" | "escalation">(),
     /** Sandbox env var names this job may access. Null = full caller-scoped inheritance. */
     envAllowlist: text("env_allowlist").array(),
     /** 'task' = minimal task prompt (no personality/notes). Null = 'full' (current behavior). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `medium` model catalog category (Sonnet-class intelligence) and makes it the default tier for scheduled job executions. Frontier (`main`) becomes opt-in for jobs. Interactive Slack conversations, subagents, and the memory pipeline are untouched.

## Changes

### Migration `0079_medium_model_category.sql`
- `ALTER TYPE "model_catalog_category" ADD VALUE IF NOT EXISTS 'medium';`
- Seeds a default selection: `anthropic/claude-sonnet-5` → `medium` (enabled, is_default) with `ON CONFLICT DO NOTHING`. The model ID appears only here (org policy: everything else routes through the catalog).
- Transaction safety: the migration runner (`drizzle-orm/neon-http/migrator`) executes each `--> statement-breakpoint`-separated statement as its own HTTP request (own implicit transaction), so the new enum value is committed before the seed INSERT uses it — the PG "unsafe use of new enum value" restriction doesn't apply. Same pattern as `0071_add_mpim_channel_type.sql`.

### Schema (`packages/db/src/schema.ts`)
- `medium` added to `modelCatalogCategoryEnum` and to the `jobs.model` column type.

### Catalog + resolution (`apps/api/src/lib/model-catalog.ts`, `ai.ts`)
- `medium` added to `MODEL_CATEGORIES`, the grouped response, and `ModelCatalogResponse` (plus the dashboard models route schema).
- New `getMediumModel()` / `getMediumModelId()` following the existing factory pattern: DB setting (`model_medium`) → catalog default → **fallback to main** (never crashes when no medium selection exists).
- `medium` added to `JOB_MODEL_CATEGORIES`; `getModelByCategory("medium")` routes through the fallback-aware getter.

### Job default (`execute-job.ts`, `agents.ts` `createHeadlessAgent`)
- `jobs.model` NULL or invalid → resolves to `medium` (was `main`). Explicit `main`/`fast`/`escalation` unchanged. `createHeadlessAgent` is only used by job execution, so no interactive path is affected.

### Job tools (`tools/jobs.ts`)
- `create_job` / `update_job` model enums now `main | fast | medium | escalation`; descriptions state the job default is `medium` (Sonnet-class) and `main` is frontier opt-in.

### Tests
- `execute-job.test.ts`: NULL → medium, invalid (`embedding`) → medium, explicit `main` → main, explicit `fast` → fast; task-mode tests unchanged and passing.
- `ai.test.ts`: `medium` setting override, catalog default, and main-model fallback; `isJobModelCategory` accepts `medium`.

## Migration numbering hazard

⚠️ **This PR takes migration number 0079** (0078 was taken on main by scoped job execution, #1304). PR #1286 also carried an 0078 that must renumber — per the established protocol, **whichever of #1286 and this PR merges second must renumber to the next free slot** (0080) and bump its `_journal.json` `when` timestamp accordingly.

## Verification

- `pnpm typecheck` passes (API + dashboard).
- `vitest run src/cron/execute-job.test.ts src/lib/ai.test.ts`: 41/41 passing.
- Pre-existing failures in `src/pipeline/respond.test.ts` (native-block delivery-receipt logging) reproduce on clean `main` and are unrelated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13c0ac7-a09f-4b79-9509-90a27ead4506?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13c0ac7-a09f-4b79-9509-90a27ead4506&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

