### PR TITLE
Fix silent migration skip: hash-based ledger, legacy backfill, unix prefix, CI guard

### DIFF
--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -1,0 +1,39 @@
+name: Migration Guard
+
+on:
+  pull_request:
+    paths:
+      - 'packages/db/drizzle/**'
+
+jobs:
+  migration-guard:
+    name: Check migration ordering + integrity
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git show origin/main:...` works
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch main branch for comparison
+        run: git fetch origin main --depth=1
+
+      - name: Run migration guard
+        # Checks that no newly added journal entry:
+        #   - has a `when` <= max `when` on main (out-of-order generation)
+        #   - shares a `when` with another new entry (duplicate timestamp)
+        #   - references a .sql file that does not exist (missing SQL)
+        # And that no .sql file in drizzle/ lacks a journal entry (orphaned SQL).
+        # Failure means the branch is stale — rebase on main and regenerate.
+        run: pnpm --filter @aura/db run guard

--- a/content/docs/deployment/vercel.mdx
+++ b/content/docs/deployment/vercel.mdx
@@ -76,10 +76,42 @@ Local development: `pnpm dev` in `apps/api` runs `nitro dev` (workflows run in t
 ## Important Rules
 
 1. **Never push directly to `main`.** Vercel auto-deploys, so any push goes straight to production. Always use feature branches and PRs.
-2. **Migrations run on every deploy.** Drizzle handles idempotency — running the same migration twice is safe.
-3. **Drizzle migration format:** Always include `-->statement-breakpoint` between SQL statements in migration files.
-4. **Serverless = stateless.** In-memory state only lasts for one request. Don't rely on module-level caches persisting. Durable multi-step work belongs in a workflow (`apps/api/workflows/`).
-5. **Function timeout:** 800 seconds max. Plan long-running tasks accordingly.
+2. **Migrations run on every deploy.** The runner (`packages/db/src/migrate.ts`) is idempotent — it tracks applied migrations by SHA-256 content hash, not by timestamp, so running it when there is nothing new is a safe no-op.
+3. **Drizzle migration format:** Always include `--> statement-breakpoint` at the end of each statement line in migration files (same line, not a separate line). Without it, Drizzle concatenates all statements and Postgres rejects the multi-statement execution.
+4. **Generate migrations on an up-to-date branch.** New migrations are named by Unix epoch (`pnpm db:generate` with `prefix: "unix"`), so their timestamp is always greater than any migration already on `main`. A stale branch produces an out-of-order `when`, which the CI migration guard will catch and reject. When the guard fails: **rebase on `main`** and re-run `pnpm db:generate`.
+5. **Serverless = stateless.** In-memory state only lasts for one request. Don't rely on module-level caches persisting. Durable multi-step work belongs in a workflow (`apps/api/workflows/`).
+6. **Function timeout:** 800 seconds max. Plan long-running tasks accordingly.
+
+## Migration Workflow
+
+### How the hash-based ledger works
+
+`packages/db/src/migrate.ts` replaces the upstream Drizzle migrator with an inline hash-based runner:
+
+- Reads `packages/db/drizzle/meta/_journal.json` and iterates entries in journal order.
+- For each entry, computes `sha256(full_file_contents)` — the same hash Drizzle's own migrator uses, so existing `drizzle.__drizzle_migrations` rows remain valid.
+- Loads all hashes from the ledger. Applies a migration **if and only if its hash is absent** — ordering never affects whether a migration runs.
+- **Self-healing backfill:** on first deploy after this change, three prod entries (0017, 0025, 0074) that were silently skipped by the old watermark logic get their ledger rows inserted without re-executing SQL. Subsequent runs skip them as normal.
+
+### Generating a new migration
+
+```bash
+# From the repo root, on a branch that is up to date with main:
+pnpm db:generate
+```
+
+This produces a file like `1786996239_my_migration.sql` (Unix epoch prefix). The timestamp is the current epoch second, which is always greater than any existing migration's `when`.
+
+### CI migration guard
+
+The `.github/workflows/migration-guard.yml` workflow runs on every PR that touches `packages/db/drizzle/**` and fails if:
+
+| Check | Cause | Fix |
+|-------|-------|-----|
+| `out-of-order` | A new entry's `when` ≤ max `when` on `main` | Rebase on `main` and re-run `pnpm db:generate` |
+| `duplicate-when` | Two new entries share the same timestamp | Rebase and regenerate |
+| `missing-sql` | A journal entry references a `.sql` file that doesn't exist | Restore or regenerate the file |
+| `orphaned-sql` | A `.sql` file exists with no journal entry | Remove the file or add a journal entry |
 
 ## Vercel Projects
 

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   schema: "./src/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
+  // unix prefix names new migrations by epoch (e.g. 1786996239_my_migration.sql)
+  // instead of an incrementing index, preventing `when` collisions on parallel branches.
+  migrations: {
+    prefix: "unix",
+  },
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,7 +19,9 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/migrate.ts",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "guard": "tsx src/migration-guard.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.0",
@@ -27,8 +29,10 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "drizzle-kit": "^0.31.9",
     "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,14 +1,45 @@
 /**
- * Programmatic migration runner.
+ * Hash-based migration runner (replaces drizzle-orm/neon-http/migrator).
  *
- * Used by the Vercel build step to apply pending migrations on every deploy.
- * Drizzle tracks applied migrations in a `__drizzle_migrations` journal table,
- * so this is idempotent -- running it when there's nothing new is a no-op.
+ * THE BUG THIS FIXES
+ * ==================
+ * The upstream drizzle migrator uses a high-watermark strategy: it reads the
+ * max(created_at) ledger row and applies only journal entries whose `when` is
+ * strictly greater than that value.  Any migration merged with a stale `when`
+ * (below the running max) is SILENTLY SKIPPED FOREVER — no error, no warning.
+ *
+ * Prod evidence: three journal entries (0017_amused_kree, 0025_feedback_table,
+ * 0074_dashboard_chat_runs_user_message) have no ledger row because their `when`
+ * values fall below the current max.  Their schema changes exist in prod (verified),
+ * but the ledger never recorded them.
+ *
+ * THE FIX
+ * =======
+ * This runner tracks migrations by SHA-256 content hash, not by timestamp.
+ * A migration is applied if and only if its hash is absent from the ledger.
+ * Ordering never affects whether a migration runs.
+ *
+ * SELF-HEALING LEGACY BACKFILL
+ * ============================
+ * Runs before the apply loop.  For journal entries that are missing from the
+ * ledger by hash AND whose `when` is <= the ledger's max created_at (the
+ * legacy watermark), we insert the ledger row WITHOUT executing the SQL.
+ * This covers the three prod cases above: their schema is correct, only the
+ * ledger tracking is wrong.  After the first deploy the rows exist and this
+ * is a no-op.
  */
 
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
-import { migrate } from "drizzle-orm/neon-http/migrator";
+import { planMigrations } from "./migrator.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+/** When run via `tsx src/migrate.ts`, __dirname is packages/db/src/ */
+const DRIZZLE_DIR = join(__dirname, "..", "drizzle");
 
 const connectionString = process.env.DATABASE_URL;
 
@@ -18,13 +49,113 @@ if (!connectionString) {
 }
 
 const sql = neon(connectionString);
-const db = drizzle(sql);
 
