### PR TITLE
Models: single source of truth for category defaults + expose medium/escalation in Slack App Home

### DIFF
--- a/apps/api/src/lib/ai.test.ts
+++ b/apps/api/src/lib/ai.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   gatewayAuthIsInstance: vi.fn(),
-  getDefaultModelId: vi.fn(),
   getModelCapabilities: vi.fn(),
   updateModelCapabilities: vi.fn(),
   wrapLanguageModel: vi.fn(({ model, middleware }: any) => ({
@@ -37,7 +36,6 @@ vi.mock("./settings.js", () => ({
 }));
 
 vi.mock("./model-catalog.js", () => ({
-  getDefaultModelId: mocks.getDefaultModelId,
   getModelCapabilities: mocks.getModelCapabilities,
   updateModelCapabilities: mocks.updateModelCapabilities,
 }));
@@ -55,19 +53,21 @@ vi.mock("./invocation-lock.js", () => ({
   isInvocationCurrent: vi.fn(),
 }));
 
-import { withAnthropicFallback, getModelByCategory, isJobModelCategory } from "./ai.js";
+import { withAnthropicFallback, getModelByCategory, isJobModelCategory, LAST_RESORT_MODELS } from "./ai.js";
 import { getSetting } from "./settings.js";
+import { logger } from "./logger.js";
 
 const getSettingMock = vi.mocked(getSetting);
+const loggerWarnMock = vi.mocked(logger.warn);
 
-describe("getModelByCategory", () => {
+describe("getModelByCategory — resolution order", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSettingMock.mockResolvedValue(null);
-    mocks.getDefaultModelId.mockResolvedValue(null);
   });
 
-  it("resolves the fast category from the DB setting override first", async () => {
+  // Requirement: present settings row → used directly, no fallback
+  it("uses the DB settings row when present (fast)", async () => {
     getSettingMock.mockImplementation(async (key: string) =>
       key === "model_fast" ? "openai/gpt-fast-override" : null,
     );
@@ -76,21 +76,10 @@ describe("getModelByCategory", () => {
 
     expect(modelId).toBe("openai/gpt-fast-override");
     expect(getSettingMock).toHaveBeenCalledWith("model_fast");
-    expect(mocks.getDefaultModelId).not.toHaveBeenCalled();
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to the catalog default for the category", async () => {
-    mocks.getDefaultModelId.mockImplementation(async (category: string) =>
-      category === "fast" ? "google/gemini-fast-default" : null,
-    );
-
-    const { modelId } = await getModelByCategory("fast");
-
-    expect(modelId).toBe("google/gemini-fast-default");
-    expect(mocks.getDefaultModelId).toHaveBeenCalledWith("fast");
-  });
-
-  it("resolves the escalation category via its own setting key", async () => {
+  it("uses the DB settings row when present (escalation)", async () => {
     getSettingMock.mockImplementation(async (key: string) =>
       key === "model_escalation" ? "openai/gpt-escalation" : null,
     );
@@ -99,26 +88,10 @@ describe("getModelByCategory", () => {
 
     expect(modelId).toBe("openai/gpt-escalation");
     expect(getSettingMock).toHaveBeenCalledWith("model_escalation");
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
-  it("resolves the main category identically to getMainModel", async () => {
-    mocks.getDefaultModelId.mockImplementation(async (category: string) =>
-      category === "main" ? "anthropic/claude-main" : null,
-    );
-
-    const { modelId } = await getModelByCategory("main");
-
-    expect(modelId).toBe("anthropic/claude-main");
-    expect(getSettingMock).toHaveBeenCalledWith("model_main");
-  });
-
-  it("throws when neither a setting nor a catalog default exists", async () => {
-    await expect(getModelByCategory("fast")).rejects.toThrow(
-      "No default model configured for category: fast",
-    );
-  });
-
-  it("resolves the medium category from the DB setting override first", async () => {
+  it("uses the DB settings row when present (medium)", async () => {
     getSettingMock.mockImplementation(async (key: string) =>
       key === "model_medium" ? "anthropic/claude-medium-override" : null,
     );
@@ -127,29 +100,59 @@ describe("getModelByCategory", () => {
 
     expect(modelId).toBe("anthropic/claude-medium-override");
     expect(getSettingMock).toHaveBeenCalledWith("model_medium");
-    expect(mocks.getDefaultModelId).not.toHaveBeenCalled();
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
-  it("resolves the medium category from the catalog default", async () => {
-    mocks.getDefaultModelId.mockImplementation(async (category: string) =>
-      category === "medium" ? "anthropic/claude-medium-default" : null,
+  it("uses the DB settings row when present (main)", async () => {
+    getSettingMock.mockImplementation(async (key: string) =>
+      key === "model_main" ? "anthropic/claude-main-override" : null,
     );
 
-    const { modelId } = await getModelByCategory("medium");
+    const { modelId } = await getModelByCategory("main");
 
-    expect(modelId).toBe("anthropic/claude-medium-default");
-    expect(mocks.getDefaultModelId).toHaveBeenCalledWith("medium");
-  });
-
-  it("falls back to the main model when no medium selection exists", async () => {
-    mocks.getDefaultModelId.mockImplementation(async (category: string) =>
-      category === "main" ? "anthropic/claude-main" : null,
-    );
-
-    const { modelId } = await getModelByCategory("medium");
-
-    expect(modelId).toBe("anthropic/claude-main");
+    expect(modelId).toBe("anthropic/claude-main-override");
     expect(getSettingMock).toHaveBeenCalledWith("model_main");
+    expect(loggerWarnMock).not.toHaveBeenCalled();
+  });
+
+  // Requirement: missing settings row → hardcoded LAST_RESORT_MODELS fallback + warning
+  it("falls back to LAST_RESORT_MODELS and logs a warning when no settings row exists (fast)", async () => {
+    const { modelId } = await getModelByCategory("fast");
+
+    expect(modelId).toBe(LAST_RESORT_MODELS.fast);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "No DB setting for model category, using last-resort default",
+      expect.objectContaining({ category: "fast", fallback: LAST_RESORT_MODELS.fast }),
+    );
+  });
+
+  it("falls back to LAST_RESORT_MODELS and logs a warning when no settings row exists (main)", async () => {
+    const { modelId } = await getModelByCategory("main");
+
+    expect(modelId).toBe(LAST_RESORT_MODELS.main);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "No DB setting for model category, using last-resort default",
+      expect.objectContaining({ category: "main", fallback: LAST_RESORT_MODELS.main }),
+    );
+  });
+
+  it("falls back to LAST_RESORT_MODELS.medium when no settings row exists (not main)", async () => {
+    const { modelId } = await getModelByCategory("medium");
+
+    expect(modelId).toBe(LAST_RESORT_MODELS.medium);
+    // Must NOT fall through to the main setting key
+    expect(getSettingMock).not.toHaveBeenCalledWith("model_main");
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "No DB setting for model category, using last-resort default",
+      expect.objectContaining({ category: "medium" }),
+    );
+  });
+
+  // Requirement: unknown category → throws
+  it("throws for an unknown category (not in LAST_RESORT_MODELS)", async () => {
+    await expect(
+      getModelByCategory("unknown_category" as any),
+    ).rejects.toThrow("No last-resort model configured for unknown category: unknown_category");
   });
 });
 

--- a/apps/api/src/lib/ai.ts
+++ b/apps/api/src/lib/ai.ts
@@ -7,7 +7,7 @@ import {
 /** The model type that wrapLanguageModel accepts (LanguageModelV3, not re-exported by "ai"). */
 export type WrappableModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 import { getSetting } from "./settings.js";
-import { getDefaultModelId, updateModelCapabilities } from "./model-catalog.js";
+import { type ModelCategory, updateModelCapabilities } from "./model-catalog.js";
 import { logger } from "./logger.js";
 import {
   getProviderThinkingOptions,
@@ -19,8 +19,16 @@ import type { ModelCapabilities } from "@aura/db/schema";
  * All LLM and embedding calls go through Vercel AI Gateway.
  *
  * Models are resolved dynamically: DB settings take priority,
- * then DB-backed catalog defaults. This lets admins
+ * then an explicit hardcoded last-resort constant map. This lets admins
  * change models from the Slack App Home without redeploying.
+ *
+ * Resolution order (see LAST_RESORT_MODELS below):
+ *   1. settings row (model_main / model_fast / model_medium / model_escalation / model_embedding)
+ *   2. Hardcoded LAST_RESORT_MODELS — logs a warning so operators notice the gap
+ *
+ * Note: model_catalog_selections.isDefault is no longer consulted during
+ * resolution; it is only used to populate the curated lists shown in
+ * the legacy Slack App Home dropdowns (deprecated — see model-catalog.ts).
  *
  * When deployed on Vercel, auth is handled automatically via OIDC.
  * For local development, set VERCEL_AI_GATEWAY_API_KEY in .env.local.
@@ -31,17 +39,36 @@ import type { ModelCapabilities } from "@aura/db/schema";
  * directly using ANTHROPIC_API_KEY.
  */
 
+/**
+ * Last-resort model IDs used when no settings row exists for a category.
+ * These are gateway model IDs (provider/model-name format with dotted versions).
+ * Update this map when a newer default is desired — it is the single source
+ * of truth for the fallback path.
+ */
+export const LAST_RESORT_MODELS: Record<ModelCategory, string> = {
+  main:      "anthropic/claude-sonnet-4.5",
+  fast:      "anthropic/claude-haiku-4.5",
+  medium:    "anthropic/claude-sonnet-4.5",
+  embedding: "openai/text-embedding-3-small",
+  escalation:"anthropic/claude-opus-4.5",
+};
+
 async function resolveModelId(
   settingKey: string,
-  category: "main" | "fast" | "medium" | "embedding" | "escalation",
+  category: ModelCategory,
 ): Promise<string> {
   const override = await getSetting(settingKey);
   if (override) return override;
 
-  const defaultModelId = await getDefaultModelId(category);
-  if (defaultModelId) return defaultModelId;
-
-  throw new Error(`No default model configured for category: ${category}`);
+  const fallback = LAST_RESORT_MODELS[category];
+  if (!fallback) {
+    throw new Error(`No last-resort model configured for unknown category: ${category}`);
+  }
+  logger.warn("No DB setting for model category, using last-resort default", {
+    category,
+    fallback,
+  });
+  return fallback;
 }
 
 /**
@@ -286,18 +313,10 @@ export async function getFastModelId(): Promise<string> {
 
 /**
  * Resolve the medium model ID string (no gateway wrapping).
- * Priority: DB setting > catalog default > main model (never crashes when
- * no medium selection is configured).
+ * Priority: DB setting > LAST_RESORT_MODELS.medium
  */
 export async function getMediumModelId(): Promise<string> {
-  const override = await getSetting("model_medium");
-  if (override) return override;
-
-  const defaultModelId = await getDefaultModelId("medium");
-  if (defaultModelId) return defaultModelId;
-
-  logger.warn("No medium model configured, falling back to main");
-  return getMainModelId();
+  return resolveModelId("model_medium", "medium");
 }
 
 /**

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -555,6 +555,19 @@ export async function getModelCatalogResponse(
   };
 }
 
+/**
+ * @deprecated
+ * `getDefaultModelId` reads `model_catalog_selections.isDefault` to find a
+ * per-category default. It is no longer called from the model-resolution path
+ * (`apps/api/src/lib/ai.ts`), which now uses `LAST_RESORT_MODELS` as the
+ * fallback so that resolution never silently relies on potentially stale
+ * catalog data.
+ *
+ * The `model_catalog_selections` table (and the `defaults` field in
+ * `ModelCatalogResponse`) is retained for the legacy curated lists shown in
+ * the Slack App Home `static_select` menus. Do not drop the table or the
+ * `isDefault` column without first migrating those callers.
+ */
 export async function getDefaultModelId(
   category: ModelCategory,
   workspaceId = DEFAULT_WORKSPACE_ID,

--- a/apps/api/src/slack/home.ts
+++ b/apps/api/src/slack/home.ts
@@ -12,6 +12,7 @@ import {
   getModelCatalogResponse,
   type ModelOption,
 } from "../lib/model-catalog.js";
+import { LAST_RESORT_MODELS } from "../lib/ai.js";
 
 // ── Credential Definitions ───────────────────────────────────────────────────
 
@@ -639,10 +640,11 @@ export async function publishHomeTab(
       catalog.catalog.map((model) => [model.value, model.label]),
     );
 
-    const mainValue = currentSettings.model_main || catalog.defaults.main || "";
-    const fastValue = currentSettings.model_fast || catalog.defaults.fast || "";
-    const embeddingValue =
-      currentSettings.model_embedding || catalog.defaults.embedding || "";
+    const mainValue = currentSettings.model_main || LAST_RESORT_MODELS.main;
+    const fastValue = currentSettings.model_fast || LAST_RESORT_MODELS.fast;
+    const mediumValue = currentSettings.model_medium || LAST_RESORT_MODELS.medium;
+    const escalationValue = currentSettings.model_escalation || LAST_RESORT_MODELS.escalation;
+    const embeddingValue = currentSettings.model_embedding || LAST_RESORT_MODELS.embedding;
 
     const blocks: any[] = [
       {
@@ -683,6 +685,24 @@ export async function publishHomeTab(
           },
         },
         buildDropdown("select_model_fast", "Fast Model", catalog.fast, fastValue),
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*:newspaper: Medium Model*\nDefault tier for scheduled jobs — Sonnet-class balance of speed and quality.",
+          },
+        },
+        buildDropdown("select_model_medium", "Medium Model", catalog.medium, mediumValue),
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*:arrow_up: Escalation Model*\nSwapped in automatically when the main model is struggling mid-conversation.",
+          },
+        },
+        buildDropdown("select_model_escalation", "Escalation Model", catalog.escalation, escalationValue),
         { type: "divider" },
         {
           type: "section",
@@ -759,6 +779,8 @@ export async function publishHomeTab(
       // Read-only view
       const mainLabel = labelByValue.get(mainValue) || mainValue;
       const fastLabel = labelByValue.get(fastValue) || fastValue;
+      const mediumLabel = labelByValue.get(mediumValue) || mediumValue;
+      const escalationLabel = labelByValue.get(escalationValue) || escalationValue;
       const embeddingLabel = labelByValue.get(embeddingValue) || embeddingValue;
 
       blocks.push(
@@ -766,7 +788,7 @@ export async function publishHomeTab(
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `*:brain: Main Model:* ${mainLabel}\n*:zap: Fast Model:* ${fastLabel}\n*:mag: Embedding Model:* ${embeddingLabel}`,
+            text: `*:brain: Main Model:* ${mainLabel}\n*:zap: Fast Model:* ${fastLabel}\n*:newspaper: Medium Model:* ${mediumLabel}\n*:arrow_up: Escalation Model:* ${escalationLabel}\n*:mag: Embedding Model:* ${embeddingLabel}`,
           },
         },
       );
@@ -813,6 +835,8 @@ export async function publishHomeTab(
 export const ACTION_TO_SETTING: Record<string, string> = {
   select_model_main: "model_main",
   select_model_fast: "model_fast",
+  select_model_medium: "model_medium",
+  select_model_escalation: "model_escalation",
   select_model_embedding: "model_embedding",
   select_slack_task_display_mode: "slack_task_display_mode",
 };

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -122,6 +122,23 @@ Additional cron jobs:
 - **Email sync** — Periodic inbox sync for connected Gmail accounts.
 - **Note expiry** — Cleans up expired plan notes.
 
+## Model Resolution
+
+Every LLM call in Aura resolves a gateway model ID at runtime through a two-step chain:
+
+1. **Settings row** — `getSetting("model_<category>")` reads the `settings` table. Admins set these from the dashboard or the Slack App Home. This is the authoritative source.
+2. **Last-resort hardcoded constant** (`LAST_RESORT_MODELS` in `apps/api/src/lib/ai.ts`) — used when no settings row exists. A `warn`-level log entry is emitted so operators know the fallback fired. The constant is intentionally explicit and small so it is easy to update when a newer default model is preferred.
+
+| Category | Setting key | Last-resort default |
+|---|---|---|
+| `main` | `model_main` | `anthropic/claude-sonnet-4.5` |
+| `fast` | `model_fast` | `anthropic/claude-haiku-4.5` |
+| `medium` | `model_medium` | `anthropic/claude-sonnet-4.5` |
+| `escalation` | `model_escalation` | `anthropic/claude-opus-4.5` |
+| `embedding` | `model_embedding` | `openai/text-embedding-3-small` |
+
+> **Deprecated path**: `model_catalog_selections.isDefault` was previously used as a middle tier between the settings row and the hardcoded constant. It is no longer consulted during resolution. The table is kept for the curated dropdown lists shown in the Slack App Home; see the `@deprecated` note on `getDefaultModelId` in `model-catalog.ts`.
+
 ## Extended Thinking
 
 Aura captures the model's reasoning process before it generates a response, across every provider that exposes it -- not just Claude. These reasoning traces are:


### PR DESCRIPTION
Authored by Aura via Claude Code in the sandbox (no Cursor agent). Requested by Joan, Aug 17 2026.