### PR TITLE
Security: redact secret values in dashboard settings API + write-only editing

### DIFF
--- a/apps/api/src/lib/settings-redaction.test.ts
+++ b/apps/api/src/lib/settings-redaction.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from "vitest";
+import { isSecretSettingKey, redactSettingValue, MASKED_VALUE } from "./settings-redaction.js";
+
+describe("isSecretSettingKey", () => {
+  it("matches keys containing 'secret'", () => {
+    expect(isSecretSettingKey("elevenlabs_webhook_secret")).toBe(true);
+    expect(isSecretSettingKey("my_secret")).toBe(true);
+    expect(isSecretSettingKey("SECRET_VALUE")).toBe(true);
+  });
+
+  it("matches keys containing 'token'", () => {
+    expect(isSecretSettingKey("slack_bot_token")).toBe(true);
+    expect(isSecretSettingKey("TOKEN")).toBe(true);
+  });
+
+  it("matches keys containing 'password'", () => {
+    expect(isSecretSettingKey("db_password")).toBe(true);
+    expect(isSecretSettingKey("PASSWORD")).toBe(true);
+  });
+
+  it("matches keys containing 'api_key'", () => {
+    expect(isSecretSettingKey("openai_api_key")).toBe(true);
+    expect(isSecretSettingKey("API_KEY")).toBe(true);
+  });
+
+  it("matches keys containing 'apikey'", () => {
+    expect(isSecretSettingKey("stripe_apikey")).toBe(true);
+    expect(isSecretSettingKey("APIKEY")).toBe(true);
+  });
+
+  it("matches keys containing 'private_key'", () => {
+    expect(isSecretSettingKey("rsa_private_key")).toBe(true);
+    expect(isSecretSettingKey("PRIVATE_KEY")).toBe(true);
+  });
+
+  it("matches keys containing 'refresh_token'", () => {
+    expect(isSecretSettingKey("google_refresh_token")).toBe(true);
+    expect(isSecretSettingKey("REFRESH_TOKEN")).toBe(true);
+  });
+
+  it("matches keys containing 'credential'", () => {
+    expect(isSecretSettingKey("google_credential")).toBe(true);
+    expect(isSecretSettingKey("CREDENTIALS")).toBe(true);
+  });
+
+  it("matches keys containing 'webhook_secret'", () => {
+    expect(isSecretSettingKey("github_webhook_secret")).toBe(true);
+  });
+
+  it("matches keys containing 'signing'", () => {
+    expect(isSecretSettingKey("slack_signing_secret")).toBe(true);
+    expect(isSecretSettingKey("SIGNING_KEY")).toBe(true);
+  });
+
+  it("matches keys starting with 'credential:'", () => {
+    expect(isSecretSettingKey("credential:user123:google")).toBe(true);
+    expect(isSecretSettingKey("credential:some_key")).toBe(true);
+  });
+
+  it("does not match harmless keys", () => {
+    expect(isSecretSettingKey("model_main")).toBe(false);
+    expect(isSecretSettingKey("theme")).toBe(false);
+    expect(isSecretSettingKey("e2b_sandbox_id:abc")).toBe(false);
+    expect(isSecretSettingKey("slack_channel")).toBe(false);
+    expect(isSecretSettingKey("feature_flag")).toBe(false);
+  });
+});
+
+describe("redactSettingValue", () => {
+  const baseSetting = {
+    key: "some_key",
+    value: "actual-value",
+    description: null,
+    updatedAt: new Date("2024-01-01"),
+    updatedBy: "dashboard",
+    workspaceId: "ws1",
+  };
+
+  it("does not redact non-secret keys", () => {
+    const result = redactSettingValue({ ...baseSetting, key: "model_main", value: "claude-3" });
+    expect(result.value).toBe("claude-3");
+    expect(result.redacted).toBe(false);
+    expect(result.hasValue).toBe(true);
+  });
+
+  it("redacts secret keys and replaces value with masked placeholder", () => {
+    const result = redactSettingValue({ ...baseSetting, key: "google_refresh_token", value: "secret123" });
+    expect(result.value).toBe(MASKED_VALUE);
+    expect(result.redacted).toBe(true);
+    expect(result.hasValue).toBe(true);
+  });
+
+  it("sets hasValue=false for secret keys with empty stored value", () => {
+    const result = redactSettingValue({ ...baseSetting, key: "elevenlabs_webhook_secret", value: "" });
+    expect(result.value).toBe(MASKED_VALUE);
+    expect(result.redacted).toBe(true);
+    expect(result.hasValue).toBe(false);
+  });
+
+  it("does not mutate the original object", () => {
+    const original = { ...baseSetting, key: "api_key", value: "real-key" };
+    redactSettingValue(original);
+    expect(original.value).toBe("real-key");
+  });
+});
+
+// --- GET route integration-style tests ---
+
+vi.mock("../db/client.js", () => ({ db: {} }));
+
+const { dashboardSettingsApp } = await import("../routes/dashboard/settings.js");
+
+function makeDbSetting(overrides: Partial<{
+  key: string; value: string; description: string | null;
+  updatedAt: Date; updatedBy: string | null; workspaceId: string;
+}> = {}) {
+  return {
+    key: "some_key",
+    value: "some_value",
+    description: null,
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    updatedBy: "dashboard",
+    workspaceId: "ws1",
+    ...overrides,
+  };
+}
+
+// Mock Drizzle builder for the list endpoint
+function mockDb(rows: ReturnType<typeof makeDbSetting>[]) {
+  const query: any = {
+    from: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => Promise.resolve(rows)),
+    limit: vi.fn(() => Promise.resolve(rows.slice(0, 1))),
+  };
+  return { select: vi.fn(() => query), insert: vi.fn(), query };
+}
+
+describe("GET /api/dashboard/settings — redaction in list endpoint", () => {
+  it("returns raw value for non-secret keys", async () => {
+    const { db } = await import("../db/client.js");
+    const mock = mockDb([makeDbSetting({ key: "model_main", value: "claude-3" })]);
+    Object.assign(db, mock);
+
+    const res = await dashboardSettingsApp.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    expect(body[0].value).toBe("claude-3");
+    expect(body[0].redacted).toBe(false);
+  });
+
+  it("masks value for secret key in list response", async () => {
+    const { db } = await import("../db/client.js");
+    const mock = mockDb([makeDbSetting({ key: "google_refresh_token", value: "real-secret" })]);
+    Object.assign(db, mock);
+
+    const res = await dashboardSettingsApp.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    expect(body[0].value).toBe(MASKED_VALUE);
+    expect(body[0].redacted).toBe(true);
+    expect(body[0].hasValue).toBe(true);
+  });
+
+  it("sets hasValue=false for secret key with empty stored value", async () => {
+    const { db } = await import("../db/client.js");
+    const mock = mockDb([makeDbSetting({ key: "elevenlabs_webhook_secret", value: "" })]);
+    Object.assign(db, mock);
+
+    const res = await dashboardSettingsApp.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    expect(body[0].redacted).toBe(true);
+    expect(body[0].hasValue).toBe(false);
+  });
+});
+
+describe("PUT /api/dashboard/settings/:key — write-only semantics", () => {
+  it("returns 204 (no-op) when empty value submitted for secret key", async () => {
+    const res = await dashboardSettingsApp.request("/google_refresh_token", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: "" }),
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 204 (no-op) when masked placeholder submitted for secret key", async () => {
+    const res = await dashboardSettingsApp.request("/google_refresh_token", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: MASKED_VALUE }),
+    });
+    expect(res.status).toBe(204);
+  });
+});