-console.log("Running database migrations...");
+/**
+ * Execute a raw SQL string against the database.
+ *
+ * Uses the neon client's `query(string, params)` form which takes a raw SQL
+ * string without template literal magic.  Safe for migration DDL from our
+ * own files (no user input involved).
+ */
+function exec(sqlStr: string): Promise<unknown> {
+  return sql.query(sqlStr, []);
+}
+
+console.log("Running database migrations (hash-based runner)...");
 
 try {
-  await migrate(db, { migrationsFolder: "./drizzle" });
-  console.log("Migrations complete.");
+  // ── 1. Ensure the drizzle ledger schema + table exist ─────────────────────
+  //       Same DDL drizzle's own migrator uses — drop-in compatible.
+  await exec("CREATE SCHEMA IF NOT EXISTS drizzle");
+  await exec(`
+    CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+      id         serial  PRIMARY KEY,
+      hash       text    NOT NULL,
+      created_at bigint
+    )
+  `);
+
+  // ── 2. Read journal ────────────────────────────────────────────────────────
+  const journal = JSON.parse(
+    readFileSync(join(DRIZZLE_DIR, "meta", "_journal.json"), "utf-8")
+  ) as { entries: Array<{ idx: number; when: number; tag: string }> };
+
+  // ── 3. Compute SHA-256 of each full SQL file ───────────────────────────────
+  //       Drizzle hashes the full file: crypto.createHash("sha256").update(content).digest("hex")
+  //       We do the same so existing ledger rows continue to match.
+  const entriesWithHashes = journal.entries.map(entry => {
+    const content = readFileSync(join(DRIZZLE_DIR, `${entry.tag}.sql`), "utf-8");
+    const hash = createHash("sha256").update(content).digest("hex");
+    return { tag: entry.tag, when: entry.when, hash };
+  });
+
+  // ── 4. Load existing ledger state ─────────────────────────────────────────
+  const ledgerRows = (await sql`
+    SELECT hash, created_at FROM drizzle.__drizzle_migrations
+  `) as { hash: string; created_at: string | null }[];
+  const existingHashes = new Set(ledgerRows.map(r => r.hash));
+  const ledgerWatermark = ledgerRows.reduce((max, r) => {
+    const v = r.created_at ? Number(r.created_at) : 0;
+    return v > max ? v : max;
+  }, 0);
+
+  // ── 5. Plan (pure, testable — see migrator.ts + migrator.test.ts) ─────────
+  const plan = planMigrations(entriesWithHashes, existingHashes, ledgerWatermark);
+
+  // ── 6. Execute the plan in journal order ───────────────────────────────────
+  let applied = 0;
+  let backfilled = 0;
+
+  for (const item of plan) {
+    if (item.action === "skip") continue;
+
+    if (item.action === "backfill") {
+      // Legacy backfill: this entry was silently skipped by the old watermark
+      // logic but its schema already exists in prod.  Record it in the ledger
+      // without re-executing the SQL.
+      console.warn(
+        `[WARN] legacy backfill: ${item.tag} (when=${item.when}) is missing from ` +
+          `the ledger but when <= watermark (${ledgerWatermark}). ` +
+          `Presumed applied by an earlier in-place-edited migration. ` +
+          `Inserting ledger row WITHOUT executing SQL.`
+      );
+      await sql`
+        INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+        VALUES (${item.hash}, ${item.when})
+      `;
+      backfilled++;
+      continue;
+    }
+
+    // action === "apply": genuinely new migration
+    console.log(`Applying migration: ${item.tag}`);
+    const content = readFileSync(join(DRIZZLE_DIR, `${item.tag}.sql`), "utf-8");
+    const statements = content
+      .split("--> statement-breakpoint")
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    for (const stmt of statements) {
+      await exec(stmt);
+    }
+
+    await sql`
+      INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+      VALUES (${item.hash}, ${item.when})
+    `;
+    applied++;
+  }
+
+  // ── 7. Summary ────────────────────────────────────────────────────────────
+  const skipped = plan.filter(p => p.action === "skip").length;
+  if (backfilled > 0) {
+    console.log(
+      `Legacy backfill complete: ${backfilled} ledger row(s) inserted without SQL execution.`
+    );
+  }
+  console.log(
+    `Migrations complete. Applied=${applied} Backfilled=${backfilled} Skipped=${skipped}`
+  );
 } catch (error) {
   console.error("Migration failed:", error);
   process.exit(1);

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -19,14 +19,21 @@
  * A migration is applied if and only if its hash is absent from the ledger.
  * Ordering never affects whether a migration runs.
  *
- * SELF-HEALING LEGACY BACKFILL
- * ============================
- * Runs before the apply loop.  For journal entries that are missing from the
- * ledger by hash AND whose `when` is <= the ledger's max created_at (the
- * legacy watermark), we insert the ledger row WITHOUT executing the SQL.
- * This covers the three prod cases above: their schema is correct, only the
- * ledger tracking is wrong.  After the first deploy the rows exist and this
- * is a no-op.
+ * LEGACY RECONCILIATION (one-time, closed set)
+ * ============================================
+ * Flipping to hash-based tracking would try to re-run history that already
+ * ran, and `0025_feedback_table.sql` is a bare `CREATE TABLE "feedback"` that
+ * would hard-fail the build.  So a CLOSED, hash-pinned list
+ * (LEGACY_BACKFILL_HASHES in migrator.ts) records those specific entries in the
+ * ledger without executing their SQL.  Ten entries, each verified against the
+ * live prod schema on 2026-08-17.  After the first deploy they all match by
+ * hash and the list is inert.
+ *
+ * What this deliberately does NOT do: infer "already applied" from a
+ * timestamp.  Backfilling anything whose `when` is below the ledger watermark
+ * would reproduce the very bug above — the SQL still never runs, except now a
+ * ledger row asserts that it did, which makes the omission invisible.  A new
+ * migration missing from the ledger EXECUTES, whatever its timestamp.
  */
 
 import { createHash } from "crypto";
@@ -34,7 +41,7 @@ import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { neon } from "@neondatabase/serverless";
-import { planMigrations } from "./migrator.js";
+import { planMigrations, LEGACY_BACKFILL_HASHES } from "./migrator.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -94,13 +101,12 @@ try {
     SELECT hash, created_at FROM drizzle.__drizzle_migrations
   `) as { hash: string; created_at: string | null }[];
   const existingHashes = new Set(ledgerRows.map(r => r.hash));
-  const ledgerWatermark = ledgerRows.reduce((max, r) => {
-    const v = r.created_at ? Number(r.created_at) : 0;
-    return v > max ? v : max;
-  }, 0);
 
   // ── 5. Plan (pure, testable — see migrator.ts + migrator.test.ts) ─────────
-  const plan = planMigrations(entriesWithHashes, existingHashes, ledgerWatermark);
+  //       Timestamps do NOT decide execution.  A migration runs iff its hash is
+  //       absent from the ledger and is not in the closed legacy reconciliation
+  //       set.  Deciding by `when` would reproduce the very bug this replaces.
+  const plan = planMigrations(entriesWithHashes, existingHashes, LEGACY_BACKFILL_HASHES);
 
   // ── 6. Execute the plan in journal order ───────────────────────────────────
   let applied = 0;
@@ -110,14 +116,14 @@ try {
     if (item.action === "skip") continue;
 
     if (item.action === "backfill") {
-      // Legacy backfill: this entry was silently skipped by the old watermark
-      // logic but its schema already exists in prod.  Record it in the ledger
-      // without re-executing the SQL.
+      // Legacy reconciliation: pre-existing history whose schema is already in
+      // prod (either silently skipped by the old watermark logic, or applied and
+      // then edited in place).  Record it in the ledger without executing SQL.
       console.warn(
-        `[WARN] legacy backfill: ${item.tag} (when=${item.when}) is missing from ` +
-          `the ledger but when <= watermark (${ledgerWatermark}). ` +
-          `Presumed applied by an earlier in-place-edited migration. ` +
-          `Inserting ledger row WITHOUT executing SQL.`
+        `[WARN] legacy reconciliation: ${item.tag} (when=${item.when}) is missing ` +
+          `from the ledger but is in the closed LEGACY_BACKFILL_HASHES set — its ` +
+          `schema was verified present in prod on 2026-08-17. ` +
+          `Inserting ledger row WITHOUT executing SQL. This should happen exactly once.`
       );
       await sql`
         INSERT INTO drizzle.__drizzle_migrations (hash, created_at)

