### PR TITLE
Fixes #1327: strict-schema guard missed multi-line integer+min/max (5 jobs dead today)

### DIFF
--- a/apps/api/src/lib/tool.test.ts
+++ b/apps/api/src/lib/tool.test.ts
@@ -145,11 +145,13 @@ describe("strict-mode JSON schema compatibility", () => {
     for (const f of readdirSync(dir)) {
       if (!f.endsWith(".ts") || f.includes(".test.")) continue;
       const src = readFileSync(join(dir, f), "utf8");
-      for (const [i, line] of src.split("\n").entries()) {
-        if (/z\.number\(\)\.int\(\)/.test(line) && /\.(min|max)\(/.test(line)) {
-          offenders.push(`${f}:${i + 1}`);
-        }
-      }
+      // Collapse whitespace so multi-line builder chains are caught too --
+      // the original single-line check missed
+      //   z\n  .number()\n  .int()\n  .min(1)
+      // which is how Prettier formats longer chains (see notes.ts/sandbox.ts).
+      const flat = src.replace(/\s+/g, "");
+      const re = /z\.number\(\)\.int\(\)\.(?:min|max)\(/g;
+      if (re.test(flat)) offenders.push(f);
     }
     expect(offenders).toEqual([]);
   });

--- a/apps/api/src/tools/notes.ts
+++ b/apps/api/src/tools/notes.ts
@@ -99,7 +99,6 @@ export function createNoteTools(context?: ScheduleContext) {
           ),
         importance: z
           .number()
-          .int()
           .min(1)
           .max(100)
           .optional()
@@ -352,7 +351,6 @@ export function createNoteTools(context?: ScheduleContext) {
           ),
         importance: z
           .number()
-          .int()
           .min(1)
           .max(100)
           .optional()

--- a/apps/api/src/tools/sandbox.ts
+++ b/apps/api/src/tools/sandbox.ts
@@ -1024,7 +1024,6 @@ export function createSandboxTools(context?: ScheduleContext) {
           .describe("The 8-character command id returned by run_command_detached or a timed-out run_command."),
         tail_lines: z
           .number()
-          .int()
           .min(1)
           .max(1000)
           .default(200)


### PR DESCRIPTION
## What broke

`tools.1.custom: For 'integer' type, properties maximum, minimum are not supported` — strict mode (defaulted on in #1317) rejects `{ type: "integer", minimum, maximum }`, and it kills the **whole turn**, not just the offending tool call.

Five job executions died on this today (2026-08-24 14:30 UTC, same heartbeat tick):
- `stripe-italy-failed-charge-enrichment` (Delia's live Stripe collections job)
- `spend-circuit-breaker-watch`
- `alicia-carmen-inse-confirmar-hoy` (user-facing DM reminder that never went out)
- `file-heartbeat-stall-issue`
- `inside-sales-zh-termin-reminder`

## Why #1324 didn't catch it

#1324 added a regression test, but it matched line-by-line on `z.number().int()`. Prettier splits longer builder chains:

```ts
importance: z
  .number()
  .int()
  .min(1)
  .max(100)
```

so `notes.ts` (`save_note`/`edit_note` → `importance`) and `sandbox.ts` (`check_command` → `tail_lines`) were invisible to it. Those are two of the most widely-attached toolsets — hence every job touching notes or the sandbox died.

## Fix

1. Drop `.int()` from the three remaining chains. `.min()/.max()` already constrain the range; nothing depended on integer coercion.
2. Rewrite the guard to flatten whitespace before matching, so any formatting is caught.

Verified: new detector reports `[notes.ts, sandbox.ts]` against the pre-fix tree, `[]` after.