### PR TITLE
Fixes #1284: forward AI SDK strict + inputExamples through defineTool()

### DIFF
--- a/apps/api/src/lib/tool.test.ts
+++ b/apps/api/src/lib/tool.test.ts
@@ -42,6 +42,61 @@ import {
   TOOL_CALL_AFTER_DETACHED_SUSPEND_ERROR,
 } from "./tool.js";
 
+describe("defineTool strict + inputExamples forwarding", () => {
+  it("defaults strict to true when omitted", () => {
+    const t = defineTool({
+      description: "a tool",
+      inputSchema: z.object({ q: z.string() }),
+      execute: async () => ({ ok: true }),
+    });
+
+    // vi.mock("ai") makes tool() an identity function, so the returned
+    // object is exactly the config passed to the underlying tool() call.
+    expect((t as any).strict).toBe(true);
+    expect((t as any).inputExamples).toBeUndefined();
+  });
+
+  it("forwards strict: false into the tool() config", () => {
+    const t = defineTool({
+      description: "a tool with a strict-incompatible schema",
+      inputSchema: z.object({ fields: z.record(z.any()) }),
+      strict: false,
+      execute: async () => ({ ok: true }),
+    });
+
+    expect((t as any).strict).toBe(false);
+  });
+
+  it("forwards inputExamples unchanged into the tool() config", () => {
+    const examples = [
+      { input: { q: "first example" } },
+      { input: { q: "second example" } },
+    ];
+    const t = defineTool({
+      description: "a tool with examples",
+      inputSchema: z.object({ q: z.string() }),
+      inputExamples: examples,
+      execute: async () => ({ ok: true }),
+    });
+
+    expect((t as any).inputExamples).toEqual(examples);
+    expect((t as any).strict).toBe(true);
+  });
+
+  it("still injects strict when defineTool-only metadata fields are present", () => {
+    const t = defineTool({
+      description: "a tool",
+      inputSchema: z.object({ q: z.string() }),
+      slack: { status: "Working..." },
+      requiredCredentials: ["some_key"],
+      execute: async () => ({ ok: true }),
+    });
+
+    expect((t as any).strict).toBe(true);
+    expect((t as any).__requiredCredentials).toEqual(["some_key"]);
+  });
+});
+
 describe("tool detached suspend enforcement", () => {
   it("returns a hard error for tool calls after a detached command suspends the turn", async () => {
     dbMocks.returning.mockResolvedValue([{ id: "log-1" }]);

--- a/apps/api/src/lib/tool.ts
+++ b/apps/api/src/lib/tool.ts
@@ -126,8 +126,22 @@ export function defineTool<TInput, TOutput>(config: {
   slack?: SlackToolMetadata<TInput, TOutput>;
   toModelOutput?: Tool<TInput, TOutput, any>["toModelOutput"];
   requiredCredentials?: string[];
+  /**
+   * Provider-side strict schema validation for tool-call inputs (AI SDK
+   * BaseFunctionTool.strict). Defaults to true so malformed inputs are
+   * rejected at the tool-call layer instead of failing deep in execute().
+   * Set to false only for tools whose inputSchema can't be represented as
+   * strict JSON schema (e.g. z.record() with free-form values).
+   */
+  strict?: boolean;
+  /**
+   * Example inputs shown to the language model (AI SDK
+   * BaseFunctionTool.inputExamples) to ground tool-call generation on real
+   * call shapes. Passed through to tool() unchanged.
+   */
+  inputExamples?: Array<{ input: TInput }>;
 }) {
-  const { slack, requiredCredentials, ...rest } = config;
+  const { slack, requiredCredentials, strict, ...rest } = config;
   const originalExecute = rest.execute;
 
   const toolRef: ToolNameRef = {};
@@ -204,7 +218,7 @@ export function defineTool<TInput, TOutput>(config: {
     }
   };
 
-  const toolConfig = { ...rest, execute: auditedExecute };
+  const toolConfig = { ...rest, strict: strict ?? true, execute: auditedExecute };
   const t = tool<TInput, TOutput, any>(
     toolConfig as unknown as Tool<TInput, TOutput, any>,
   );

--- a/apps/api/src/tools/bigquery.ts
+++ b/apps/api/src/tools/bigquery.ts
@@ -462,6 +462,20 @@ export function createBigQueryTools(context?: ScheduleContext) {
       description:
         `Run a read-only BigQuery query (SELECT/WITH only). ${BIGQUERY_SQL_STYLE_GUIDANCE} ${BIGQUERY_DEBUGGING_LADDER} For unfamiliar tables, bq_inspect_table before querying. Do not infer permissions issues from one complex failing query; retry a minimal valid query first.`,
       inputSchema: executeQueryInputSchema,
+      inputExamples: [
+        {
+          input: {
+            sql: "SELECT status, COUNT(*) AS n FROM `project.crm.leads` WHERE created_at >= '2026-01-01' GROUP BY status ORDER BY n DESC",
+            max_rows: 100,
+          },
+        },
+        {
+          input: {
+            sql: "WITH recent AS (SELECT * FROM `project.analytics.events` WHERE event_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)) SELECT event_name, COUNT(*) AS total FROM recent GROUP BY event_name",
+            max_rows: 50,
+          },
+        },
+      ],
       execute: async (input) => executeBigQueryQuery(input, "bq_execute_query"),
       slack: {
         status: "Running a SQL query...",

--- a/apps/api/src/tools/conversations.ts
+++ b/apps/api/src/tools/conversations.ts
@@ -100,6 +100,26 @@ export function createConversationSearchTools(context?: ScheduleContext) {
           .default(0)
           .describe("Number of messages to skip for pagination (default 0)"),
       }),
+      inputExamples: [
+        {
+          input: {
+            query: "quarterly report deadline",
+            mode: "text",
+            limit: DEFAULT_LIMIT,
+            offset: 0,
+          },
+        },
+        {
+          input: {
+            query: "concerns about the pricing migration",
+            mode: "semantic",
+            user_id: "U066V1AN6",
+            since: "2026-07-01",
+            limit: DEFAULT_LIMIT,
+            offset: 0,
+          },
+        },
+      ],
       execute: async ({ query, mode, user_id, channel_id, since, until, role, limit, offset }) => {
         try {
           if (mode === "semantic" && !query?.trim()) {

--- a/apps/api/src/tools/cursor-agent.ts
+++ b/apps/api/src/tools/cursor-agent.ts
@@ -52,6 +52,27 @@ export function createCursorAgentTools(context?: ScheduleContext) {
             "GitHub repository in owner/repo format, e.g. 'org/repo'. Defaults to 'AuraHQ-ai/aura'",
           ),
       }),
+      inputExamples: [
+        {
+          input: {
+            issue_description:
+              "Fix the crash in apps/api/src/respond.ts when a Slack thread has more than 1000 messages: paginate the history fetch and add a regression test.",
+            branch_prefix: "cursor",
+            key_files: ["apps/api/src/respond.ts"],
+          },
+        },
+        {
+          input: {
+            issue_description:
+              "Add a 'snooze' action to job reminder DMs: new tool, DB column on jobs, and dashboard toggle.",
+            branch_prefix: "cursor",
+            key_files: [
+              "apps/api/src/tools/jobs.ts",
+              "packages/db/src/schema.ts",
+            ],
+          },
+        },
+      ],
       execute: async ({ issue_description, branch_prefix, ref, key_files, repository }) => {
         try {
           const { launchCursorAgent } = await import(

--- a/apps/api/src/tools/jobs.ts
+++ b/apps/api/src/tools/jobs.ts
@@ -105,6 +105,27 @@ export function createJobTools(
             "'task' runs the job with a minimal ~2k-token task prompt (no personality, self-directive, or notes index) — fewer places for context rot in mechanical jobs. Memory stays unified either way. Omit or 'full' for the standard prompt.",
           ),
       }),
+      inputExamples: [
+        {
+          input: {
+            description: "Remind Joan to review PR #1284",
+            execute_in: "2 hours",
+            timezone: "UTC",
+            priority: "normal",
+          },
+        },
+        {
+          input: {
+            name: "bug-digest",
+            description: "Check #bugs for new reports since the last run and post a summary",
+            recurring: "0 9 * * 1-5",
+            channel_name: "bugs",
+            timezone: "Europe/Zurich",
+            priority: "normal",
+            max_per_day: 1,
+          },
+        },
+      ],
       execute: async ({
         name,
         description,

--- a/apps/api/src/tools/lists.ts
+++ b/apps/api/src/tools/lists.ts
@@ -89,6 +89,29 @@ export function createListWriteTools(client: WebClient) {
               "Or use typed objects: {select: [\"done\"]}, {rich_text: [...]}, {user: [\"U01234\"]}, {date: [\"2025-09-20\"]}.",
           ),
       }),
+      // fields is z.record(z.any()) — free-form keys/values can't be expressed
+      // as strict JSON schema, so provider-side strict validation stays off.
+      strict: false,
+      inputExamples: [
+        {
+          input: {
+            list_id: "F0123ABCD",
+            item_id: "Rec0123ABCD",
+            fields: { Col0STATUS1: ["done"] },
+          },
+        },
+        {
+          input: {
+            list_id: "F0123ABCD",
+            item_id: "Rec0456EFGH",
+            fields: {
+              Col0OWNER01: ["U0123ABCD"],
+              Col0DUEDATE: { date: ["2026-09-20"] },
+              Col0TITLE01: "Ship strict tool inputs",
+            },
+          },
+        },
+      ],
       execute: async ({ list_id, item_id, fields }) => {
         try {
 

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -781,6 +781,23 @@ export function createSandboxTools(context?: ScheduleContext) {
             "Command timeout in seconds (default 90, max 750). Explicitly opt in to values above 90s only for headless/batch work or long-running agent commands; Slack chat.stream caps around 3 minutes, so longer foreground calls can freeze the active Slack message.",
           ),
       }),
+      inputExamples: [
+        { input: { command: "cat /home/user/output.txt", timeout_seconds: 90 } },
+        {
+          input: {
+            command: "git status && git log --oneline -5",
+            workdir: "/home/user/repo",
+            timeout_seconds: 90,
+          },
+        },
+        {
+          input: {
+            command: "python analyze.py --input data.csv > results.txt 2>&1",
+            workdir: "/home/user/analysis",
+            timeout_seconds: 300,
+          },
+        },
+      ],
       execute: async ({ command, workdir, timeout_seconds }) => {
         const userId = context?.userId || "aura";
         try {

--- a/apps/api/src/tools/slack.ts
+++ b/apps/api/src/tools/slack.ts
@@ -1056,6 +1056,20 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
             "The message text to send. Supports Slack mrkdwn formatting.",
           ),
       }),
+      inputExamples: [
+        {
+          input: {
+            channel: "general",
+            message: "Deploy finished — all checks green. :rocket:",
+          },
+        },
+        {
+          input: {
+            channel: "C0BNVKS77",
+            message: "*Heads up:* the weekly bug digest is ready in <#C0BUGS123>.",
+          },
+        },
+      ],
       execute: async ({ channel: channelInput, message }) => {
         try {
           const channel = await resolveChannelByName(client, channelInput);
@@ -1364,6 +1378,20 @@ export async function createSlackTools(client: WebClient, context?: ScheduleCont
             "The message text to send. Supports Slack mrkdwn formatting.",
           ),
       }),
+      inputExamples: [
+        {
+          input: {
+            user_name: "Joan",
+            message: "Quick reminder: the PR review is due today.",
+          },
+        },
+        {
+          input: {
+            user_name: ["Joan", "Alex", "Sam"],
+            message: "Kicking off the incident retro thread — notes incoming.",
+          },
+        },
+      ],
       execute: async ({ user_name, message }) => {
         try {
           const names = Array.isArray(user_name) ? user_name : [user_name];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1284. The installed `ai@7.0.15` SDK already supports the `strict` and `inputExamples` reliability levers on function tools (`BaseFunctionTool.strict` / `BaseFunctionTool.inputExamples` in `@ai-sdk/provider-utils@5.0.5`), but our `defineTool()` wrapper never forwarded them. This closes the gap so malformed tool-call inputs (`invalid_arguments` / "Expected object, received string" — see #1174, #1180) are rejected by provider-side schema validation instead of failing deep in execution, and grounds the highest-traffic tools on real call shapes.

## Changes

### `apps/api/src/lib/tool.ts`
- `defineTool()` config now accepts `strict?: boolean` and `inputExamples?: Array<{ input: TInput }>`.
- `strict` defaults to **`true`** when omitted and is injected into the config passed to the underlying `tool()` call; `inputExamples` passes through unchanged.

### `inputExamples` added to 8 high-frequency / malformed-input-prone tools
Each example was written against the tool's actual zod `inputSchema` (field names and enum values verified, not guessed):

| Tool | File | Examples |
|---|---|---|
| `run_command` | `tools/sandbox.ts` | 3 |
| `bq_execute_query` | `tools/bigquery.ts` | 2 |
| `send_channel_message` | `tools/slack.ts` | 2 |
| `send_direct_message` | `tools/slack.ts` | 2 (incl. the `string[]` group-DM union arm) |
| `create_job` | `tools/jobs.ts` | 2 (one-shot + recurring cron) |
| `update_slack_list_item` | `tools/lists.ts` | 2 (simple + typed-object field values) |
| `dispatch_cursor_agent` | `tools/cursor-agent.ts` | 2 |
| `search_my_conversations` | `tools/conversations.ts` | 2 (text + semantic modes) |

### Strict opt-out (case-by-case review)
- `update_slack_list_item` sets `strict: false` explicitly: its `fields` input is `z.record(z.any())`, whose free-form keys/values can't be represented as strict JSON schema.
- `send_direct_message`'s `string | string[]` union maps cleanly to `anyOf` and keeps the default `strict: true`.
- All other tools keep the default `true`.

### Tests (`apps/api/src/lib/tool.test.ts`)
- `strict` defaults to `true` when omitted.
- `strict: false` is forwarded into the `tool()` config.
- `inputExamples` is forwarded unchanged (and `strict` still injected alongside it).
- `strict` injection is unaffected by defineTool-only metadata (`slack`, `requiredCredentials`).

## Out of scope (untouched, per issue)
`toolOrder`, `repairToolCall`, `activeTools`, code-mode/toolCallers, and `addToolInputExamplesMiddleware`.

## Verification
- `pnpm typecheck` passes (API + dashboard).
- `pnpm --filter aura-api test`: `src/lib/tool.test.ts` 5/5 pass. Four failures in `src/pipeline/respond.test.ts` are **pre-existing on the base commit** (reproduced with this change stashed) and unrelated to this PR.

## Merge gate note
No streaming-boundary or Slack response-shape change — this only affects tool-call generation grounding and provider-side validation. Low risk. A smoke turn exercising `run_command` end-to-end is cheap insurance before merge but not a hard blocker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4e7215b-ced8-44e4-b015-d5590339c3de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4e7215b-ced8-44e4-b015-d5590339c3de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

