### PR TITLE
Fixes #1333: ops-notice destination configurable via settings, not env-only

### DIFF
--- a/apps/api/src/cron/heartbeat.test.ts
+++ b/apps/api/src/cron/heartbeat.test.ts
@@ -62,6 +62,8 @@ const executeJobMock = vi.hoisted(() => vi.fn());
 const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
 const safePostMessageMock = vi.hoisted(() => vi.fn());
 const resolveSlackDestinationMock = vi.hoisted(() => vi.fn());
+const getSettingMock = vi.hoisted(() => vi.fn());
+const logErrorMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../db/client.js", () => ({
   db: {
@@ -103,6 +105,29 @@ vi.mock("../lib/slack-messaging.js", () => ({
 vi.mock("../tools/slack.js", () => ({
   resolveSlackDestination: resolveSlackDestinationMock,
 }));
+
+// The ops routing ladder is DB-first: settings.aura_ops_channel /
+// settings.founder_user_id take priority over the env vars. Mock the settings
+// reader so tests control both rungs deterministically (and so the real
+// job-notifications module does not consume queued db results).
+vi.mock("../lib/settings.js", () => ({
+  getSetting: getSettingMock,
+  setSetting: vi.fn(),
+  getAllSettings: vi.fn(async () => ({})),
+  getConfig: vi.fn(async (_key: string, fallback = "") => fallback),
+  getSettingJSON: vi.fn(async (_key: string, fallback: unknown = null) => fallback),
+}));
+
+vi.mock("../lib/error-logger.js", () => ({
+  logError: logErrorMock,
+  sanitizeErrorText: vi.fn((value: string | null | undefined) => value ?? ""),
+  flushLoggerDrops: vi.fn(),
+  resetErrorLoggerStateForTest: vi.fn(),
+}));
+
+function mockSettingsRows(rows: Record<string, string>) {
+  getSettingMock.mockImplementation(async (key: string) => rows[key] ?? null);
+}
 
 function queueDbResults(...results: unknown[][]) {
   dbMock.results = [...results];
@@ -168,6 +193,7 @@ describe("heartbeat stale running recovery", () => {
     dbMock.results = [];
     dbMock.operations = [];
     vi.clearAllMocks();
+    getSettingMock.mockResolvedValue(null);
     sendJobFailureDmMock.mockResolvedValue(true);
     safePostMessageMock.mockResolvedValue({ ok: true });
     resolveSlackDestinationMock.mockImplementation(
@@ -530,6 +556,61 @@ describe("heartbeat stale running recovery", () => {
     );
   });
 
+  it("routes the retry-exhausted notice to the settings-configured ops channel over env vars", async () => {
+    mockSettingsRows({ aura_ops_channel: "C_SETTINGS_OPS" });
+    process.env.AURA_OPS_CHANNEL = "C_ENV_OPS";
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+    queueDbResults(
+      [],
+      [{ id: "00000000-0000-4000-8000-000000000103", jobId: "job-1", supervisorAttempts: 3 }],
+      [{ id: "00000000-0000-4000-8000-000000000103", jobId: "job-1" }],
+      [{ id: "job-1", name: "stuck supervisor job", requestedBy: "U_REQUESTER" }],
+      [],
+    );
+
+    const { sweepOrphanedOutcomes } = await import("./heartbeat.js");
+    const result = await sweepOrphanedOutcomes();
+
+    expect(result.inProgressSkipped).toBe(1);
+    expect(safePostMessageMock).toHaveBeenCalledTimes(1);
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "C_SETTINGS_OPS",
+        text: expect.stringContaining("exhausted retries"),
+      }),
+    );
+    expect(logErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("routes the retry-exhausted notice to the settings-configured founder DM when no ops channel is set", async () => {
+    mockSettingsRows({ founder_user_id: "U_SETTINGS_FOUNDER" });
+    queueDbResults(
+      [],
+      [{ id: "00000000-0000-4000-8000-000000000103", jobId: "job-1", supervisorAttempts: 3 }],
+      [{ id: "00000000-0000-4000-8000-000000000103", jobId: "job-1" }],
+      [{ id: "job-1", name: "stuck supervisor job", requestedBy: "U_REQUESTER" }],
+      [],
+    );
+
+    const { sweepOrphanedOutcomes } = await import("./heartbeat.js");
+    const result = await sweepOrphanedOutcomes();
+
+    expect(result.inProgressSkipped).toBe(1);
+    expect(resolveSlackDestinationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "U_SETTINGS_FOUNDER",
+    );
+    expect(safePostMessageMock).toHaveBeenCalledTimes(1);
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "D_U_SETTINGS_FOUNDER",
+        text: expect.stringContaining("exhausted retries"),
+      }),
+    );
+  });
+
   it("routes the retry-exhausted notice to the founder DM when only FOUNDER_USER_ID is set", async () => {
     process.env.FOUNDER_USER_ID = "U_FOUNDER";
     queueDbResults(
@@ -579,6 +660,10 @@ describe("heartbeat stale running recovery", () => {
         channel: "D_U_REQUESTER",
         text: "Supervisor for job stuck supervisor job exhausted retries; manual intervention needed",
       }),
+    );
+    // The misconfiguration must be visible in monitoring, not only in logs.
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ errorName: "job_ops_notice_no_ops_destination" }),
     );
   });
 

--- a/apps/api/src/cron/job-notifications.test.ts
+++ b/apps/api/src/cron/job-notifications.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const safePostMessageMock = vi.hoisted(() => vi.fn());
 const resolveSlackDestinationMock = vi.hoisted(() => vi.fn());
+const getSettingMock = vi.hoisted(() => vi.fn());
+const logErrorMock = vi.hoisted(() => vi.fn());
 const loggerMock = vi.hoisted(() => ({
   info: vi.fn(),
   warn: vi.fn(),
@@ -21,6 +23,26 @@ vi.mock("../tools/slack.js", () => ({
   resolveSlackDestination: resolveSlackDestinationMock,
 }));
 
+vi.mock("../lib/settings.js", () => ({
+  getSetting: getSettingMock,
+  setSetting: vi.fn(),
+  getAllSettings: vi.fn(async () => ({})),
+  getConfig: vi.fn(async (_key: string, fallback = "") => fallback),
+  getSettingJSON: vi.fn(async (_key: string, fallback: unknown = null) => fallback),
+}));
+
+vi.mock("../lib/error-logger.js", () => ({
+  logError: logErrorMock,
+  sanitizeErrorText: vi.fn((value: string | null | undefined) => value ?? ""),
+  flushLoggerDrops: vi.fn(),
+  resetErrorLoggerStateForTest: vi.fn(),
+}));
+
+/** Point the mocked settings table at specific key/value pairs (unset keys resolve to null). */
+function mockSettingsRows(rows: Record<string, string>) {
+  getSettingMock.mockImplementation(async (key: string) => rows[key] ?? null);
+}
+
 const originalFounderUserId = process.env.FOUNDER_USER_ID;
 const originalAuraOpsChannel = process.env.AURA_OPS_CHANNEL;
 
@@ -28,6 +50,7 @@ beforeEach(() => {
   delete process.env.FOUNDER_USER_ID;
   delete process.env.AURA_OPS_CHANNEL;
   vi.clearAllMocks();
+  getSettingMock.mockResolvedValue(null);
   safePostMessageMock.mockResolvedValue({ ok: true });
   resolveSlackDestinationMock.mockImplementation(
     async (_client: unknown, destination: string) =>
@@ -49,15 +72,55 @@ afterEach(() => {
 });
 
 describe("resolveOpsNotificationTarget fallback ladder", () => {
-  it("prefers AURA_OPS_CHANNEL over everything else", async () => {
+  it("prefers the aura_ops_channel setting over everything else, including env vars", async () => {
+    mockSettingsRows({
+      aura_ops_channel: "C_SETTINGS_OPS",
+      founder_user_id: "U_SETTINGS_FOUNDER",
+    });
+    process.env.AURA_OPS_CHANNEL = "C_ENV_OPS";
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+
+    const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
+
+    await expect(resolveOpsNotificationTarget("U_REQUESTER")).resolves.toEqual({
+      kind: "ops_channel",
+      destination: "C_SETTINGS_OPS",
+    });
+  });
+
+  it("prefers AURA_OPS_CHANNEL over founder / requester targets when the setting is unset", async () => {
     process.env.AURA_OPS_CHANNEL = "C_OPS";
     process.env.FOUNDER_USER_ID = "U_FOUNDER";
 
     const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
 
-    expect(resolveOpsNotificationTarget("U_REQUESTER")).toEqual({
+    await expect(resolveOpsNotificationTarget("U_REQUESTER")).resolves.toEqual({
       kind: "ops_channel",
       destination: "C_OPS",
+    });
+  });
+
+  it("prefers the founder_user_id setting over the FOUNDER_USER_ID env var", async () => {
+    mockSettingsRows({ founder_user_id: "U_SETTINGS_FOUNDER" });
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+
+    const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
+
+    await expect(resolveOpsNotificationTarget("U_REQUESTER")).resolves.toEqual({
+      kind: "founder_dm",
+      destination: "U_SETTINGS_FOUNDER",
+    });
+  });
+
+  it("ignores whitespace-only settings rows and falls through the ladder", async () => {
+    mockSettingsRows({ aura_ops_channel: "   ", founder_user_id: "  " });
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+
+    const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
+
+    await expect(resolveOpsNotificationTarget("U_REQUESTER")).resolves.toEqual({
+      kind: "founder_dm",
+      destination: "U_ENV_FOUNDER",
     });
   });
 
@@ -66,7 +129,7 @@ describe("resolveOpsNotificationTarget fallback ladder", () => {
 
     const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
 
-    expect(resolveOpsNotificationTarget("U_REQUESTER")).toEqual({
+    await expect(resolveOpsNotificationTarget("U_REQUESTER")).resolves.toEqual({
       kind: "founder_dm",
       destination: "U_FOUNDER",
     });
@@ -75,7 +138,7 @@ describe("resolveOpsNotificationTarget fallback ladder", () => {
   it("falls back to the requester DM as a last resort", async () => {
     const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
 
-    expect(resolveOpsNotificationTarget("U_REQUESTER")).toEqual({
+    await expect(resolveOpsNotificationTarget("U_REQUESTER")).resolves.toEqual({
       kind: "requester_dm",
       destination: "U_REQUESTER",
     });
@@ -84,9 +147,9 @@ describe("resolveOpsNotificationTarget fallback ladder", () => {
   it("keeps the system-owned (aura) skip semantics on the last-resort path", async () => {
     const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
 
-    expect(resolveOpsNotificationTarget("aura")).toBeNull();
-    expect(resolveOpsNotificationTarget(null)).toBeNull();
-    expect(resolveOpsNotificationTarget("  ")).toBeNull();
+    await expect(resolveOpsNotificationTarget("aura")).resolves.toBeNull();
+    await expect(resolveOpsNotificationTarget(null)).resolves.toBeNull();
+    await expect(resolveOpsNotificationTarget("  ")).resolves.toBeNull();
   });
 
   it("still resolves the ops channel for system-owned jobs", async () => {
@@ -94,9 +157,20 @@ describe("resolveOpsNotificationTarget fallback ladder", () => {
 
     const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
 
-    expect(resolveOpsNotificationTarget("aura")).toEqual({
+    await expect(resolveOpsNotificationTarget("aura")).resolves.toEqual({
       kind: "ops_channel",
       destination: "C_OPS",
+    });
+  });
+
+  it("still resolves the settings-configured ops channel for system-owned jobs", async () => {
+    mockSettingsRows({ aura_ops_channel: "C_SETTINGS_OPS" });
+
+    const { resolveOpsNotificationTarget } = await import("./job-notifications.js");
+
+    await expect(resolveOpsNotificationTarget("aura")).resolves.toEqual({
+      kind: "ops_channel",
+      destination: "C_SETTINGS_OPS",
     });
   });
 });
@@ -125,6 +199,49 @@ describe("sendJobOpsNotice", () => {
       }),
     );
     expect(loggerMock.warn).not.toHaveBeenCalled();
+    expect(logErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("posts to the settings-configured ops channel even when env vars point elsewhere", async () => {
+    mockSettingsRows({ aura_ops_channel: "C_SETTINGS_OPS" });
+    process.env.AURA_OPS_CHANNEL = "C_ENV_OPS";
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+
+    const { sendJobOpsNotice } = await import("./job-notifications.js");
+    const result = await sendJobOpsNotice(notice);
+
+    expect(result).toEqual({ ok: true, target: "ops_channel" });
+    expect(resolveSlackDestinationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "C_SETTINGS_OPS",
+    );
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "C_SETTINGS_OPS",
+        text: expect.stringContaining("`daily sync` (requested by <@U_REQUESTER>)"),
+      }),
+    );
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+    expect(logErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("posts to the settings-configured founder DM when no ops channel is configured", async () => {
+    mockSettingsRows({ founder_user_id: "U_SETTINGS_FOUNDER" });
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+
+    const { sendJobOpsNotice } = await import("./job-notifications.js");
+    const result = await sendJobOpsNotice(notice);
+
+    expect(result).toEqual({ ok: true, target: "founder_dm" });
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "D_U_SETTINGS_FOUNDER",
+        text: expect.stringContaining("<@U_REQUESTER>"),
+      }),
+    );
+    expect(logErrorMock).not.toHaveBeenCalled();
   });
 
   it("posts to the founder DM when only FOUNDER_USER_ID is configured", async () => {
@@ -161,12 +278,31 @@ describe("sendJobOpsNotice", () => {
     );
   });
 
+  it("writes an error_events row when the ladder falls back to the requester DM", async () => {
+    const { sendJobOpsNotice } = await import("./job-notifications.js");
+    await sendJobOpsNotice(notice);
+
+    expect(logErrorMock).toHaveBeenCalledTimes(1);
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorName: "job_ops_notice_no_ops_destination",
+        errorMessage: expect.stringContaining("daily sync"),
+        context: expect.objectContaining({
+          jobId: "job-1",
+          jobName: "daily sync",
+          requestedBy: "U_REQUESTER",
+        }),
+      }),
+    );
+  });
+
   it("skips system-owned jobs entirely when no ops destination is configured", async () => {
     const { sendJobOpsNotice } = await import("./job-notifications.js");
     const result = await sendJobOpsNotice({ ...notice, requestedBy: "aura" });
 
     expect(result).toEqual({ ok: false, target: null });
     expect(safePostMessageMock).not.toHaveBeenCalled();
+    expect(logErrorMock).not.toHaveBeenCalled();
   });
 
   it("reports failure without throwing when Slack posting fails", async () => {

--- a/apps/api/src/cron/job-notifications.ts
+++ b/apps/api/src/cron/job-notifications.ts
@@ -1,5 +1,7 @@
 import { WebClient } from "@slack/web-api";
+import { logError } from "../lib/error-logger.js";
 import { logger } from "../lib/logger.js";
+import { getSetting } from "../lib/settings.js";
 import { safePostMessage } from "../lib/slack-messaging.js";
 import { resolveSlackDestination } from "../tools/slack.js";
 
@@ -27,24 +29,47 @@ export type OpsNoticeTarget = {
   destination: string;
 };
 
+/** Settings key for the ops channel (channel ID or name). Takes priority over the AURA_OPS_CHANNEL env var. */
+export const OPS_CHANNEL_SETTING_KEY = "aura_ops_channel";
+/** Settings key for the founder's Slack user ID. Takes priority over the FOUNDER_USER_ID env var. */
+export const FOUNDER_USER_ID_SETTING_KEY = "founder_user_id";
+
+/**
+ * Resolve the founder's Slack user ID: DB setting first (editable from the
+ * dashboard), then the FOUNDER_USER_ID env var. Returns null when neither
+ * is configured.
+ */
+export async function resolveFounderUserId(): Promise<string | null> {
+  return (
+    (await getSetting(FOUNDER_USER_ID_SETTING_KEY))?.trim() ||
+    process.env.FOUNDER_USER_ID?.trim() ||
+    null
+  );
+}
+
 /**
  * Resolve where internal job lifecycle/ops notices (retries, escalations,
  * disable notices, retry-exhausted alerts) should go. These are internal
  * plumbing, NOT user deliverables, so they must not land in the requester's
  * DM when an ops destination is configured.
  *
- * Fallback ladder:
- * 1. AURA_OPS_CHANNEL env (channel ID or name)
- * 2. FOUNDER_USER_ID env (DM)
- * 3. Last resort only: DM requestedBy (keeps the `requestedBy === "aura"` skip)
+ * Fallback ladder (DB settings first so ops routing is configurable from the
+ * dashboard without a redeploy):
+ * 1. settings.aura_ops_channel (channel ID or name)
+ * 2. AURA_OPS_CHANNEL env (channel ID or name)
+ * 3. settings.founder_user_id (DM)
+ * 4. FOUNDER_USER_ID env (DM)
+ * 5. Last resort only: DM requestedBy (keeps the `requestedBy === "aura"` skip)
  */
-export function resolveOpsNotificationTarget(
+export async function resolveOpsNotificationTarget(
   requestedBy: string | null | undefined,
-): OpsNoticeTarget | null {
-  const opsChannel = process.env.AURA_OPS_CHANNEL?.trim();
+): Promise<OpsNoticeTarget | null> {
+  const opsChannel =
+    (await getSetting(OPS_CHANNEL_SETTING_KEY))?.trim() ||
+    process.env.AURA_OPS_CHANNEL?.trim();
   if (opsChannel) return { kind: "ops_channel", destination: opsChannel };
 
-  const founderUserId = process.env.FOUNDER_USER_ID?.trim();
+  const founderUserId = await resolveFounderUserId();
   if (founderUserId) return { kind: "founder_dm", destination: founderUserId };
 
   const requester = resolveJobFailureDmTarget(requestedBy);
@@ -84,7 +109,7 @@ export async function sendJobOpsNotice({
   text: string;
   logContext?: Record<string, unknown>;
 }): Promise<SendJobOpsNoticeResult> {
-  const target = resolveOpsNotificationTarget(requestedBy);
+  const target = await resolveOpsNotificationTarget(requestedBy);
 
   if (!target) {
     logger.warn("job_ops_notice_skipped_no_target", {
@@ -98,9 +123,18 @@ export async function sendJobOpsNotice({
 
   if (target.kind === "requester_dm") {
     logger.warn(
-      "job_ops_notice_no_ops_destination_configured: set AURA_OPS_CHANNEL or FOUNDER_USER_ID; falling back to requester DM",
+      "job_ops_notice_no_ops_destination_configured: set the aura_ops_channel / founder_user_id settings (or AURA_OPS_CHANNEL / FOUNDER_USER_ID env vars); falling back to requester DM",
       { jobId, jobName, requestedBy, ...logContext },
     );
+    // Surface the misconfiguration in monitoring (error_events + #aura-errors),
+    // not just in logs — an internal engineering notice is about to land in an
+    // end user's DM.
+    logError({
+      errorName: "job_ops_notice_no_ops_destination",
+      errorMessage: `Job ops notice for "${jobName}" fell back to the requester DM because no ops destination is configured. Set the aura_ops_channel or founder_user_id setting (or the AURA_OPS_CHANNEL / FOUNDER_USER_ID env vars).`,
+      userId: target.destination,
+      context: { jobId, jobName, requestedBy, ...logContext },
+    });
   }
 
   const message =

--- a/apps/api/src/cron/supervisor.test.ts
+++ b/apps/api/src/cron/supervisor.test.ts
@@ -58,6 +58,8 @@ const getCredentialMock = vi.hoisted(() => vi.fn());
 const sendJobFailureDmMock = vi.hoisted(() => vi.fn());
 const safePostMessageMock = vi.hoisted(() => vi.fn());
 const resolveSlackDestinationMock = vi.hoisted(() => vi.fn());
+const getSettingMock = vi.hoisted(() => vi.fn());
+const logErrorMock = vi.hoisted(() => vi.fn());
 
 type MockFetchResponse = {
   ok: boolean;
@@ -113,6 +115,28 @@ vi.mock("../lib/slack-messaging.js", () => ({
 vi.mock("../tools/slack.js", () => ({
   resolveSlackDestination: resolveSlackDestinationMock,
 }));
+
+// The ops routing ladder is DB-first: settings.aura_ops_channel /
+// settings.founder_user_id take priority over the env vars. Mock the settings
+// reader so tests control both rungs deterministically.
+vi.mock("../lib/settings.js", () => ({
+  getSetting: getSettingMock,
+  setSetting: vi.fn(),
+  getAllSettings: vi.fn(async () => ({})),
+  getConfig: vi.fn(async (_key: string, fallback = "") => fallback),
+  getSettingJSON: vi.fn(async (_key: string, fallback: unknown = null) => fallback),
+}));
+
+vi.mock("../lib/error-logger.js", () => ({
+  logError: logErrorMock,
+  sanitizeErrorText: vi.fn((value: string | null | undefined) => value ?? ""),
+  flushLoggerDrops: vi.fn(),
+  resetErrorLoggerStateForTest: vi.fn(),
+}));
+
+function mockSettingsRows(rows: Record<string, string>) {
+  getSettingMock.mockImplementation(async (key: string) => rows[key] ?? null);
+}
 
 function queueDbResults(...results: unknown[][]) {
   dbMock.results = [...results];
@@ -269,6 +293,7 @@ describe("supervisor cron", () => {
     dbMock.results = [];
     dbMock.operations = [];
     vi.clearAllMocks();
+    getSettingMock.mockResolvedValue(null);
     generateTextMock.mockResolvedValue({
       output: {
         decision: "report_failure",
@@ -488,6 +513,76 @@ describe("supervisor cron", () => {
     expect(sendJobFailureDmMock).not.toHaveBeenCalled();
   });
 
+  it("routes lifecycle notices to the settings-configured ops channel even when env vars point elsewhere", async () => {
+    mockSettingsRows({ aura_ops_channel: "C_SETTINGS_OPS" });
+    process.env.AURA_OPS_CHANNEL = "C_ENV_OPS";
+    process.env.FOUNDER_USER_ID = "U_ENV_FOUNDER";
+    generateTextMock.mockResolvedValue({
+      output: { decision: "retry_as_is", reasoning: "transient failure" },
+    });
+    queueDbResults([baseOutcome()], [baseJob()], [baseExecution()]);
+
+    const response = await invokeSupervisor();
+
+    expect(response.status).toBe(200);
+    expect(safePostMessageMock).toHaveBeenCalledTimes(1);
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "C_SETTINGS_OPS",
+        text: expect.stringContaining("<@U_REQUESTER>"),
+      }),
+    );
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+  });
+
+  it("routes lifecycle notices to the settings-configured founder DM without any env vars", async () => {
+    mockSettingsRows({ founder_user_id: "U_SETTINGS_FOUNDER" });
+    generateTextMock.mockResolvedValue({
+      output: { decision: "retry_as_is", reasoning: "transient failure" },
+    });
+    queueDbResults([baseOutcome()], [baseJob()], [baseExecution()]);
+
+    const response = await invokeSupervisor();
+
+    expect(response.status).toBe(200);
+    expect(resolveSlackDestinationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "U_SETTINGS_FOUNDER",
+    );
+    expect(safePostMessageMock).toHaveBeenCalledTimes(1);
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channel: "D_U_SETTINGS_FOUNDER",
+        text: expect.stringContaining("<@U_REQUESTER>"),
+      }),
+    );
+    expect(sendJobFailureDmMock).not.toHaveBeenCalled();
+  });
+
+  it("escalate DMs the settings-configured founder when the ops notice went to the ops channel", async () => {
+    mockSettingsRows({
+      aura_ops_channel: "C_SETTINGS_OPS",
+      founder_user_id: "U_SETTINGS_FOUNDER",
+    });
+    generateTextMock.mockResolvedValue({
+      output: { decision: "escalate", reasoning: "needs human judgment" },
+    });
+    queueDbResults([baseOutcome()], [baseJob()], [baseExecution()]);
+
+    const response = await invokeSupervisor();
+
+    expect(response.status).toBe(200);
+    expect(safePostMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ channel: "C_SETTINGS_OPS" }),
+    );
+    expect(sendJobFailureDmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedBy: "U_SETTINGS_FOUNDER" }),
+    );
+  });
+
   it("escalate does not double-DM the founder when the ops notice already went to the founder", async () => {
     process.env.FOUNDER_USER_ID = "U_FOUNDER";
     generateTextMock.mockResolvedValue({
@@ -596,6 +691,10 @@ describe("supervisor cron", () => {
     expect(safePostMessageMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ channel: "D_U_REQUESTER" }),
+    );
+    // The misconfiguration must be visible in monitoring, not only in logs.
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ errorName: "job_ops_notice_no_ops_destination" }),
     );
   });
 

--- a/apps/api/src/cron/supervisor.ts
+++ b/apps/api/src/cron/supervisor.ts
@@ -9,6 +9,7 @@ import { logger } from "../lib/logger.js";
 import { aiTelemetry, withTrace } from "../lib/langfuse.js";
 import { jobExecutions, jobOutcomes, jobs } from "@aura/db/schema";
 import {
+  resolveFounderUserId,
   resolveOpsNotificationTarget,
   sendJobFailureDm,
   sendJobOpsNotice,
@@ -292,7 +293,7 @@ async function sendSupervisorOpsNotice(
 }
 
 async function sendFounderDm(job: JobRow, text: string): Promise<void> {
-  const founderUserId = process.env.FOUNDER_USER_ID?.trim() || job.requestedBy;
+  const founderUserId = (await resolveFounderUserId()) || job.requestedBy;
   if (!founderUserId || founderUserId === job.requestedBy) return;
 
   await sendJobFailureDm({
@@ -591,7 +592,7 @@ async function applySupervisorDecision(
       // routing ladder falls back to requester_dm (no ops channel / founder
       // configured), send only the user-safe text so internal reasoning stays
       // out of the end-user's channel.
-      const opsTarget = resolveOpsNotificationTarget(context.job.requestedBy);
+      const opsTarget = await resolveOpsNotificationTarget(context.job.requestedBy);
       const noticeText = opsTarget?.kind === "requester_dm" ? userText : opsText;
 
       const opsResult = await sendSupervisorOpsNotice(context.job, noticeText, {

--- a/apps/api/src/lib/settings-redaction.test.ts
+++ b/apps/api/src/lib/settings-redaction.test.ts
@@ -63,6 +63,10 @@ describe("isSecretSettingKey", () => {
     expect(isSecretSettingKey("e2b_sandbox_id:abc")).toBe(false);
     expect(isSecretSettingKey("slack_channel")).toBe(false);
     expect(isSecretSettingKey("feature_flag")).toBe(false);
+    // Ops-notice routing keys are configuration, not secrets — they must stay
+    // readable (view + edit) in the dashboard.
+    expect(isSecretSettingKey("aura_ops_channel")).toBe(false);
+    expect(isSecretSettingKey("founder_user_id")).toBe(false);
   });
 });
 

--- a/apps/dashboard/src/routes/settings/index.tsx
+++ b/apps/dashboard/src/routes/settings/index.tsx
@@ -48,6 +48,28 @@ interface ModelCatalog {
   lastSyncedAt: string | null;
 }
 
+/**
+ * Ops notification routing keys — internal job lifecycle notices (retries,
+ * escalations, disable notices) are routed here instead of the requester's DM.
+ * DB settings take priority over the AURA_OPS_CHANNEL / FOUNDER_USER_ID env vars.
+ */
+const OPS_NOTIFICATION_KEYS = [
+  {
+    key: "aura_ops_channel",
+    title: "Ops Channel",
+    placeholder: "e.g. C0123456789 or #aura-ops",
+    description:
+      "Slack channel (ID or name) that receives internal job lifecycle notices (retries, escalations, disable notices). Takes priority over the AURA_OPS_CHANNEL env var.",
+  },
+  {
+    key: "founder_user_id",
+    title: "Founder User ID",
+    placeholder: "e.g. U0123456789",
+    description:
+      "Slack user DM'd with ops notices when no ops channel is set. Takes priority over the FOUNDER_USER_ID env var. Without either, notices fall back to the job requester's DM.",
+  },
+] as const;
+
 /** Runtime-state keys that represent per-sandbox/per-user transient state. */
 function isRuntimeKey(key: string): boolean {
   return (
@@ -75,6 +97,7 @@ function SettingsPage() {
   });
 
   const [modelDrafts, setModelDrafts] = useState<Partial<Record<ModelCategory, string>>>({});
+  const [opsDrafts, setOpsDrafts] = useState<Record<string, string>>({});
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingKey, setEditingKey] = useState<string | null>(null);
@@ -123,6 +146,19 @@ function SettingsPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["models"] });
     },
+  });
+
+  function actualOpsValue(key: string): string {
+    return opsDrafts[key] ?? getSettingValue(key);
+  }
+
+  const saveOpsMutation = useMutation({
+    mutationFn: async () => {
+      for (const { key } of OPS_NOTIFICATION_KEYS) {
+        await apiPut(`/settings/${key}`, { value: actualOpsValue(key).trim() });
+      }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["settings"] }),
   });
 
   const saveSettingMutation = useMutation({
@@ -219,6 +255,38 @@ function SettingsPage() {
           </div>
           <Button onClick={() => saveModelsMutation.mutate()} disabled={saveModelsMutation.isPending} size="sm">
             <Save className="h-4 w-4" /> {saveModelsMutation.isPending ? "Saving..." : "Save Models"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle className="text-base">Ops Notifications</CardTitle></CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Where internal job lifecycle notices (retries, escalations, disable notices,
+            retry-exhausted alerts) are sent. Without an ops channel or founder, these
+            fall back to the job requester's DM.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {OPS_NOTIFICATION_KEYS.map((field) => (
+              <div key={field.key}>
+                <label className="text-sm font-medium mb-1 block" htmlFor={`ops-${field.key}`}>
+                  {field.title}
+                </label>
+                <Input
+                  id={`ops-${field.key}`}
+                  placeholder={field.placeholder}
+                  value={actualOpsValue(field.key)}
+                  onChange={(e) =>
+                    setOpsDrafts((drafts) => ({ ...drafts, [field.key]: e.target.value }))
+                  }
+                />
+                <p className="text-xs text-muted-foreground mt-1">{field.description}</p>
+              </div>
+            ))}
+          </div>
+          <Button onClick={() => saveOpsMutation.mutate()} disabled={saveOpsMutation.isPending} size="sm">
+            <Save className="h-4 w-4" /> {saveOpsMutation.isPending ? "Saving..." : "Save Ops Notifications"}
           </Button>
         </CardContent>
       </Card>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes #1333. The ops-notice routing added in PR #1183 was inert in production: `resolveOpsNotificationTarget()` only read the `AURA_OPS_CHANNEL` / `FOUNDER_USER_ID` env vars, and neither is set. Every internal job lifecycle notice (stale-kill retries, escalations, disable notices, retry-exhausted alerts) therefore fell through to the requester's DM — verified live on Aug 19 2026 when a non-technical SDR received four English engineering notices from her own daily prospect-list job.

## Changes

### API (`apps/api/src/cron/job-notifications.ts`)
- `resolveOpsNotificationTarget()` is now **async** with a DB-first ladder:
  1. `settings.aura_ops_channel` (new settings key, channel ID or name)
  2. `AURA_OPS_CHANNEL` env
  3. `settings.founder_user_id` (new settings key)
  4. `FOUNDER_USER_ID` env
  5. Last resort: requester DM (keeps the existing `requestedBy === "aura"` skip semantics)
- Settings are read via the same `getSetting()` helper used for `model_main` etc.
- `sendJobOpsNotice` behaviour is unchanged: ops-channel/founder targets keep the `:gear: Job ops notice — <job> (requested by <@U…>)` prefix; the requester-DM fallback does not.
- When the ladder resolves to `requester_dm`, the existing `logger.warn` is kept **and** an `error_events` row is written via `logError` (error name `job_ops_notice_no_ops_destination`), so the misconfiguration shows up in monitoring (dashboard errors + #aura-errors), not only in logs.

### Callers
- `supervisor.ts`: awaits the new async signature in the escalate path; `sendFounderDm` now also resolves the founder from `settings.founder_user_id` before the env var (so a settings-only configuration still delivers founder escalations). The founder-DM dedupe on escalate is unchanged.
- `heartbeat.ts`: no source change needed — it only calls the already-async `sendJobOpsNotice`.

### Dashboard (`apps/dashboard/src/routes/settings/index.tsx`)
- New **Ops Notifications** card exposing `aura_ops_channel` and `founder_user_id` with view + edit (visible even when unset), saved through the existing `PUT /api/dashboard/settings/:key` endpoint. These keys are configuration, not secrets — they don't match the redaction patterns, and a redaction test now pins that.

### Tests
- `job-notifications.test.ts`, `supervisor.test.ts`, `heartbeat.test.ts` updated for the async signature; settings reads and `logError` are mocked so the real routing ladder is still exercised end-to-end through the mocked Slack layer.
- New cases: settings-row precedence over env vars (ops channel and founder), whitespace-only settings rows falling through the ladder, settings-configured routing for system-owned jobs, and `error_events` written on the requester-DM fallback. No existing assertions were weakened.

### Migrations
- None needed — `settings` is a key/value table.

## Verification

- `pnpm typecheck` passes (API + dashboard)
- `pnpm --filter aura-api test`: 63 files, **606/606 tests pass**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e97d3c48-77c5-447d-bac3-591231ca2081?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e97d3c48-77c5-447d-bac3-591231ca2081&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