--- a/apps/api/src/lib/settings-redaction.ts
+++ b/apps/api/src/lib/settings-redaction.ts
@@ -1,0 +1,60 @@
+/**
+ * Settings redaction helpers.
+ *
+ * Secret-bearing settings must never be returned as raw values in API
+ * responses. Instead, GET endpoints return a masked placeholder with
+ * `hasValue: true` and `redacted: true`. PUT endpoints treat an empty
+ * submitted value as "no change" so UIs can implement write-only fields.
+ */
+
+export const MASKED_VALUE = "••••••••";
+
+/**
+ * Returns true when the given settings key is considered secret and its
+ * value must be redacted in API responses.
+ *
+ * A key is secret when it:
+ * - starts with `credential:`, OR
+ * - contains any of: secret, token, password, api_key, apikey,
+ *   private_key, refresh_token, credential, webhook_secret, signing
+ *   (case-insensitive substring match)
+ */
+export function isSecretSettingKey(key: string): boolean {
+  if (key.startsWith("credential:")) return true;
+  const lower = key.toLowerCase();
+  return (
+    lower.includes("secret") ||
+    lower.includes("token") ||
+    lower.includes("password") ||
+    lower.includes("api_key") ||
+    lower.includes("apikey") ||
+    lower.includes("private_key") ||
+    lower.includes("refresh_token") ||
+    lower.includes("credential") ||
+    lower.includes("webhook_secret") ||
+    lower.includes("signing")
+  );
+}
+
+export interface RedactedSetting<T extends { key: string; value: string }> {
+  setting: Omit<T, "value"> & { value: string; hasValue: boolean; redacted: boolean };
+}
+
+/**
+ * Returns a copy of the setting with value redacted if the key is secret.
+ * Non-secret keys are returned unchanged (with `hasValue` and `redacted`
+ * appended for a uniform shape).
+ */
+export function redactSettingValue<T extends { key: string; value: string }>(
+  setting: T,
+): T & { hasValue: boolean; redacted: boolean } {
+  if (isSecretSettingKey(setting.key)) {
+    return {
+      ...setting,
+      value: MASKED_VALUE,
+      hasValue: setting.value !== "" && setting.value != null,
+      redacted: true,
+    };
+  }
+  return { ...setting, hasValue: true, redacted: false };
+}