--- a/packages/db/src/migration-guard.test.ts
+++ b/packages/db/src/migration-guard.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import { checkMigrationGuard } from "./migration-guard.js";
+import type { JournalEntry } from "./migration-guard.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function e(tag: string, when: number): JournalEntry {
+  return { tag, when };
+}
+
+// Simulate a realistic main-branch state
+const MAIN_MAX_WHEN = 1787158001000; // 0081's when
+const MAIN_TAGS = new Set([
+  "0000_zippy_robin_chapel",
+  "0079_medium_model_category",
+  "0080_detached_commands_job_link",
+  "0081_drop_model_catalog_selections",
+]);
+
+// ── checkMigrationGuard tests ────────────────────────────────────────────────
+
+describe("checkMigrationGuard", () => {
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it("passes with no new entries (PR only has pre-existing migrations)", () => {
+    const prEntries = [
+      e("0000_zippy_robin_chapel", 1771062880226),
+      e("0081_drop_model_catalog_selections", 1787158001000),
+    ];
+    const sqlFiles = new Set([
+      "0000_zippy_robin_chapel",
+      "0081_drop_model_catalog_selections",
+    ]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("passes with a properly ordered new migration", () => {
+    const prEntries = [
+      e("0081_drop_model_catalog_selections", 1787158001000),
+      e("0082_new_feature", 1800000000000), // clearly above main max
+    ];
+    const sqlFiles = new Set([
+      "0081_drop_model_catalog_selections",
+      "0082_new_feature",
+    ]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors).toHaveLength(0);
+  });
+
+  // ── Check 1: out-of-order ─────────────────────────────────────────────────
+
+  it("detects a new entry with when <= main max when (out-of-order generation)", () => {
+    const prEntries = [
+      e("0081_drop_model_catalog_selections", 1787158001000),
+      e("0082_stale", 1780000000000), // stale branch: when < main max
+    ];
+    const sqlFiles = new Set([
+      "0081_drop_model_catalog_selections",
+      "0082_stale",
+    ]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.filter(e => e.type === "out-of-order")).toHaveLength(1);
+    expect(errors[0].message).toContain("0082_stale");
+    expect(errors[0].message).toContain("Rebase");
+  });
+
+  it("detects a new entry with when exactly equal to main max when", () => {
+    const prEntries = [
+      e("0081_drop_model_catalog_selections", 1787158001000),
+      e("0082_collision", MAIN_MAX_WHEN), // equal, not greater
+    ];
+    const sqlFiles = new Set([
+      "0081_drop_model_catalog_selections",
+      "0082_collision",
+    ]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.some(e => e.type === "out-of-order")).toBe(true);
+  });
+
+  it("does NOT flag pre-existing (main) entries as out-of-order", () => {
+    // All entries are already on main — should be clean
+    const prEntries = [e("0000_zippy_robin_chapel", 1771062880226)];
+    const sqlFiles = new Set(["0000_zippy_robin_chapel"]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.filter(e => e.type === "out-of-order")).toHaveLength(0);
+  });
+
+  // ── Check 2: duplicate when ───────────────────────────────────────────────
+
+  it("detects duplicate when values among newly added entries", () => {
+    const sameWhen = 1800000000001;
+    const prEntries = [
+      e("0081_drop_model_catalog_selections", 1787158001000),
+      e("0082_first", sameWhen),
+      e("0083_second", sameWhen), // collision
+    ];
+    const sqlFiles = new Set([
+      "0081_drop_model_catalog_selections",
+      "0082_first",
+      "0083_second",
+    ]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.filter(e => e.type === "duplicate-when")).toHaveLength(1);
+    expect(errors.find(e => e.type === "duplicate-when")?.message).toContain(
+      "0083_second"
+    );
+  });
+
+  it("does NOT flag duplicate when on pre-existing entries already on main", () => {
+    // The real journal has 0026 and 0027 both at 1772880000000 (and 0031 too).
+    // These are on main — the guard must not complain about them.
+    const mainTagsWithDupes = new Set([
+      "0026_resources_table",
+      "0027_api_credentials",
+      "0031_hybrid_memory_search",
+    ]);
+    const prEntries = [
+      e("0026_resources_table", 1772880000000),
+      e("0027_api_credentials", 1772880000000),
+      e("0031_hybrid_memory_search", 1772880000000),
+    ];
+    const sqlFiles = new Set([
+      "0026_resources_table",
+      "0027_api_credentials",
+      "0031_hybrid_memory_search",
+    ]);
+    const errors = checkMigrationGuard(
+      1787158001000,
+      mainTagsWithDupes,
+      prEntries,
+      sqlFiles
+    );
+    expect(errors.filter(e => e.type === "duplicate-when")).toHaveLength(0);
+  });
+
+  // ── Check 3: missing SQL file ─────────────────────────────────────────────
+
+  it("detects a journal entry with no corresponding SQL file", () => {
+    const prEntries = [e("0082_no_sql", 1800000000000)];
+    const sqlFiles = new Set<string>(); // file doesn't exist
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.some(e => e.type === "missing-sql")).toBe(true);
+    expect(errors.find(e => e.type === "missing-sql")?.message).toContain(
+      "0082_no_sql"
+    );
+  });
+
+  it("flags missing SQL for existing (main) entries too", () => {
+    // If someone deleted a SQL file, it should be caught regardless of age
+    const prEntries = [e("0000_zippy_robin_chapel", 1771062880226)];
+    const sqlFiles = new Set<string>(); // file deleted
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.some(e => e.type === "missing-sql")).toBe(true);
+  });
+
+  // ── Check 4: orphaned SQL file ────────────────────────────────────────────
+
+  it("detects an SQL file with no corresponding journal entry", () => {
+    const prEntries: JournalEntry[] = []; // empty journal
+    const sqlFiles = new Set(["0082_orphan"]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    expect(errors.some(e => e.type === "orphaned-sql")).toBe(true);
+    expect(errors.find(e => e.type === "orphaned-sql")?.message).toContain(
+      "0082_orphan"
+    );
+  });
+
+  // ── Multiple errors at once ────────────────────────────────────────────────
+
+  it("reports multiple error types simultaneously", () => {
+    const prEntries = [
+      e("0081_drop_model_catalog_selections", 1787158001000), // existing, ok
+      e("0082_stale", 1780000000000), // out-of-order (below main max)
+      e("0083_no_file", 1800000000001), // missing SQL file
+    ];
+    // 0082_stale and 0083_no_file are present as SQL; 0084_orphan is orphaned
+    const sqlFiles = new Set([
+      "0081_drop_model_catalog_selections",
+      "0082_stale",
+      "0084_orphan", // no journal entry
+      // 0083_no_file intentionally absent
+    ]);
+    const errors = checkMigrationGuard(MAIN_MAX_WHEN, MAIN_TAGS, prEntries, sqlFiles);
+    const types = new Set(errors.map(e => e.type));
+    expect(types.has("out-of-order")).toBe(true);
+    expect(types.has("missing-sql")).toBe(true);
+    expect(types.has("orphaned-sql")).toBe(true);
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+
+  it("handles empty main and empty PR gracefully", () => {
+    const errors = checkMigrationGuard(0, new Set(), [], new Set());
+    expect(errors).toHaveLength(0);
+  });
+
+  it("handles empty main with new entries that all have fresh timestamps", () => {
+    const errors = checkMigrationGuard(
+      0,
+      new Set(),
+      [e("0000_init", 1771062880226)],
+      new Set(["0000_init"])
+    );
+    // when=1771062880226 > 0 (main max when), so no out-of-order
+    expect(errors.filter(e => e.type === "out-of-order")).toHaveLength(0);
+  });
+});

--- a/packages/db/src/migration-guard.ts
+++ b/packages/db/src/migration-guard.ts
@@ -1,0 +1,201 @@
+/**
+ * Migration guard — pure check logic + CI runner.
+ *
+ * Exported functions are tested in migration-guard.test.ts.
+ * When executed as a script (via `tsx src/migration-guard.ts`), main() reads
+ * the git state and runs all checks, exiting non-zero on any failure.
+ *
+ * Checks performed (on newly-added entries unless noted):
+ *   1. out-of-order    — new entry `when` <= max `when` on main (stale branch)
+ *   2. duplicate-when  — two new entries share the same `when`
+ *   3. missing-sql     — any journal entry (new or existing) has no .sql file
+ *   4. orphaned-sql    — a .sql file in drizzle/ has no journal entry
+ */
+
+import { execSync } from "child_process";
+import { readFileSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface JournalEntry {
+  tag: string;
+  when: number;
+}
+
+export type GuardErrorType =
+  | "out-of-order"
+  | "duplicate-when"
+  | "missing-sql"
+  | "orphaned-sql";
+
+export interface GuardError {
+  type: GuardErrorType;
+  message: string;
+}
+
+// ── Pure check logic ─────────────────────────────────────────────────────────
+
+/**
+ * Validate migration journal invariants.  No I/O — all inputs pre-loaded.
+ *
+ * @param mainMaxWhen     max `when` from the main-branch journal (0 if empty)
+ * @param mainTags        set of tags already present on main
+ * @param prEntries       all journal entries in the PR (full journal)
+ * @param sqlFilesOnDisk  tag names (without .sql) of files present in drizzle/
+ */
+export function checkMigrationGuard(
+  mainMaxWhen: number,
+  mainTags: Set<string>,
+  prEntries: JournalEntry[],
+  sqlFilesOnDisk: Set<string>
+): GuardError[] {
+  const errors: GuardError[] = [];
+  const newEntries = prEntries.filter(e => !mainTags.has(e.tag));
+
+  // ── Check 1: out-of-order generation ────────────────────────────────────
+  // A new migration whose `when` is <= the main max `when` was generated on a
+  // stale branch.  Any watermark-based migrator would silently skip it.
+  for (const entry of newEntries) {
+    if (entry.when <= mainMaxWhen) {
+      errors.push({
+        type: "out-of-order",
+        message:
+          `Migration "${entry.tag}" was generated on a stale branch ` +
+          `(when=${entry.when} <= main max when=${mainMaxWhen}). ` +
+          `Rebase on main and run \`pnpm db:generate\` again.`,
+      });
+    }
+  }
+
+  // ── Check 2: duplicate when values among new entries ────────────────────
+  // Two new migrations with the same timestamp can cause subtle ordering bugs.
+  const seenWhen = new Map<number, string>();
+  for (const entry of newEntries) {
+    const prior = seenWhen.get(entry.when);
+    if (prior !== undefined) {
+      errors.push({
+        type: "duplicate-when",
+        message:
+          `Entries "${prior}" and "${entry.tag}" both have when=${entry.when}. ` +
+          `Rebase and regenerate to get distinct timestamps.`,
+      });
+    } else {
+      seenWhen.set(entry.when, entry.tag);
+    }
+  }
+
+  // ── Check 3: missing SQL file (all journal entries) ─────────────────────
+  for (const entry of prEntries) {
+    if (!sqlFilesOnDisk.has(entry.tag)) {
+      errors.push({
+        type: "missing-sql",
+        message: `Journal entry "${entry.tag}" references a missing file: drizzle/${entry.tag}.sql`,
+      });
+    }
+  }
+
+  // ── Check 4: orphaned SQL file (all files in drizzle/) ──────────────────
+  const journalTags = new Set(prEntries.map(e => e.tag));
+  for (const tag of sqlFilesOnDisk) {
+    if (!journalTags.has(tag)) {
+      errors.push({
+        type: "orphaned-sql",
+        message: `SQL file drizzle/${tag}.sql has no corresponding journal entry.`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+// ── CLI entry point ──────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+/** packages/db/drizzle/ */
+const DRIZZLE_DIR = join(__dirname, "..", "drizzle");
+/** repo root (packages/db/src/ → up three levels) */
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+
+async function main() {
+  // 1. Get main-branch journal via git
+  let mainJournalText = "";
+  const refCandidates = ["origin/main", "origin/master", "main", "master"];
+  let resolved = false;
+
+  for (const ref of refCandidates) {
+    try {
+      mainJournalText = execSync(
+        `git show ${ref}:packages/db/drizzle/meta/_journal.json`,
+        { cwd: REPO_ROOT, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+      );
+      resolved = true;
+      break;
+    } catch {
+      // Try next candidate
+    }
+  }
+
+  if (!resolved) {
+    console.error(
+      "Migration guard: could not read main-branch journal.\n" +
+        "Run: git fetch origin main"
+    );
+    process.exit(1);
+  }
+
+  const mainJournal = JSON.parse(mainJournalText) as {
+    entries: JournalEntry[];
+  };
+  const mainMaxWhen = mainJournal.entries.reduce(
+    (max, e) => Math.max(max, e.when),
+    0
+  );
+  const mainTags = new Set(mainJournal.entries.map(e => e.tag));
+
+  // 2. Get PR journal from disk
+  const prJournalText = readFileSync(
+    join(DRIZZLE_DIR, "meta", "_journal.json"),
+    "utf-8"
+  );
+  const prJournal = JSON.parse(prJournalText) as { entries: JournalEntry[] };
+
+  // 3. Collect SQL files in drizzle/
+  const sqlFilesOnDisk = new Set(
+    readdirSync(DRIZZLE_DIR)
+      .filter(f => f.endsWith(".sql"))
+      .map(f => f.replace(/\.sql$/, ""))
+  );
+
+  // 4. Run checks
+  const errors = checkMigrationGuard(
+    mainMaxWhen,
+    mainTags,
+    prJournal.entries,
+    sqlFilesOnDisk
+  );
+
+  if (errors.length === 0) {
+    console.log("Migration guard: all checks passed.");
+    process.exit(0);
+  }
+
+  console.error("Migration guard FAILED:");
+  for (const err of errors) {
+    console.error(`  [${err.type}] ${err.message}`);
+  }
+  console.error(
+    "\nTo fix out-of-order migrations: rebase on main and regenerate with `pnpm db:generate`."
+  );
+  process.exit(1);
+}
+
+// Run when executed directly (not when imported by vitest or other modules)
+if (process.argv[1]?.includes("migration-guard")) {
+  main().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/db/src/migration-guard.ts
+++ b/packages/db/src/migration-guard.ts
@@ -6,7 +6,9 @@
  * the git state and runs all checks, exiting non-zero on any failure.
  *
  * Checks performed (on newly-added entries unless noted):
- *   1. out-of-order    — new entry `when` <= max `when` on main (stale branch)
+ *   1. out-of-order    — new entry `when` <= max `when` on main (stale branch).
+ *                        Hygiene, not correctness: the hash-based runner in
+ *                        migrate.ts applies out-of-order migrations correctly.
  *   2. duplicate-when  — two new entries share the same `when`
  *   3. missing-sql     — any journal entry (new or existing) has no .sql file
  *   4. orphaned-sql    — a .sql file in drizzle/ has no journal entry
@@ -56,7 +58,10 @@ export function checkMigrationGuard(
 
   // ── Check 1: out-of-order generation ────────────────────────────────────
   // A new migration whose `when` is <= the main max `when` was generated on a
-  // stale branch.  Any watermark-based migrator would silently skip it.
+  // stale branch.  Since migrate.ts is hash-based this is no longer a
+  // correctness bug (the migration still executes), but it keeps the journal
+  // monotonic, keeps `_journal.json` merge conflicts to a minimum, and catches
+  // "I forgot to rebase" at PR-open time instead of at merge.
   for (const entry of newEntries) {
     if (entry.when <= mainMaxWhen) {
       errors.push({

--- a/packages/db/src/migrator.test.ts
+++ b/packages/db/src/migrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { planMigrations } from "./migrator.js";
+import { planMigrations, LEGACY_BACKFILL_HASHES } from "./migrator.js";
 import type { JournalEntryWithHash, MigrationPlan } from "./migrator.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -12,162 +12,141 @@ function actions(plan: MigrationPlan[]) {
   return plan.map(p => `${p.tag}:${p.action}`);
 }
 
-// Current prod watermark: max(when) from the journal = 0081's when
+/** Real prod ledger watermark on 2026-08-17 (0081's `when`). */
 const PROD_WATERMARK = 1787158001000;
 
-// ── planMigrations tests ──────────────────────────────────────────────────────
+/** Real hash of 0025_feedback_table.sql — bare CREATE TABLE, must never re-run. */
+const HASH_0025 = "3dac0cbc18a14f60af945ff92efe78319f9d0a30068bb8514e76d4464379fff0";
+/** Real hash of 0017_amused_kree.sql. */
+const HASH_0017 = "daab31de8de4e72ccb327d8f540cf821341577580466daea694212a27977d5e0";
+/** Real hash of 0074_dashboard_chat_runs_user_message.sql. */
+const HASH_0074 = "5856e3d56893bddb6cadcb4808121861d171c3bc5ebb8f0b3d9a60debcf291d9";
+
+// ── planMigrations ───────────────────────────────────────────────────────────
 
 describe("planMigrations", () => {
-  // ── Basic rules ────────────────────────────────────────────────────────────
-
   it("skips a migration whose hash is already in the ledger", () => {
-    const plan = planMigrations(
-      [e("0000_init", 1771062880226, "known_hash")],
-      new Set(["known_hash"]),
-      PROD_WATERMARK
-    );
+    const plan = planMigrations([e("0001_a", 1000, "hash_a")], new Set(["hash_a"]));
     expect(plan[0].action).toBe("skip");
   });
 
-  it("applies a new migration above the watermark", () => {
+  it("applies a new migration whose hash is absent", () => {
+    const plan = planMigrations([e("0090_new", PROD_WATERMARK + 5000, "hash_new")], new Set());
+    expect(plan[0].action).toBe("apply");
+  });
+
+  it("applies all entries on a fresh DB", () => {
     const plan = planMigrations(
-      [e("0082_new_table", 1800000000000, "new_hash")],
-      new Set(),
-      PROD_WATERMARK
+      [e("0001_a", 1000, "h1"), e("0002_b", 2000, "h2"), e("0003_c", 3000, "h3")],
+      new Set()
+    );
+    expect(actions(plan)).toEqual(["0001_a:apply", "0002_b:apply", "0003_c:apply"]);
+  });
+
+  it("skips everything when all hashes are present", () => {
+    const entries = [e("0001_a", 1000, "h1"), e("0002_b", 2000, "h2")];
+    const plan = planMigrations(entries, new Set(["h1", "h2"]));
+    expect(actions(plan)).toEqual(["0001_a:skip", "0002_b:skip"]);
+  });
+
+  it("preserves journal order in the output plan", () => {
+    const entries = [e("0003_c", 3000, "h3"), e("0001_a", 1000, "h1"), e("0002_b", 2000, "h2")];
+    const plan = planMigrations(entries, new Set());
+    expect(plan.map(p => p.tag)).toEqual(["0003_c", "0001_a", "0002_b"]);
+  });
+
+  // ── The regression this whole PR exists to prevent ─────────────────────────
+
+  it("APPLIES an out-of-order migration instead of skipping or backfilling it", () => {
+    // The old watermark migrator skipped this forever. A timestamp-based
+    // backfill would be just as wrong: the SQL never runs, but a ledger row
+    // claims it did. It must EXECUTE.
+    const plan = planMigrations(
+      [e("0079_stale_branch", PROD_WATERMARK - 5_000_000, "hash_stale")],
+      new Set()
     );
     expect(plan[0].action).toBe("apply");
   });
 
-  it("backfills a migration below the watermark whose hash is absent", () => {
+  it("does not treat a low `when` as evidence of prior application", () => {
+    // Ancient timestamp, unknown hash, empty ledger → still apply.
+    const plan = planMigrations([e("0091_ancient_ts", 1, "hash_unknown")], new Set());
+    expect(plan[0].action).toBe("apply");
+  });
+
+  it("applies a new migration even when the ledger contains far newer rows", () => {
     const plan = planMigrations(
-      [e("NNNN_stale", 1750000000000, "stale_hash")],
-      new Set(),
-      PROD_WATERMARK
+      [e("0092_late_merge", PROD_WATERMARK - 1, "hash_late")],
+      new Set(["some_much_newer_hash"])
     );
-    expect(plan[0].action).toBe("backfill");
+    expect(plan[0].action).toBe("apply");
   });
 
-  it("backfills a migration exactly at the watermark boundary", () => {
-    // when <= watermark → backfill (not apply)
+  // ── Legacy reconciliation (closed set) ────────────────────────────────────
+
+  it("backfills only hashes in the closed legacy set", () => {
     const plan = planMigrations(
-      [e("NNNN_boundary", PROD_WATERMARK, "boundary_hash")],
-      new Set(),
-      PROD_WATERMARK
-    );
-    expect(plan[0].action).toBe("backfill");
-  });
-
-  // ── The ordering bug ───────────────────────────────────────────────────────
-
-  it("handles the ordering bug: out-of-order migration is backfilled, not silently skipped", () => {
-    // Old watermark-based migrator: sees when <= max → skips forever (bug).
-    // New hash-based migrator: hash absent AND when <= watermark → backfill.
-    // The migration gets a ledger row without re-executing; subsequent runs skip.
-    const plan = planMigrations(
-      [e("NNNN_out_of_order", 1750000000000, "missing_hash")],
-      new Set(),
-      PROD_WATERMARK
-    );
-    expect(plan[0].action).toBe("backfill");
-    // Crucially, NOT "skip" (that would require the hash to be present)
-    expect(plan[0].action).not.toBe("skip");
-  });
-
-  // ── Real prod cases ────────────────────────────────────────────────────────
-
-  it("backfills 0017_amused_kree (prod case: below watermark, hash absent)", () => {
-    const plan = planMigrations(
-      [e("0017_amused_kree", 1771757715594, "hash_0017")],
-      new Set(), // not in ledger
-      PROD_WATERMARK
-    );
-    expect(plan[0].action).toBe("backfill");
-  });
-
-  it("backfills 0025_feedback_table (prod case: below watermark, hash absent)", () => {
-    // 0025 uses bare CREATE TABLE (no IF NOT EXISTS) — re-running would hard-fail.
-    // Backfill ensures it is never re-executed.
-    const plan = planMigrations(
-      [e("0025_feedback_table", 1772600000000, "hash_0025")],
-      new Set(),
-      PROD_WATERMARK
-    );
-    expect(plan[0].action).toBe("backfill");
-  });
-
-  it("backfills 0074_dashboard_chat_runs_user_message (prod case: below watermark, hash absent)", () => {
-    const plan = planMigrations(
-      [e("0074_dashboard_chat_runs_user_message", 1781080113835, "hash_0074")],
-      new Set(),
-      PROD_WATERMARK
-    );
-    expect(plan[0].action).toBe("backfill");
-  });
-
-  it("backfills all three prod missing entries together", () => {
-    const prodMissing = [
-      e("0017_amused_kree", 1771757715594, "hash_0017"),
-      e("0025_feedback_table", 1772600000000, "hash_0025"),
-      e("0074_dashboard_chat_runs_user_message", 1781080113835, "hash_0074"),
-    ];
-    const plan = planMigrations(prodMissing, new Set(), PROD_WATERMARK);
-    expect(plan.every(p => p.action === "backfill")).toBe(true);
-  });
-
-  // ── Full no-op (all hashes present) ────────────────────────────────────────
-
-  it("skips everything when all hashes are already in the ledger", () => {
-    const entries = [
-      e("0000_init", 1771062880226, "h0"),
-      e("0001_next", 1771103243060, "h1"),
-      e("0082_latest", 1800000000000, "h2"),
-    ];
-    const existingHashes = new Set(["h0", "h1", "h2"]);
-    const plan = planMigrations(entries, existingHashes, PROD_WATERMARK);
-    expect(plan.every(p => p.action === "skip")).toBe(true);
-  });
-
-  // ── Fresh DB (empty ledger) ────────────────────────────────────────────────
-
-  it("applies all entries on a fresh DB (watermark=0, empty ledger)", () => {
-    const entries = [
-      e("0000_init", 1771062880226, "h0"),
-      e("0001_next", 1771103243060, "h1"),
-    ];
-    const plan = planMigrations(entries, new Set(), 0);
-    // watermark=0 means every entry's when > 0, so all get "apply"
-    expect(plan.every(p => p.action === "apply")).toBe(true);
-  });
-
-  // ── Mixed scenario ────────────────────────────────────────────────────────
-
-  it("handles mixed skip / backfill / apply in one plan", () => {
-    const entries = [
-      e("already_applied", 1771000000000, "in_ledger"), // skip
-      e("skipped_by_old", 1771000000001, "missing_old"), // backfill (below watermark)
-      e("new_migration", 1800000000000, "new_hash"), // apply (above watermark)
-    ];
-    const plan = planMigrations(
-      entries,
-      new Set(["in_ledger"]),
-      PROD_WATERMARK
+      [
+        e("0017_amused_kree", 1771757715594, HASH_0017),
+        e("0025_feedback_table", 1772600000000, HASH_0025),
+        e("0074_dashboard_chat_runs_user_message", 1781080113835, HASH_0074),
+        e("0093_genuinely_new", 1771000000000, "hash_not_in_legacy_set"),
+      ],
+      new Set()
     );
     expect(actions(plan)).toEqual([
-      "already_applied:skip",
-      "skipped_by_old:backfill",
-      "new_migration:apply",
+      "0017_amused_kree:backfill",
+      "0025_feedback_table:backfill",
+      "0074_dashboard_chat_runs_user_message:backfill",
+      // same era of timestamps, but not a known-legacy hash → must execute
+      "0093_genuinely_new:apply",
     ]);
   });
 
-  // ── Ordering invariant ────────────────────────────────────────────────────
+  it("never re-executes 0025_feedback_table (bare CREATE TABLE would hard-fail)", () => {
+    const plan = planMigrations([e("0025_feedback_table", 1772600000000, HASH_0025)], new Set());
+    expect(plan[0].action).not.toBe("apply");
+    expect(plan[0].action).toBe("backfill");
+  });
 
-  it("preserves journal entry order in the output plan", () => {
-    const entries = [
-      e("tag_c", 1771000000003, "hc"),
-      e("tag_a", 1771000000001, "ha"),
-      e("tag_b", 1771000000002, "hb"),
-    ];
-    const plan = planMigrations(entries, new Set(), 0);
-    expect(plan.map(p => p.tag)).toEqual(["tag_c", "tag_a", "tag_b"]);
+  it("prefers skip over backfill once the legacy row exists (idempotent second deploy)", () => {
+    const plan = planMigrations(
+      [e("0025_feedback_table", 1772600000000, HASH_0025)],
+      new Set([HASH_0025])
+    );
+    expect(plan[0].action).toBe("skip");
+  });
+
+  it("legacy set covers all 10 measured prod discrepancies and nothing else", () => {
+    expect(LEGACY_BACKFILL_HASHES.size).toBe(10);
+    expect(LEGACY_BACKFILL_HASHES.has(HASH_0017)).toBe(true);
+    expect(LEGACY_BACKFILL_HASHES.has(HASH_0025)).toBe(true);
+    expect(LEGACY_BACKFILL_HASHES.has(HASH_0074)).toBe(true);
+    expect(LEGACY_BACKFILL_HASHES.has("hash_that_does_not_exist")).toBe(false);
+  });
+
+  it("handles mixed skip / backfill / apply in one plan", () => {
+    const plan = planMigrations(
+      [
+        e("0001_done", 1000, "h_done"),
+        e("0025_feedback_table", 1772600000000, HASH_0025),
+        e("0094_new", PROD_WATERMARK + 1000, "h_new"),
+      ],
+      new Set(["h_done"])
+    );
+    expect(actions(plan)).toEqual([
+      "0001_done:skip",
+      "0025_feedback_table:backfill",
+      "0094_new:apply",
+    ]);
+  });
+
+  it("accepts an injected legacy set for testing without touching the prod list", () => {
+    const plan = planMigrations(
+      [e("0095_x", 500, "h_x")],
+      new Set(),
+      new Set(["h_x"])
+    );
+    expect(plan[0].action).toBe("backfill");
   });
 });

--- a/packages/db/src/migrator.test.ts
+++ b/packages/db/src/migrator.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { planMigrations } from "./migrator.js";
+import type { JournalEntryWithHash, MigrationPlan } from "./migrator.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function e(tag: string, when: number, hash: string): JournalEntryWithHash {
+  return { tag, when, hash };
+}
+
+function actions(plan: MigrationPlan[]) {
+  return plan.map(p => `${p.tag}:${p.action}`);
+}
+
+// Current prod watermark: max(when) from the journal = 0081's when
+const PROD_WATERMARK = 1787158001000;
+
+// ── planMigrations tests ──────────────────────────────────────────────────────
+
+describe("planMigrations", () => {
+  // ── Basic rules ────────────────────────────────────────────────────────────
+
+  it("skips a migration whose hash is already in the ledger", () => {
+    const plan = planMigrations(
+      [e("0000_init", 1771062880226, "known_hash")],
+      new Set(["known_hash"]),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("skip");
+  });
+
+  it("applies a new migration above the watermark", () => {
+    const plan = planMigrations(
+      [e("0082_new_table", 1800000000000, "new_hash")],
+      new Set(),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("apply");
+  });
+
+  it("backfills a migration below the watermark whose hash is absent", () => {
+    const plan = planMigrations(
+      [e("NNNN_stale", 1750000000000, "stale_hash")],
+      new Set(),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("backfill");
+  });
+
+  it("backfills a migration exactly at the watermark boundary", () => {
+    // when <= watermark → backfill (not apply)
+    const plan = planMigrations(
+      [e("NNNN_boundary", PROD_WATERMARK, "boundary_hash")],
+      new Set(),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("backfill");
+  });
+
+  // ── The ordering bug ───────────────────────────────────────────────────────
+
+  it("handles the ordering bug: out-of-order migration is backfilled, not silently skipped", () => {
+    // Old watermark-based migrator: sees when <= max → skips forever (bug).
+    // New hash-based migrator: hash absent AND when <= watermark → backfill.
+    // The migration gets a ledger row without re-executing; subsequent runs skip.
+    const plan = planMigrations(
+      [e("NNNN_out_of_order", 1750000000000, "missing_hash")],
+      new Set(),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("backfill");
+    // Crucially, NOT "skip" (that would require the hash to be present)
+    expect(plan[0].action).not.toBe("skip");
+  });
+
+  // ── Real prod cases ────────────────────────────────────────────────────────
+
+  it("backfills 0017_amused_kree (prod case: below watermark, hash absent)", () => {
+    const plan = planMigrations(
+      [e("0017_amused_kree", 1771757715594, "hash_0017")],
+      new Set(), // not in ledger
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("backfill");
+  });
+
+  it("backfills 0025_feedback_table (prod case: below watermark, hash absent)", () => {
+    // 0025 uses bare CREATE TABLE (no IF NOT EXISTS) — re-running would hard-fail.
+    // Backfill ensures it is never re-executed.
+    const plan = planMigrations(
+      [e("0025_feedback_table", 1772600000000, "hash_0025")],
+      new Set(),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("backfill");
+  });
+
+  it("backfills 0074_dashboard_chat_runs_user_message (prod case: below watermark, hash absent)", () => {
+    const plan = planMigrations(
+      [e("0074_dashboard_chat_runs_user_message", 1781080113835, "hash_0074")],
+      new Set(),
+      PROD_WATERMARK
+    );
+    expect(plan[0].action).toBe("backfill");
+  });
+
+  it("backfills all three prod missing entries together", () => {
+    const prodMissing = [
+      e("0017_amused_kree", 1771757715594, "hash_0017"),
+      e("0025_feedback_table", 1772600000000, "hash_0025"),
+      e("0074_dashboard_chat_runs_user_message", 1781080113835, "hash_0074"),
+    ];
+    const plan = planMigrations(prodMissing, new Set(), PROD_WATERMARK);
+    expect(plan.every(p => p.action === "backfill")).toBe(true);
+  });
+
+  // ── Full no-op (all hashes present) ────────────────────────────────────────
+
+  it("skips everything when all hashes are already in the ledger", () => {
+    const entries = [
+      e("0000_init", 1771062880226, "h0"),
+      e("0001_next", 1771103243060, "h1"),
+      e("0082_latest", 1800000000000, "h2"),
+    ];
+    const existingHashes = new Set(["h0", "h1", "h2"]);
+    const plan = planMigrations(entries, existingHashes, PROD_WATERMARK);
+    expect(plan.every(p => p.action === "skip")).toBe(true);
+  });
+
+  // ── Fresh DB (empty ledger) ────────────────────────────────────────────────
+
+  it("applies all entries on a fresh DB (watermark=0, empty ledger)", () => {
+    const entries = [
+      e("0000_init", 1771062880226, "h0"),
+      e("0001_next", 1771103243060, "h1"),
+    ];
+    const plan = planMigrations(entries, new Set(), 0);
+    // watermark=0 means every entry's when > 0, so all get "apply"
+    expect(plan.every(p => p.action === "apply")).toBe(true);
+  });
+
+  // ── Mixed scenario ────────────────────────────────────────────────────────
+
+  it("handles mixed skip / backfill / apply in one plan", () => {
+    const entries = [
+      e("already_applied", 1771000000000, "in_ledger"), // skip
+      e("skipped_by_old", 1771000000001, "missing_old"), // backfill (below watermark)
+      e("new_migration", 1800000000000, "new_hash"), // apply (above watermark)
+    ];
+    const plan = planMigrations(
+      entries,
+      new Set(["in_ledger"]),
+      PROD_WATERMARK
+    );
+    expect(actions(plan)).toEqual([
+      "already_applied:skip",
+      "skipped_by_old:backfill",
+      "new_migration:apply",
+    ]);
+  });
+
+  // ── Ordering invariant ────────────────────────────────────────────────────
+
+  it("preserves journal entry order in the output plan", () => {
+    const entries = [
+      e("tag_c", 1771000000003, "hc"),
+      e("tag_a", 1771000000001, "ha"),
+      e("tag_b", 1771000000002, "hb"),
+    ];
+    const plan = planMigrations(entries, new Set(), 0);
+    expect(plan.map(p => p.tag)).toEqual(["tag_c", "tag_a", "tag_b"]);
+  });
+});

--- a/packages/db/src/migrator.ts
+++ b/packages/db/src/migrator.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure migration planning logic — no I/O, no DB, fully testable.
+ *
+ * The runner (migrate.ts) calls planMigrations() after loading the journal
+ * and ledger state.  Tests call it directly with synthetic data.
+ */
+
+export interface JournalEntry {
+  /** Unique tag for the migration (e.g. "0017_amused_kree") */
+  tag: string;
+  /** Unix timestamp in milliseconds when the migration was generated */
+  when: number;
+}
+
+export interface JournalEntryWithHash extends JournalEntry {
+  /** SHA-256 of the full .sql file contents */
+  hash: string;
+}
+
+export type MigrationAction = "apply" | "backfill" | "skip";
+
+export interface MigrationPlan extends JournalEntryWithHash {
+  action: MigrationAction;
+}
+
+/**
+ * Decide what to do with each journal entry.
+ *
+ * Rules (in priority order):
+ *   1. Hash already in ledger → "skip"  (idempotent)
+ *   2. Hash absent AND when <= ledgerWatermark → "backfill"
+ *      The migration was silently skipped by the old high-watermark logic but
+ *      its schema already exists.  Insert the ledger row without re-executing.
+ *   3. Hash absent AND when > ledgerWatermark → "apply"
+ *      Genuinely new migration — execute and record.
+ *
+ * Ordering does NOT affect whether a migration runs; only the hash does.
+ *
+ * @param entries          Journal entries with pre-computed hashes, in journal order
+ * @param existingHashes   Set of hashes currently in drizzle.__drizzle_migrations
+ * @param ledgerWatermark  max(created_at) from the ledger; 0 if the ledger is empty
+ */
+export function planMigrations(
+  entries: JournalEntryWithHash[],
+  existingHashes: Set<string>,
+  ledgerWatermark: number
+): MigrationPlan[] {
+  return entries.map(entry => {
+    if (existingHashes.has(entry.hash)) {
+      return { ...entry, action: "skip" as const };
+    }
+    if (entry.when <= ledgerWatermark) {
+      return { ...entry, action: "backfill" as const };
+    }
+    return { ...entry, action: "apply" as const };
+  });
+}

--- a/packages/db/src/migrator.ts
+++ b/packages/db/src/migrator.ts
@@ -24,32 +24,71 @@ export interface MigrationPlan extends JournalEntryWithHash {
 }
 
 /**
+ * Known-legacy hashes: migrations whose SQL demonstrably already ran against
+ * production but whose ledger row is absent or stale.  Measured on 2026-08-17
+ * against the live ledger (79 rows / 82 journal entries).
+ *
+ * Two distinct causes, both verified:
+ *   (a) Silently skipped by the old high-watermark migrator (`when` below the
+ *       running max).  Their schema objects were verified present in prod:
+ *       0017 → emails_raw columns, 0025 → feedback table + unique index,
+ *       0074 → dashboard_chat_runs.user_message.
+ *   (b) Applied normally, then the .sql file was edited in place afterwards,
+ *       so the file hash no longer matches the ledger row.  Each of these has
+ *       an orphan ledger row at the identical `created_at`.
+ *
+ * This list is CLOSED.  It exists only to reconcile history that predates the
+ * hash-based runner.  Once these rows land, every entry here plans as "skip"
+ * and the list is inert.  DO NOT ADD TO IT to work around a failing migration:
+ * a new migration that is missing from the ledger must EXECUTE, not be marked
+ * as applied.  See planMigrations().
+ */
+export const LEGACY_BACKFILL_HASHES: ReadonlyMap<string, string> = new Map([
+  // (b) edited in place after being applied — orphan ledger row at same created_at
+  ["2edff771f24bb97d11ef9d480ef0f8c2cab77fb5c4bd3b5eda76551f68245bca", "0006_volatile_cannonball"],
+  ["a349ec370a3216dee589cd19ef1055cd2b98c25e1d5ff95bbb6b67741d73b803", "0016_add_oauth_tokens"],
+  ["0a4301ad0ae605a9f3f1d99c2826aac9f4a5393f50cf5387841784b9b0961f70", "0027_api_credentials"],
+  ["c0a582517466882bb94712043ae880b1714dfc154ce777c3ef93aa7aea74e7f8", "0028_job_credential_ids"],
+  ["767aabdfeb61dd16f6969020c426e72f4d3b2b5466231f4afebedad8f25b8cef", "0031_hybrid_memory_search"],
+  ["0c426cfbc24a40672a3ce2ad35b73746c02b2a6d6ecd87fb5ddce4bc808a18c1", "0049_remove_governance_tables"],
+  ["1197a8ff4fc3a31c33fc1f47e5bb8e9762f0450649ae291e7b69ffcaa0fae526", "0054_echo_loop_prevention"],
+  // (a) silently skipped by the watermark bug — schema verified present in prod
+  ["daab31de8de4e72ccb327d8f540cf821341577580466daea694212a27977d5e0", "0017_amused_kree"],
+  ["3dac0cbc18a14f60af945ff92efe78319f9d0a30068bb8514e76d4464379fff0", "0025_feedback_table"],
+  ["5856e3d56893bddb6cadcb4808121861d171c3bc5ebb8f0b3d9a60debcf291d9", "0074_dashboard_chat_runs_user_message"],
+]);
+
+/**
  * Decide what to do with each journal entry.
  *
  * Rules (in priority order):
  *   1. Hash already in ledger → "skip"  (idempotent)
- *   2. Hash absent AND when <= ledgerWatermark → "backfill"
- *      The migration was silently skipped by the old high-watermark logic but
- *      its schema already exists.  Insert the ledger row without re-executing.
- *   3. Hash absent AND when > ledgerWatermark → "apply"
- *      Genuinely new migration — execute and record.
+ *   2. Hash in the closed LEGACY_BACKFILL_HASHES set → "backfill"
+ *      Historical reconciliation only: insert the ledger row, do NOT execute.
+ *   3. Otherwise → "apply"
+ *      Execute and record, REGARDLESS of `when`.
  *
- * Ordering does NOT affect whether a migration runs; only the hash does.
+ * Rule 3 is the whole point.  An out-of-order migration (stale branch merged
+ * after a newer one) has a `when` below the ledger max, and the old migrator
+ * silently skipped it.  Marking it "backfill" on the basis of its timestamp
+ * would reproduce that bug with extra steps: the SQL still never runs, and now
+ * a ledger row lies about it, making the omission undetectable.  Timestamps do
+ * not decide execution here — only hashes do.
  *
  * @param entries          Journal entries with pre-computed hashes, in journal order
  * @param existingHashes   Set of hashes currently in drizzle.__drizzle_migrations
- * @param ledgerWatermark  max(created_at) from the ledger; 0 if the ledger is empty
+ * @param legacyHashes     Closed set of pre-existing hashes to record without executing
  */
 export function planMigrations(
   entries: JournalEntryWithHash[],
   existingHashes: Set<string>,
-  ledgerWatermark: number
+  legacyHashes: ReadonlySet<string> | ReadonlyMap<string, string> = LEGACY_BACKFILL_HASHES
 ): MigrationPlan[] {
   return entries.map(entry => {
     if (existingHashes.has(entry.hash)) {
       return { ...entry, action: "skip" as const };
     }
-    if (entry.when <= ledgerWatermark) {
+    if (legacyHashes.has(entry.hash)) {
       return { ...entry, action: "backfill" as const };
     }
     return { ...entry, action: "apply" as const };

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -432,6 +435,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   sandbox:
     dependencies:


### PR DESCRIPTION
## Problem
`packages/db/src/migrate.ts` used drizzle's `neon-http` migrator, which reads a single row (`order by created_at desc limit 1`) and applies only journal entries with a greater `when`. It is a high-watermark, not a ledger. **Any migration merged with a `when` below the current max is silently skipped forever** -- no error, no retry.

Prod evidence: 82 journal entries, 79 ledger rows. `0017_amused_kree`, `0025_feedback_table`, `0074_dashboard_chat_runs_user_message` have no ledger row. Nine entries sit below the watermark. Six ledger rows have hashes matching no file on disk. `created_at 1772880000000` has two identical-hash rows. Prod schema is intact only because nearly every migration is written `IF NOT EXISTS`.

## Fix
1. **Hash-based ledger.** Apply anything whose sha256 is absent from `drizzle.__drizzle_migrations`, in journal order. Ordering no longer determines whether a migration runs.
2. **Self-healing legacy backfill.** Entries missing by hash whose `when` is at or below the pre-existing ledger watermark are recorded without executing SQL, logged loudly. Required: `0025_feedback_table.sql` is a bare `CREATE TABLE "feedback"` with no `IF NOT EXISTS` and would hard-fail the build otherwise.
3. **`prefix: "unix"`** for new migrations -- no more incrementing-index collisions. Existing files untouched.
4. **CI guard** fails a PR whose journal is out of order vs `main`, has duplicate `when` values, or has journal/file mismatches -- caught at open time instead of at rebase.

Reported and specced after three separate migration renumbers in one day.