### PR TITLE
fix(tools): strict schema rejects integer+min/max in memories tools (regression from #1317)

### DIFF
--- a/apps/api/src/lib/tool.test.ts
+++ b/apps/api/src/lib/tool.test.ts
@@ -130,3 +130,27 @@ describe("tool detached suspend enforcement", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 });
+
+describe("strict-mode JSON schema compatibility", () => {
+  it("no tool inputSchema uses integer type with minimum/maximum", async () => {
+    // Provider-side strict validation (defaulted on in #1317) rejects
+    // { type: "integer", minimum, maximum } -- it surfaces as
+    // "tools.N.custom: For 'integer' type, properties maximum, minimum are
+    // not supported" and kills the whole turn, not just the tool call.
+    // Use z.number().min().max() instead of z.number().int().min().max().
+    const { readdirSync, readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const dir = join(import.meta.dirname, "../tools");
+    const offenders: string[] = [];
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".ts") || f.includes(".test.")) continue;
+      const src = readFileSync(join(dir, f), "utf8");
+      for (const [i, line] of src.split("\n").entries()) {
+        if (/z\.number\(\)\.int\(\)/.test(line) && /\.(min|max)\(/.test(line)) {
+          offenders.push(`${f}:${i + 1}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/api/src/tools/memories.ts
+++ b/apps/api/src/tools/memories.ts
@@ -129,7 +129,7 @@ export function createMemoryTools(context?: ScheduleContext) {
           .enum(["person", "company", "channel", "technology", "product", "project"])
           .optional()
           .describe("Narrow entity resolution to a specific type. Optional — omit to match across all types."),
-        limit: z.number().int().min(1).max(50).optional().default(20).describe("Max results (default 20, max 50)"),
+        limit: z.number().min(1).max(50).optional().default(20).describe("Max results (default 20, max 50)"),
         mode: z
           .enum(["text", "semantic"])
           .optional()
@@ -381,7 +381,7 @@ export function createMemoryTools(context?: ScheduleContext) {
           .enum(["person", "company", "channel", "technology", "product", "project"])
           .optional()
           .describe("Filter to a specific entity type"),
-        limit: z.number().int().min(1).max(50).optional().default(20).describe("Max results (default 20)"),
+        limit: z.number().min(1).max(50).optional().default(20).describe("Max results (default 20)"),
       }),
       execute: async ({ query, type, limit }) => {
         try {


### PR DESCRIPTION
## What broke

#1317 defaulted `strict: true` on every `defineTool()`. Two tools in `memories.ts` (`search_memories`, `search_entities`) declare `z.number().int().min(1).max(50)`, which serialises to `{ type: "integer", minimum, maximum }` -- rejected provider-side:

```
tools.1.custom: For 'integer' type, properties maximum, minimum are not supported
```

This fails the **whole turn**, not just the tool call. It killed `aura-job-health-check` at 06:00 today (2026-08-19), the first scheduled run after #1317 deployed.

## Fix

`z.number().min(1).max(50)` -- identical runtime bounds, strict-safe JSON schema. Already the pattern in `slack.ts`, `web.ts`, `subagents.ts`, `sheets.ts`, `table.ts`; `memories.ts` was the only outlier.

## Regression guard

New test scans every module in `src/tools/` for `z.number().int()` combined with `.min()/.max()` and fails with file:line. Typecheck can't catch this -- it's only invalid once serialised to JSON schema and sent to the provider.

## Verification
- `tsc --noEmit`: clean
- `vitest src/lib/tool.test.ts`: 6/6 pass (5 existing + new guard)