--- a/apps/api/src/routes/dashboard/settings.ts
+++ b/apps/api/src/routes/dashboard/settings.ts
@@ -1,22 +1,36 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { eq, asc, sql } from "drizzle-orm";
+import { eq, asc } from "drizzle-orm";
 import { settings } from "@aura/db/schema";
 import { db } from "../../db/client.js";
 import { logger } from "../../lib/logger.js";
 import { errorSchema, createDashboardApp } from "./schemas.js";
+import { isSecretSettingKey, redactSettingValue, MASKED_VALUE } from "../../lib/settings-redaction.js";
 
 export const dashboardSettingsApp = createDashboardApp();
+
+const redactedSettingSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+  hasValue: z.boolean(),
+  redacted: z.boolean(),
+  description: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+  updatedBy: z.string().nullable(),
+  workspaceId: z.string(),
+});
 
 const listSettingsRoute = createRoute({
   method: "get",
   path: "/",
   tags: ["Settings"],
   summary: "List all settings",
+  description:
+    "Returns all settings for the workspace. Values for secret-bearing keys (tokens, passwords, API keys, etc.) are replaced with a masked placeholder; those rows include `redacted: true` and `hasValue: true` when a value is stored.",
   responses: {
     200: {
       content: {
         "application/json": {
-          schema: z.array(z.any()),
+          schema: z.array(redactedSettingSchema),
         },
       },
       description: "Success",
@@ -35,7 +49,7 @@ dashboardSettingsApp.openapi(listSettingsRoute, async (c) => {
       .from(settings)
       .orderBy(asc(settings.key));
 
-    return c.json(allSettings as any, 200);
+    return c.json(allSettings.map(redactSettingValue) as any, 200);
   } catch (error) {
     logger.error("Failed to list settings", { error: String(error) });
     return c.json({ error: "Internal server error" }, 500);
@@ -47,6 +61,8 @@ const getSettingRoute = createRoute({
   path: "/{key}",
   tags: ["Settings"],
   summary: "Get a setting by key",
+  description:
+    "Returns a single setting. For secret-bearing keys the value is replaced with a masked placeholder and `redacted: true` is set. Use PUT to overwrite; submit an empty value to leave the stored value unchanged.",
   request: {
     params: z.object({
       key: z.string().openapi({ param: { name: "key", in: "path" } }),
@@ -56,7 +72,11 @@ const getSettingRoute = createRoute({
     200: {
       content: {
         "application/json": {
-          schema: z.object({ value: z.string() }),
+          schema: z.object({
+            value: z.string(),
+            hasValue: z.boolean(),
+            redacted: z.boolean(),
+          }),
         },
       },
       description: "Success",
@@ -84,7 +104,11 @@ dashboardSettingsApp.openapi(getSettingRoute, async (c) => {
 
     if (!setting) return c.json({ error: "Not found" }, 404);
 
-    return c.json({ value: setting.value } as any, 200);
+    const redacted = redactSettingValue(setting);
+    return c.json(
+      { value: redacted.value, hasValue: redacted.hasValue, redacted: redacted.redacted } as any,
+      200,
+    );
   } catch (error) {
     logger.error("Failed to get setting", { error: String(error) });
     return c.json({ error: "Internal server error" }, 500);
@@ -96,6 +120,8 @@ const upsertSettingRoute = createRoute({
   path: "/{key}",
   tags: ["Settings"],
   summary: "Create or update a setting",
+  description:
+    "Upserts a setting value. For secret-bearing keys, submitting an empty string leaves the stored value unchanged (write-only semantics). Submitting the masked placeholder value is also treated as no-op. Non-empty values always overwrite.",
   request: {
     params: z.object({
       key: z.string().openapi({ param: { name: "key", in: "path" } }),
@@ -114,6 +140,9 @@ const upsertSettingRoute = createRoute({
       content: { "application/json": { schema: z.any() } },
       description: "Success",
     },
+    204: {
+      description: "No-op: secret key with empty value submitted, stored value unchanged",
+    },
     500: {
       content: { "application/json": { schema: errorSchema } },
       description: "Error",
@@ -125,6 +154,12 @@ dashboardSettingsApp.openapi(upsertSettingRoute, async (c) => {
   try {
     const key = c.req.param("key");
     const { value } = await c.req.json<{ value: string }>();
+
+    // Write-only semantics for secret keys: empty string or the masked
+    // placeholder both mean "leave stored value unchanged".
+    if (isSecretSettingKey(key) && (value === "" || value === MASKED_VALUE)) {
+      return c.body(null, 204);
+    }
 
     const [upserted] = await db
       .insert(settings)
@@ -144,7 +179,7 @@ dashboardSettingsApp.openapi(upsertSettingRoute, async (c) => {
       })
       .returning();
 
-    return c.json(upserted as any, 200);
+    return c.json(redactSettingValue(upserted) as any, 200);
   } catch (error) {
     logger.error("Failed to upsert setting", { error: String(error) });
     return c.json({ error: "Internal server error" }, 500);

--- a/apps/dashboard/src/routes/settings/index.tsx
+++ b/apps/dashboard/src/routes/settings/index.tsx
@@ -12,11 +12,13 @@ import { ThemeSelect } from "@/components/theme-toggle";
 import { formatDate } from "@/lib/utils";
 import { MODEL_CATEGORIES, type ModelCategory } from "@/lib/model-categories";
 import { useMemo, useState } from "react";
-import { RefreshCw, Save, Plus, Pencil } from "lucide-react";
+import { RefreshCw, Save, Plus, Pencil, ChevronDown, ChevronRight, Lock } from "lucide-react";
 
 interface Setting {
   key: string;
   value: string;
+  hasValue: boolean;
+  redacted: boolean;
   description: string | null;
   updatedAt: string;
   updatedBy: string | null;
@@ -46,6 +48,19 @@ interface ModelCatalog {
   lastSyncedAt: string | null;
 }
 
+/** Runtime-state keys that represent per-sandbox/per-user transient state. */
+function isRuntimeKey(key: string): boolean {
+  return (
+    key.startsWith("e2b_sandbox_id:") ||
+    key.startsWith("e2b_template:") ||
+    key.startsWith("sandbox:") ||
+    key.startsWith("session:") ||
+    key.startsWith("runtime:")
+  );
+}
+
+const MASKED_VALUE = "••••••••";
+
 function SettingsPage() {
   const queryClient = useQueryClient();
 
@@ -63,11 +78,14 @@ function SettingsPage() {
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editingRedacted, setEditingRedacted] = useState(false);
   const [formKey, setFormKey] = useState("");
   const [formValue, setFormValue] = useState("");
+  const [runtimeExpanded, setRuntimeExpanded] = useState(false);
 
   function openCreate() {
     setEditingKey(null);
+    setEditingRedacted(false);
     setFormKey("");
     setFormValue("");
     setDialogOpen(true);
@@ -75,8 +93,11 @@ function SettingsPage() {
 
   function openEdit(setting: Setting) {
     setEditingKey(setting.key);
+    setEditingRedacted(setting.redacted);
     setFormKey(setting.key);
-    setFormValue(setting.value);
+    // For redacted settings, start with empty so user must type a new value
+    // (empty = no-op on the server side).
+    setFormValue(setting.redacted ? "" : setting.value);
     setDialogOpen(true);
   }
 
@@ -128,9 +149,14 @@ function SettingsPage() {
   if (loadingSettings) return <PageSkeleton rows={8} />;
   if (settingsError) return <div className="text-destructive text-sm">Failed to load settings: {settingsError.message}</div>;
 
-  const nonModelSettings = (settings ?? []).filter(
+  const allSettings = settings ?? [];
+
+  // Partition into model, runtime, and regular settings
+  const nonModelSettings = allSettings.filter(
     (s) => !s.key.startsWith("model_") && !s.key.startsWith("credential:"),
   );
+  const regularSettings = nonModelSettings.filter((s) => !isRuntimeKey(s.key));
+  const runtimeSettings = nonModelSettings.filter((s) => isRuntimeKey(s.key));
 
   const isEditing = editingKey !== null;
   const defaultOption = [{ value: "__default", label: "Default" }];
@@ -216,10 +242,21 @@ function SettingsPage() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {nonModelSettings.map((s) => (
+            {regularSettings.map((s) => (
               <TableRow key={s.key}>
-                <TableCell className="font-mono text-sm">{s.key}</TableCell>
-                <TableCell className="text-sm">{s.value}</TableCell>
+                <TableCell className="font-mono text-sm">
+                  <span className="flex items-center gap-1.5">
+                    {s.redacted && <Lock className="h-3 w-3 text-muted-foreground shrink-0" />}
+                    {s.key}
+                  </span>
+                </TableCell>
+                <TableCell className="text-sm">
+                  {s.redacted ? (
+                    <span className="text-muted-foreground font-mono">{s.hasValue ? MASKED_VALUE : "—"}</span>
+                  ) : (
+                    s.value
+                  )}
+                </TableCell>
                 <TableCell className="text-muted-foreground text-sm">{formatDate(s.updatedAt)}</TableCell>
                 <TableCell className="text-muted-foreground text-sm">{s.updatedBy || "—"}</TableCell>
                 <TableCell>
@@ -229,7 +266,7 @@ function SettingsPage() {
                 </TableCell>
               </TableRow>
             ))}
-            {nonModelSettings.length === 0 && (
+            {regularSettings.length === 0 && (
               <TableRow>
                 <TableCell colSpan={5} className="text-center text-muted-foreground py-8">No settings</TableCell>
               </TableRow>
@@ -237,6 +274,51 @@ function SettingsPage() {
           </TableBody>
         </Table>
       </div>
+
+      {runtimeSettings.length > 0 && (
+        <div className="rounded-xl border overflow-hidden">
+          <button
+            type="button"
+            className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+            onClick={() => setRuntimeExpanded((v) => !v)}
+          >
+            {runtimeExpanded ? (
+              <ChevronDown className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0" />
+            )}
+            Runtime state ({runtimeSettings.length})
+          </button>
+          {runtimeExpanded && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[200px]">Key</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead className="w-[160px]">Updated</TableHead>
+                  <TableHead className="w-[120px]">By</TableHead>
+                  <TableHead className="w-10" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {runtimeSettings.map((s) => (
+                  <TableRow key={s.key}>
+                    <TableCell className="font-mono text-sm">{s.key}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground font-mono truncate max-w-xs">{s.value}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{formatDate(s.updatedAt)}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">{s.updatedBy || "—"}</TableCell>
+                    <TableCell>
+                      <Button variant="ghost" size="icon-sm" onClick={() => openEdit(s)}>
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      )}
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent>
@@ -259,10 +341,17 @@ function SettingsPage() {
             <div className="space-y-1.5">
               <label className="text-sm font-medium">Value</label>
               <Input
-                placeholder="Setting value"
+                placeholder={editingRedacted ? "Enter new value to overwrite (leave blank to keep current)" : "Setting value"}
                 value={formValue}
                 onChange={(e) => setFormValue(e.target.value)}
+                type={editingRedacted ? "password" : "text"}
               />
+              {editingRedacted && (
+                <p className="text-xs text-muted-foreground flex items-center gap-1">
+                  <Lock className="h-3 w-3" />
+                  This is a secret field. Leave blank to keep the stored value unchanged.
+                </p>
+              )}
             </div>
             <div className="flex justify-end gap-2">
               <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>

--- a/content/docs/api-reference/overview.mdx
+++ b/content/docs/api-reference/overview.mdx
@@ -132,6 +132,36 @@ Returns the live `promptMode='task'` system prefix as `{ "prompt": "<task_mode>.
 
 **Auth:** Dashboard bearer token.
 
+### `GET /api/dashboard/settings`
+
+Returns all settings for the workspace as a JSON array. Each item has the following shape:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `key` | `string` | Setting key |
+| `value` | `string` | Raw value for non-secret keys; masked placeholder (`••••••••`) for secret keys |
+| `hasValue` | `boolean` | `true` when a non-empty value is stored (always `true` for non-secret keys) |
+| `redacted` | `boolean` | `true` when the value has been masked |
+| `description` | `string \| null` | Optional description |
+| `updatedAt` | `string \| null` | ISO 8601 timestamp of last update |
+| `updatedBy` | `string \| null` | Who last updated this setting |
+
+**Secret-bearing keys** are redacted automatically. A key is considered secret when it starts with `credential:` or contains any of: `secret`, `token`, `password`, `api_key`, `apikey`, `private_key`, `refresh_token`, `credential`, `webhook_secret`, `signing` (case-insensitive). Raw values are never returned for these keys.
+
+**Auth:** Dashboard bearer token.
+
+### `GET /api/dashboard/settings/:key`
+
+Returns `{ value, hasValue, redacted }` for a single setting. Same redaction rules as the list endpoint apply.
+
+**Auth:** Dashboard bearer token.
+
+### `PUT /api/dashboard/settings/:key`
+
+Upserts a setting. **Write-only semantics for secret keys:** submitting an empty string or the masked placeholder (`••••••••`) as the value is treated as a no-op and returns `204 No Content` — the stored value is left unchanged. Submitting a non-empty, non-placeholder value always overwrites the stored value. The response body (for `200`) applies the same redaction as the GET endpoints.
+
+**Auth:** Dashboard bearer token.
+
 ### Model categories & settings keys
 
 `GET /api/dashboard/models` returns the model catalog grouped into five categories — `main`, `fast`, `medium`, `embedding`, and `escalation` — plus per-category `defaults`. The per-category lists contain the **full catalog synced from the Vercel AI Gateway**, filtered only by capability metadata: models typed `embedding`, `image`, `video`, or `reranking` are excluded from the chat categories, and the `embedding` category lists embedding models. Models with unknown type appear everywhere rather than being hidden by a guessed blocklist.


### PR DESCRIPTION
Authored by Aura via Claude Code in the sandbox (no Cursor agent). Requested by Joan, Aug 17 2026.