### PR TITLE
Dashboard: medium/escalation model selectors + editable per-job scoped-execution fields

### DIFF
--- a/apps/api/src/routes/dashboard/jobs.test.ts
+++ b/apps/api/src/routes/dashboard/jobs.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../db/client.js", () => ({ db: {} }));
+
+const { updateJobBodySchema } = await import("./jobs.js");
+
+describe("updateJobBodySchema (PATCH /api/dashboard/jobs/:id)", () => {
+  it("accepts an empty body (no-op update)", () => {
+    expect(updateJobBodySchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts enabled toggles", () => {
+    expect(updateJobBodySchema.safeParse({ enabled: true }).success).toBe(true);
+    expect(updateJobBodySchema.safeParse({ enabled: false }).success).toBe(true);
+  });
+
+  it("accepts every job-eligible model category and null", () => {
+    for (const model of ["main", "fast", "medium", "escalation", null]) {
+      const result = updateJobBodySchema.safeParse({ model });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects model categories outside the job-eligible catalog list", () => {
+    expect(updateJobBodySchema.safeParse({ model: "embedding" }).success).toBe(false);
+    expect(updateJobBodySchema.safeParse({ model: "gpt-4" }).success).toBe(false);
+    expect(updateJobBodySchema.safeParse({ model: "" }).success).toBe(false);
+  });
+
+  it("accepts env allowlists of valid env var names, empty array, and null", () => {
+    expect(
+      updateJobBodySchema.safeParse({ envAllowlist: ["GITHUB_TOKEN", "_PRIVATE", "lower_case1"] })
+        .success,
+    ).toBe(true);
+    expect(updateJobBodySchema.safeParse({ envAllowlist: [] }).success).toBe(true);
+    expect(updateJobBodySchema.safeParse({ envAllowlist: null }).success).toBe(true);
+  });
+
+  it("rejects invalid env var names", () => {
+    expect(updateJobBodySchema.safeParse({ envAllowlist: ["1BAD"] }).success).toBe(false);
+    expect(updateJobBodySchema.safeParse({ envAllowlist: ["HAS SPACE"] }).success).toBe(false);
+    expect(updateJobBodySchema.safeParse({ envAllowlist: ["DASH-ED"] }).success).toBe(false);
+    expect(updateJobBodySchema.safeParse({ envAllowlist: [""] }).success).toBe(false);
+    expect(updateJobBodySchema.safeParse({ envAllowlist: ["KEY=value"] }).success).toBe(false);
+  });
+
+  it("accepts prompt modes full, task, and null", () => {
+    for (const promptMode of ["full", "task", null]) {
+      expect(updateJobBodySchema.safeParse({ promptMode }).success).toBe(true);
+    }
+  });
+
+  it("rejects unknown prompt modes", () => {
+    expect(updateJobBodySchema.safeParse({ promptMode: "minimal" }).success).toBe(false);
+  });
+
+  it("distinguishes omitted fields (undefined) from explicit null", () => {
+    const omitted = updateJobBodySchema.parse({});
+    expect("model" in omitted && omitted.model !== undefined).toBe(false);
+
+    const cleared = updateJobBodySchema.parse({ model: null, envAllowlist: null, promptMode: null });
+    expect(cleared.model).toBeNull();
+    expect(cleared.envAllowlist).toBeNull();
+    expect(cleared.promptMode).toBeNull();
+  });
+});

--- a/apps/api/src/routes/dashboard/jobs.ts
+++ b/apps/api/src/routes/dashboard/jobs.ts
@@ -2,8 +2,32 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { eq, sql, ilike, desc } from "drizzle-orm";
 import { jobs, jobExecutions, conversationTraces } from "@aura/db/schema";
 import { db } from "../../db/client.js";
+import { JOB_MODEL_CATEGORIES } from "../../lib/ai.js";
 import { logger } from "../../lib/logger.js";
 import { errorSchema, paginationQuerySchema, idParamSchema, createDashboardApp } from "./schemas.js";
+
+/** Env var NAMES only (never values) — standard POSIX-style identifier. */
+const ENV_VAR_NAME_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * All fields optional: omitted = leave unchanged, explicit null = clear the
+ * override (model → medium default, envAllowlist → full inheritance,
+ * promptMode → full prompt).
+ */
+export const updateJobBodySchema = z.object({
+  enabled: z.boolean().optional(),
+  model: z.enum(JOB_MODEL_CATEGORIES).nullable().optional(),
+  envAllowlist: z
+    .array(
+      z
+        .string()
+        .regex(ENV_VAR_NAME_REGEX, "must be a valid env var name (letters, digits, underscores)"),
+    )
+    .max(100)
+    .nullable()
+    .optional(),
+  promptMode: z.enum(["full", "task"]).nullable().optional(),
+});
 
 export const dashboardJobsApp = createDashboardApp();
 
@@ -151,17 +175,17 @@ dashboardJobsApp.openapi(getJobRoute, async (c) => {
   }
 });
 
-const toggleJobRoute = createRoute({
+const updateJobRoute = createRoute({
   method: "patch",
   path: "/{id}",
   tags: ["Jobs"],
-  summary: "Toggle job enabled/disabled",
+  summary: "Update job (enabled, model, env allowlist, prompt mode)",
   request: {
     params: idParamSchema,
     body: {
       content: {
         "application/json": {
-          schema: z.object({ enabled: z.boolean() }),
+          schema: updateJobBodySchema,
         },
       },
       required: true,
@@ -171,6 +195,10 @@ const toggleJobRoute = createRoute({
     200: {
       content: { "application/json": { schema: z.any() } },
       description: "Success",
+    },
+    400: {
+      content: { "application/json": { schema: errorSchema } },
+      description: "Validation error",
     },
     404: {
       content: { "application/json": { schema: errorSchema } },
@@ -183,17 +211,20 @@ const toggleJobRoute = createRoute({
   },
 });
 
-dashboardJobsApp.openapi(toggleJobRoute, async (c) => {
+dashboardJobsApp.openapi(updateJobRoute, async (c) => {
   try {
     const id = c.req.param("id");
-    const body = await c.req.json<{ enabled: boolean }>();
+    const body = c.req.valid("json");
+
+    const set: Partial<typeof jobs.$inferInsert> = { updatedAt: new Date() };
+    if (body.enabled !== undefined) set.enabled = body.enabled ? 1 : 0;
+    if (body.model !== undefined) set.model = body.model;
+    if (body.envAllowlist !== undefined) set.envAllowlist = body.envAllowlist;
+    if (body.promptMode !== undefined) set.promptMode = body.promptMode;
 
     const result = await db
       .update(jobs)
-      .set({
-        enabled: body.enabled ? 1 : 0,
-        updatedAt: new Date(),
-      })
+      .set(set)
       .where(eq(jobs.id, id))
       .returning();
 
@@ -203,7 +234,7 @@ dashboardJobsApp.openapi(toggleJobRoute, async (c) => {
 
     return c.json(result[0] as any, 200);
   } catch (error) {
-    logger.error("Failed to toggle job", { error: String(error) });
+    logger.error("Failed to update job", { error: String(error) });
     return c.json({ error: "Internal server error" }, 500);
   }
 });

--- a/apps/dashboard/src/routes/jobs/$id.tsx
+++ b/apps/dashboard/src/routes/jobs/$id.tsx
@@ -34,6 +34,9 @@ interface JobData {
     executionCount: number;
     lastExecutedAt: string | null;
     playbook: string | null;
+    model: "main" | "fast" | "medium" | "escalation" | null;
+    promptMode: "full" | "task" | null;
+    envAllowlist: string[] | null;
   };
   executions: Execution[];
 }
@@ -104,6 +107,44 @@ function JobDetailPage() {
           <CardHeader><CardTitle className="text-sm">Last Run</CardTitle></CardHeader>
           <CardContent>
             <span className="text-sm">{formatDate(job.lastExecutedAt)}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Model</CardTitle></CardHeader>
+          <CardContent>
+            {job.model ? (
+              <Badge variant="outline">{job.model}</Badge>
+            ) : (
+              <span className="text-sm text-muted-foreground">medium (default)</span>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Prompt Mode</CardTitle></CardHeader>
+          <CardContent>
+            {job.promptMode ? (
+              <Badge variant="outline">{job.promptMode}</Badge>
+            ) : (
+              <span className="text-sm text-muted-foreground">full (default)</span>
+            )}
+          </CardContent>
+        </Card>
+        <Card className="col-span-2">
+          <CardHeader><CardTitle className="text-sm">Env Allowlist</CardTitle></CardHeader>
+          <CardContent>
+            {job.envAllowlist && job.envAllowlist.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {job.envAllowlist.map((name) => (
+                  <Badge key={name} variant="secondary" className="font-mono text-xs">
+                    {name}
+                  </Badge>
+                ))}
+              </div>
+            ) : job.envAllowlist ? (
+              <span className="text-sm text-muted-foreground">Empty (no env vars)</span>
+            ) : (
+              <span className="text-sm text-muted-foreground">Full inheritance</span>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/apps/dashboard/src/routes/jobs/$id.tsx
+++ b/apps/dashboard/src/routes/jobs/$id.tsx
@@ -4,12 +4,29 @@ import { apiGet, apiPatch } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Switch } from "@/components/ui/switch";
 import { DetailSkeleton } from "@/components/page-skeleton";
 import { formatDate } from "@/lib/utils";
-import { ArrowLeft, Play, BookOpen } from "lucide-react";
+import { ArrowLeft, Play, BookOpen, Plus, X } from "lucide-react";
+import { useState } from "react";
+
+type JobModelCategory = "main" | "fast" | "medium" | "escalation";
+
+const JOB_MODEL_OPTIONS: JobModelCategory[] = ["main", "fast", "medium", "escalation"];
+
+/** Env var NAMES only (never values) — standard POSIX-style identifier. */
+const ENV_VAR_NAME_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+interface JobPatch {
+  enabled?: boolean;
+  model?: JobModelCategory | null;
+  promptMode?: "full" | "task" | null;
+  envAllowlist?: string[] | null;
+}
 
 interface Execution {
   id: string;
@@ -34,7 +51,7 @@ interface JobData {
     executionCount: number;
     lastExecutedAt: string | null;
     playbook: string | null;
-    model: "main" | "fast" | "medium" | "escalation" | null;
+    model: JobModelCategory | null;
     promptMode: "full" | "task" | null;
     envAllowlist: string[] | null;
   };
@@ -44,14 +61,15 @@ interface JobData {
 function JobDetailPage() {
   const { id } = Route.useParams();
   const queryClient = useQueryClient();
+  const [newEnvVar, setNewEnvVar] = useState("");
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["jobs", id],
     queryFn: () => apiGet<JobData>(`/jobs/${id}`),
   });
 
-  const toggleMutation = useMutation({
-    mutationFn: (enabled: boolean) => apiPatch(`/jobs/${id}`, { enabled }),
+  const updateMutation = useMutation({
+    mutationFn: (patch: JobPatch) => apiPatch(`/jobs/${id}`, patch),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["jobs"] }),
   });
 
@@ -60,6 +78,19 @@ function JobDetailPage() {
   if (!data) return null;
 
   const { job, executions } = data;
+
+  const trimmedEnvVar = newEnvVar.trim();
+  const canAddEnvVar =
+    ENV_VAR_NAME_REGEX.test(trimmedEnvVar) &&
+    !(job.envAllowlist ?? []).includes(trimmedEnvVar);
+
+  function addEnvVar() {
+    if (!canAddEnvVar) return;
+    updateMutation.mutate({
+      envAllowlist: [...(job.envAllowlist ?? []), trimmedEnvVar],
+    });
+    setNewEnvVar("");
+  }
 
   return (
     <div className="space-y-4">
@@ -74,8 +105,8 @@ function JobDetailPage() {
         <div className="flex items-center gap-2 shrink-0">
           <Switch
             checked={job.enabled}
-            onCheckedChange={(checked) => toggleMutation.mutate(checked)}
-            disabled={toggleMutation.isPending}
+            onCheckedChange={(checked) => updateMutation.mutate({ enabled: checked })}
+            disabled={updateMutation.isPending}
           />
           <Badge variant={job.enabled ? "success" : "secondary"}>
             {job.enabled ? "Enabled" : "Disabled"}
@@ -112,38 +143,123 @@ function JobDetailPage() {
         <Card>
           <CardHeader><CardTitle className="text-sm">Model</CardTitle></CardHeader>
           <CardContent>
-            {job.model ? (
-              <Badge variant="outline">{job.model}</Badge>
-            ) : (
-              <span className="text-sm text-muted-foreground">medium (default)</span>
-            )}
+            <Select
+              value={job.model ?? "__default"}
+              onValueChange={(v) =>
+                updateMutation.mutate({
+                  model: v === "__default" ? null : (v as JobModelCategory),
+                })
+              }
+              disabled={updateMutation.isPending}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default">medium (default)</SelectItem>
+                {JOB_MODEL_OPTIONS.map((category) => (
+                  <SelectItem key={category} value={category}>{category}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </CardContent>
         </Card>
         <Card>
           <CardHeader><CardTitle className="text-sm">Prompt Mode</CardTitle></CardHeader>
           <CardContent>
-            {job.promptMode ? (
-              <Badge variant="outline">{job.promptMode}</Badge>
-            ) : (
-              <span className="text-sm text-muted-foreground">full (default)</span>
-            )}
+            <Select
+              value={job.promptMode ?? "__default"}
+              onValueChange={(v) =>
+                updateMutation.mutate({
+                  promptMode: v === "__default" ? null : (v as "full" | "task"),
+                })
+              }
+              disabled={updateMutation.isPending}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default">full (default)</SelectItem>
+                <SelectItem value="full">full</SelectItem>
+                <SelectItem value="task">task</SelectItem>
+              </SelectContent>
+            </Select>
           </CardContent>
         </Card>
         <Card className="col-span-2">
           <CardHeader><CardTitle className="text-sm">Env Allowlist</CardTitle></CardHeader>
-          <CardContent>
-            {job.envAllowlist && job.envAllowlist.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5">
-                {job.envAllowlist.map((name) => (
-                  <Badge key={name} variant="secondary" className="font-mono text-xs">
-                    {name}
-                  </Badge>
-                ))}
+          <CardContent className="space-y-2">
+            {job.envAllowlist === null ? (
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm text-muted-foreground">
+                  Full inheritance — job sees every env var its caller scope allows.
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => updateMutation.mutate({ envAllowlist: [] })}
+                  disabled={updateMutation.isPending}
+                >
+                  Restrict
+                </Button>
               </div>
-            ) : job.envAllowlist ? (
-              <span className="text-sm text-muted-foreground">Empty (no env vars)</span>
             ) : (
-              <span className="text-sm text-muted-foreground">Full inheritance</span>
+              <>
+                <div className="flex flex-wrap gap-1.5">
+                  {job.envAllowlist.map((name) => (
+                    <Badge key={name} variant="secondary" className="font-mono text-xs gap-1">
+                      {name}
+                      <button
+                        onClick={() =>
+                          updateMutation.mutate({
+                            envAllowlist: job.envAllowlist!.filter((n) => n !== name),
+                          })
+                        }
+                        disabled={updateMutation.isPending}
+                        className="cursor-pointer hover:text-destructive"
+                        aria-label={`Remove ${name}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                  {job.envAllowlist.length === 0 && (
+                    <span className="text-sm text-muted-foreground">Empty — no env vars allowed.</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={newEnvVar}
+                    onChange={(e) => setNewEnvVar(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") addEnvVar();
+                    }}
+                    placeholder="ENV_VAR_NAME"
+                    className="h-8 max-w-[240px] font-mono text-xs"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={addEnvVar}
+                    disabled={updateMutation.isPending || !canAddEnvVar}
+                  >
+                    <Plus className="h-3.5 w-3.5" /> Add
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => updateMutation.mutate({ envAllowlist: null })}
+                    disabled={updateMutation.isPending}
+                    className="ml-auto text-muted-foreground"
+                  >
+                    Reset to full inheritance
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Env var names only — values are never shown.
+                </p>
+              </>
             )}
           </CardContent>
         </Card>

--- a/apps/dashboard/src/routes/jobs/index.tsx
+++ b/apps/dashboard/src/routes/jobs/index.tsx
@@ -28,6 +28,7 @@ interface Job {
   lastExecutedAt: string | null;
   createdAt: string;
   priority: string;
+  model: "main" | "fast" | "medium" | "escalation" | null;
 }
 
 const PAGE_SIZE = 100;
@@ -88,7 +89,7 @@ function JobsPage() {
       </div>
 
       <div className={cn("flex-1 min-h-0 rounded-xl border overflow-auto transition-opacity", isFetching && !isLoading && "opacity-50")}>
-        <Table className="min-w-[1020px]">
+        <Table className="min-w-[1140px]">
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
@@ -100,15 +101,16 @@ function JobsPage() {
               <TableHead className="w-[160px]">Last Run</TableHead>
               <TableHead className="w-[160px]">Created</TableHead>
               <TableHead className="w-[80px]">Priority</TableHead>
+              <TableHead className="w-[120px]">Model</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRowsSkeleton columns={9} />
+              <TableRowsSkeleton columns={10} />
             ) : jobs.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={9}
+                  colSpan={10}
                   className="text-center text-muted-foreground py-8"
                 >
                   No jobs found
@@ -178,6 +180,15 @@ function JobsPage() {
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline">{job.priority}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {job.model ? (
+                        <Badge variant="outline">{job.model}</Badge>
+                      ) : (
+                        <span className="text-muted-foreground text-sm">
+                          medium (default)
+                        </span>
+                      )}
                     </TableCell>
                   </TableRow>
                 );

--- a/apps/dashboard/src/routes/settings/index.tsx
+++ b/apps/dashboard/src/routes/settings/index.tsx
@@ -29,9 +29,10 @@ interface ModelOption {
 interface ModelCatalog {
   main: ModelOption[];
   fast: ModelOption[];
+  medium: ModelOption[];
   embedding: ModelOption[];
   escalation: ModelOption[];
-  defaults: { main?: string; fast?: string; embedding?: string; escalation?: string };
+  defaults: { main?: string; fast?: string; medium?: string; embedding?: string; escalation?: string };
   catalog: Array<{
     value: string;
     label: string;
@@ -59,7 +60,9 @@ function SettingsPage() {
 
   const [mainModel, setMainModel] = useState<string | null>(null);
   const [fastModel, setFastModel] = useState<string | null>(null);
+  const [mediumModel, setMediumModel] = useState<string | null>(null);
   const [embeddingModel, setEmbeddingModel] = useState<string | null>(null);
+  const [escalationModel, setEscalationModel] = useState<string | null>(null);
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingKey, setEditingKey] = useState<string | null>(null);
@@ -86,13 +89,17 @@ function SettingsPage() {
 
   const actualMainModel = mainModel ?? getSettingValue("model_main");
   const actualFastModel = fastModel ?? getSettingValue("model_fast");
+  const actualMediumModel = mediumModel ?? getSettingValue("model_medium");
   const actualEmbeddingModel = embeddingModel ?? getSettingValue("model_embedding");
+  const actualEscalationModel = escalationModel ?? getSettingValue("model_escalation");
 
   const saveModelsMutation = useMutation({
     mutationFn: async () => {
       await apiPut("/settings/model_main", { value: actualMainModel || "" });
       await apiPut("/settings/model_fast", { value: actualFastModel || "" });
+      await apiPut("/settings/model_medium", { value: actualMediumModel || "" });
       await apiPut("/settings/model_embedding", { value: actualEmbeddingModel || "" });
+      await apiPut("/settings/model_escalation", { value: actualEscalationModel || "" });
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["settings"] }),
   });
@@ -134,7 +141,9 @@ function SettingsPage() {
 
   const MAIN_MODELS = enrichOptions(models?.main ?? []);
   const FAST_MODELS = enrichOptions(models?.fast ?? []);
+  const MEDIUM_MODELS = enrichOptions(models?.medium ?? []);
   const EMBEDDING_MODELS = enrichOptions(models?.embedding ?? []);
+  const ESCALATION_MODELS = enrichOptions(models?.escalation ?? []);
   const isEditing = editingKey !== null;
   const defaultOption = [{ value: "__default", label: "Default" }];
 
@@ -193,6 +202,26 @@ function SettingsPage() {
                 options={FAST_MODELS}
                 pinnedOptions={defaultOption}
                 placeholder="Select fast model"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium mb-1 block">Medium Model</label>
+              <ModelAutocomplete
+                value={actualMediumModel || "__default"}
+                onValueChange={(v) => setMediumModel(v === "__default" ? "" : v)}
+                options={MEDIUM_MODELS}
+                pinnedOptions={defaultOption}
+                placeholder="Select medium model"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium mb-1 block">Escalation Model</label>
+              <ModelAutocomplete
+                value={actualEscalationModel || "__default"}
+                onValueChange={(v) => setEscalationModel(v === "__default" ? "" : v)}
+                options={ESCALATION_MODELS}
+                pinnedOptions={defaultOption}
+                placeholder="Select escalation model"
               />
             </div>
             <div>

--- a/content/docs/api-reference/overview.mdx
+++ b/content/docs/api-reference/overview.mdx
@@ -110,3 +110,22 @@ Returns the full OpenAPI 3.1 specification for all dashboard API routes. Useful 
 **Auth:** None (public, like the login/callback routes).
 
 The spec covers 17 route groups: auth, chat, stats, notes, memories, users, conversations, errors, jobs, credentials, resources, consumption, adoption, settings, models, entities, and eval.
+
+### `PATCH /api/dashboard/jobs/:id`
+
+Partial update of a job. All body fields are optional: omitted fields are left unchanged, and an explicit `null` clears the override back to its default.
+
+| Field | Type | Semantics |
+| --- | --- | --- |
+| `enabled` | `boolean` | Enable or disable the job. |
+| `model` | `"main"` \| `"fast"` \| `"medium"` \| `"escalation"` \| `null` | Model catalog category the job executes with. `null` resolves to `medium` (the job default). Validated against the job-eligible catalog categories (`embedding` is not allowed). |
+| `envAllowlist` | `string[]` \| `null` | Sandbox env var **names** the job may access — names only, values are never accepted, returned, or logged. `null` = full caller-scoped inheritance; `[]` = no env vars. Names must match `[A-Za-z_][A-Za-z0-9_]*`. |
+| `promptMode` | `"full"` \| `"task"` \| `null` | `"task"` runs the minimal task prompt (no personality/notes). `null` resolves to `"full"` (default). |
+
+Invalid values return `400` with a validation message. The jobs list (`GET /api/dashboard/jobs`) and detail (`GET /api/dashboard/jobs/:id`) responses include these three fields.
+
+**Auth:** Dashboard bearer token.
+
+### Model categories & settings keys
+
+`GET /api/dashboard/models` returns the DB-backed model catalog grouped into five categories — `main`, `fast`, `medium`, `embedding`, and `escalation` — plus per-category `defaults`. Category overrides persist as ordinary settings via `PUT /api/dashboard/settings/:key` with keys `model_main`, `model_fast`, `model_medium`, `model_embedding`, and `model_escalation`. Resolution order everywhere is: DB setting override first, then catalog default (`medium` additionally falls back to the main model when unconfigured).

--- a/content/docs/dashboard.mdx
+++ b/content/docs/dashboard.mdx
@@ -63,11 +63,13 @@ View and manage Aura's knowledge base:
 
 ### Jobs
 
-Monitor scheduled and recurring jobs:
+Monitor and manage scheduled and recurring jobs:
 
 - View pending, running, completed, and failed jobs
 - See execution history and logs
 - Check cron schedules and frequency limits
+- See each job's model category in the list (`medium (default)` when unset)
+- Edit a job's execution scope from the detail page: model category (main/fast/medium/escalation), prompt mode (full/task), and the sandbox env allowlist — env var **names** only, values are never displayed
 
 ### Adoption
 
@@ -137,7 +139,7 @@ Manage ingested content:
 Configure instance behavior:
 
 - Admin user IDs
-- Model selection from the DB-backed Vercel AI Gateway catalog (searchable autocomplete grouped by provider)
+- Model selection from the DB-backed Vercel AI Gateway catalog (searchable autocomplete grouped by provider) for all five categories: main, fast, medium, escalation, and embedding — persisted as `model_*` settings through the settings API
 - Manual "Refresh Catalog" sync for newly available gateway models
 - Feature flags
 - Theme selection (light/dark/system) -- moved here from the header


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Catches the dashboard up with the model-category and scoped-job-execution changes from #1304 and #1307, and (per scope expansion) makes the job scoped-execution fields **editable** end-to-end: documented API endpoint + view/edit in the dashboard.

### Jobs API (`apps/api/src/routes/dashboard/jobs.ts`)
- Extended the existing `PATCH /api/dashboard/jobs/:id` route (previously enabled-toggle only) to a partial update accepting `enabled`, `model`, `envAllowlist`, and `promptMode`. Omitted fields are unchanged; explicit `null` clears the override (model → medium default, envAllowlist → full inheritance, promptMode → full).
- `model` is validated against the job-eligible catalog categories (`JOB_MODEL_CATEGORIES` from `lib/ai.ts` — main/fast/medium/escalation; `embedding` rejected). `envAllowlist` entries must match `[A-Za-z_][A-Za-z0-9_]*` (env var **names** only — values are never accepted, returned, or logged). Validation errors return 400 via the existing dashboard `validationHook`.
- The handler now uses `c.req.valid("json")` so the declared Zod schema is actually enforced.
- New tests in `apps/api/src/routes/dashboard/jobs.test.ts` covering the schema (9 tests).

### Job detail page (`apps/dashboard/src/routes/jobs/$id.tsx`)
- **Model** and **Prompt Mode** cards are now Selects ("medium (default)" / "full (default)" for null) that PATCH immediately, matching the existing enabled-Switch pattern.
- **Env Allowlist** card is a tag editor: add names via validated input, remove via badge ×, "Restrict" converts full inheritance to an explicit list, "Reset to full inheritance" sets null. Names only — a caption states values are never shown.

### Jobs list (`apps/dashboard/src/routes/jobs/index.tsx`)
- Compact **Model** column: outline badge, or muted "medium (default)" when NULL.

### Settings page (`apps/dashboard/src/routes/settings/index.tsx`)
- Added **Medium Model** and **Escalation Model** autocompletes backed by the `medium`/`escalation` catalog groups, persisting to `model_medium`/`model_escalation` **through the existing settings API** (`PUT /api/dashboard/settings/:key`), same pattern as the existing three selectors.
- Backend verified, no changes required: settings PUT is generic key/value, and `lib/ai.ts` already resolves `model_medium`/`model_escalation` overrides (no hardcoded key list to extend).

### Docs (`content/docs/`)
- `api-reference/overview.mdx`: documented the jobs PATCH fields (types + null semantics + validation) and the five model categories / `model_*` settings keys with their resolution order.
- `dashboard.mdx`: updated the Jobs and Settings page descriptions to reflect editing capabilities.

## Security
`envAllowlist` handles env var **names** only. The API schema only accepts identifier-shaped names, the handler logs errors only (never bodies), and the UI renders names with an explicit "values are never shown" note.

## Testing
- `pnpm typecheck` passes (API + dashboard).
- `pnpm --filter aura-api test`: 473 passed including the 9 new PATCH-schema tests; the 4 failures in `src/pipeline/respond.test.ts` are pre-existing on the base commit (verified via `git stash`) and unrelated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9d3e8ff-eb91-4383-abb9-4442b0c4a36d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9d3e8ff-eb91-4383-abb9-4442b0c4a36d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

